### PR TITLE
Add rule for automating pack installs

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -15,6 +15,7 @@ python_versions:
 
 dependencies:
   - core
+  - git
 
 # Authors :
 # Anish Mudaraddi

--- a/rules/install.from.git.branch.yaml
+++ b/rules/install.from.git.branch.yaml
@@ -1,0 +1,13 @@
+---
+name: "install.from.git.branch"
+pack: "stackstorm_openstack"
+description: "Installs a pack when a commit is pushed to a branch"
+enabled: true
+
+trigger:
+    type: git.head_sha_monitor
+action:
+    ref: "packs.install"
+    parameters:
+        packs:
+          - "{{ trigger.repository_url }}={{ trigger.branch }}"


### PR DESCRIPTION
I did manage to crash the sensor by doing two force pushes in quick succession which did need a restart using `sudo st2ctl reload --register-sensors --register-fail-on-failure --verbose` but other than that it appears to work well and the branch can be configured as in https://github.com/StackStorm-Exchange/stackstorm-git.
