### PR TITLE
Tweaks for VM emails

### DIFF
--- a/lib/email_api/email_api.py
+++ b/lib/email_api/email_api.py
@@ -170,7 +170,7 @@ class EmailApi:
                 self.send_email(
                     smtp_accounts=smtp_accounts,
                     subject=subject,
-                    email_to=[override_email if test_override else key],
+                    email_to=override_email if test_override else [key],
                     email_from=email_from,
                     email_cc=email_cc,
                     header=header,

--- a/lib/openstack_api/openstack_query.py
+++ b/lib/openstack_api/openstack_query.py
@@ -180,6 +180,9 @@ class OpenstackQuery(OpenstackWrapperBase):
         property_funcs = self.get_default_property_funcs(object_type, cloud_account)
         output = self.parse_properties(items, properties_to_select, property_funcs)
 
+        if len(output) == 0:
+            return "No results"
+
         if group_by != "":
             output = self.collate_results(output, group_by, get_html)
         else:

--- a/lib/openstack_api/openstack_query.py
+++ b/lib/openstack_api/openstack_query.py
@@ -181,7 +181,7 @@ class OpenstackQuery(OpenstackWrapperBase):
         output = self.parse_properties(items, properties_to_select, property_funcs)
 
         if len(output) == 0:
-            return "No results"
+            return None
 
         if group_by != "":
             output = self.collate_results(output, group_by, get_html)

--- a/lib/openstack_api/openstack_server.py
+++ b/lib/openstack_api/openstack_server.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from openstack.compute.v2.server import Server
+from openstack.exceptions import HttpException
 
 from openstack_api.openstack_connection import OpenstackConnection
 from openstack_api.openstack_identity import OpenstackIdentity
@@ -62,15 +63,19 @@ class OpenstackServer(OpenstackWrapperBase):
 
         with self._connection_cls(cloud_account) as conn:
             for project in projects:
-                selected_servers.extend(
-                    conn.list_servers(
-                        filters={
-                            "all_tenants": True,
-                            "project_id": project.id,
-                            "limit": 10000,
-                        }
+                try:
+                    selected_servers.extend(
+                        conn.list_servers(
+                            filters={
+                                "all_tenants": True,
+                                "project_id": project.id,
+                                "limit": 10000,
+                            }
+                        )
                     )
-                )
+                except HttpException as err:
+                    print(f"Failed to list servers in the project with id {project}")
+                    print(err)
         return selected_servers
 
     def search_servers_older_than(

--- a/lib/openstack_api/openstack_server.py
+++ b/lib/openstack_api/openstack_server.py
@@ -74,7 +74,7 @@ class OpenstackServer(OpenstackWrapperBase):
                         )
                     )
                 except HttpException as err:
-                    print(f"Failed to list servers in the project with id {project}")
+                    print(f"Failed to list servers in the project with id {project.id}")
                     print(err)
         return selected_servers
 


### PR DESCRIPTION
- Adds try/except to ignore an error caused by the OpenStack API attempting to fetch details of servers listed in a project when they no longer exist
- Fixes error in email.server.users
- Output "No results" instead of an error when no results are found in server.list