### PR TITLE
Switch to using yaml for Jupyter API Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,7 @@ A Stackstorm pack for running Openstack scripts:
 
 - Openstack openrc config file is required in order to run Openstack Commands. The openrc file must be stored
   in `etc/openstack/clouds.yaml` or `/home/<user>/.config/openstack/clouds.yaml`.
-- The following datastore entries are required:
-
-| Key Name                 | Description                                   | Encrypted |
-|--------------------------|-----------------------------------------------| --------- |
-| `jupyter.dev_token`      | Jupyter API Admin Token for Dev               | Yes       |
-| `jupyter.prod_token`     | Jupyter API Admin Token for Prod              | Yes       |
-| `jupyter.training_token` | Jupyter API Admin Token for Training instance | Yes       |
-| `jsm_email`              | Email used to login to atlassian              | Yes       |
-| `jsm_key`                | Key used to login to atlassian                | Yes       |
+- Copy the configuration in [stackstorm_openstack.yaml.example](https://github.com/stfc/st2-cloud-pack/blob/main/stackstorm_openstack.yaml.example) to `/opt/stackstorm/configs/stackstorm_openstack.yaml and populate the values.
 
 # Openstack Workflow
 

--- a/actions/src/jupyter.py
+++ b/actions/src/jupyter.py
@@ -21,17 +21,18 @@ class Jupyter(Action):
         """
         Delete users from the given environment
         """
-        env = jupyter_env.casefold()
-        key_name = None
-        if env == "prod".casefold():
-            key_name = "jupyter.prod_token"
-        if env == "training".casefold():
-            key_name = "jupyter.training_token"
-        if env == "dev".casefold():
-            key_name = "jupyter.dev_token"
+        jupyter_keys = self.config["jupyter"]
 
+        key_name = None
+        env = jupyter_env.casefold()
+        if env == "prod".casefold():
+            key_name = "prod_token"
+        if env == "training".casefold():
+            key_name = "training_token"
+        if env == "dev".casefold():
+            key_name = "dev_token"
         if not key_name:
             raise KeyError("Unknown Jupyter environment")
 
-        token = self.action_service.get_value(key_name, local=False, decrypt=True)
+        token = jupyter_keys[key_name]
         self._api.delete_users(jupyter_env, token, users)

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,135 +1,69 @@
 ---
-icinga_config:
-  description: "Icinga config"
+jupyter:
+  description: Jupyter Settings and tokens
   type: "object"
   required: true
   properties:
-    url:
-      description: "URL for Icinga API"
+    dev_token:
       type: "string"
-      required: true
-      secret: true
-    username:
-      description: "Username for Icinga API"
+      description: "Token for test.jupyter.stfc.ac.uk"
+      required: false
+    training_token:
       type: "string"
-      required: true
-      secret: true
-    password:
-      description: "Password for Icinga API"
+      description: "Token for training.jupyter.stfc.ac.uk"
+      required: false
+    prod_token:
       type: "string"
-      required: true
-      secret: true
-    host_endpoint:
-      description: "URL for Icinga API"
-      type: "string"
-      required: true
-      secret: true
-    downtime_endpoint:
-      description: "URL for Getting Icinga Downtimes"
-      type: "string"
-      required: true
-      secret: true
-    schedule_downtime_endpoint:
-      description: "URL for Scheduling Icinga Downtime"
-      type: "string"
-      required: true
-      secret: true
-    remove_downtime_endpoint:
-      description: "URL for Removing Icinga Downtimes"
-      type: "string"
-      required: true
-      secret: true
-external_network:
-  description: "External Network Creation Rules"
+      description: "Token for jupyter.stfc.ac.uk"
+      required: false
+
+smtp_accounts:
+  description: "SMTP accounts"
   type: "array"
   required: true
   items:
     type: "object"
     required: true
     properties:
-      direction:
-        description: "Network flow direction - ingress / egress"
+      name:
+        description: "Name of the account"
         type: "string"
-        enum:
-          - "ingress"
-          - "egress"
+        secret: false
         required: true
-        secret: true
-      ether_type:
-        description: "Network ether type - IPv4 / IPv6"
+      server:
+        description: "Email server name - e.g. imap.gmail.com"
         type: "string"
-        enum:
-          - "IPv4"
-          - "IPv6"
+        secret: false
         required: true
-        secret: true
-      protocol:
-        description: "Network protocol - tcp / udp / icmp"
-        type: "string"
-        enum:
-          - "tcp"
-          - "udp"
-          - "icmp"
-        required: true
-        secret: true
-      remote_ip_prefix:
-        description: "Network remote IP prefix"
-        type: "string"
-        required: true
-        secret: true
-      dst_port:
-        description: "Network dst port range start_port:end_port"
+      username:
+        description: "Mailbox username"
         type: "string"
         required: false
-        secret: true
-external_egress_ips:
-  description: "IPs to apply udp/tcp egress rules for external projects"
-  type: "array"
-  required: true
-  items:
-    type: "string"
-    required: true
-    secret: true
-internal_network:
-  description: "Internal Network Creation Rules"
-  type: "array"
-  required: true
-  items:
-    type: "object"
-    required: true
-    properties:
-      direction:
-        description: "Network flow direction - ingress / egress"
+      password:
+        description: "Mailbox password."
         type: "string"
-        enum:
-          - "ingress"
-          - "egress"
-        required: true
         secret: true
-      ether_type:
-        description: "Network ether type - IPv4 / IPv6"
-        type: "string"
-        enum:
-          - "IPv4"
-          - "IPv6"
-        required: true
-        secret: true
-      protocol:
-        description: "Network protocol - tcp / udp / icmp"
-        type: "string"
-        enum:
-          - "tcp"
-          - "udp"
-          - "icmp"
-        required: true
-        secret: true
-      remote_ip_prefix:
-        description: "Network remote IP prefix"
-        type: "string"
-        required: true
-        secret: true
-      dst_port:
-        description: "Network dst port range start_port:end_port"
-        type: "string"
         required: false
-        secret: true
+      port:
+        description: "Port to connect to - e.g. 465, 587."
+        type: "integer"
+        default: 465
+        required: true
+      secure:
+        description: "Set to False to disable secure protocol. Default value is True."
+        type: "boolean"
+        default: true
+      smtp_auth:
+        description: "Authenticate username and password with SMTP server to send email. Default True"
+        type: "boolean"
+        default: true
+max_attachment_size:
+  description: "Maxium size of downloaded attachment in bytes (default 1024)"
+  type: "integer"
+  required: false
+  default: 1024
+attachment_datastore_ttl:
+  description: "TTL in seconds to keep attachments in the datastore. Default 1800"
+  type: "integer"
+  required: false
+  default: 1800

--- a/stackstorm_openstack.yaml.example
+++ b/stackstorm_openstack.yaml.example
@@ -1,4 +1,9 @@
 ---
+jupyter:
+    prod_token:
+    training_token:
+    dev_token:
+
 smtp_accounts:
   - name: "default"
     password:

--- a/stackstorm_openstack.yaml.example
+++ b/stackstorm_openstack.yaml.example
@@ -1,25 +1,11 @@
 ---
-icinga_config:
-  url:
-  username:
-  password:
-  host_endpoint:
-  downtime_endpoint:
-  schedule_downtime_endpoint:
-  remove_downtime_endpoint:
-
-external_network:
-  - direction:
-    ether_type:
-    protocol:
-    remote_ip_prefix:
-    dst_port:
-
-external_egress_ips:
-
-internal_network:
-  - direction:
-    ether_type:
-    protocol:
-    remote_ip_prefix:
-    dst_port:
+smtp_accounts:
+  - name: "default"
+    password:
+    port: 465
+    secure: false
+    server: "mail.gridpp.rl.ac.uk"
+    smtp_auth: false
+    username: "cloud-support@stfc.ac.uk"
+max_attachment_size: 1024
+attachment_datastore_ttl: 1800


### PR DESCRIPTION
This is part of the work moving from the K-V store into the YAML file.
Ports the Jupyter API to use pack configs instead. The next PR will add support for deleting a number of accounts based on a template name.