### PR TITLE
Add project emails

### DIFF
--- a/actions/floating.ip.list.yaml
+++ b/actions/floating.ip.list.yaml
@@ -51,6 +51,7 @@ parameters:
       - "status"
       - "updated_at"
       - "project_name"
+      - "project_email"
     type: array
     description: "Properties to display for the floating ips that match the chosen query"
     required: true

--- a/actions/project.create.yaml
+++ b/actions/project.create.yaml
@@ -17,6 +17,10 @@ parameters:
     description: New project Name
     required: true
     type: string
+  email:
+    description: Contact email of new project
+    required: true
+    type: string
   description:
     description: New Project Description
     type: string

--- a/actions/src/project_action.py
+++ b/actions/src/project_action.py
@@ -58,20 +58,22 @@ class ProjectAction(Action):
         self,
         cloud_account: str,
         name: str,
+        email: str,
         description: str,
         is_enabled: bool,
     ) -> Tuple[bool, Optional[Project]]:
         """
         Find and return a given project's properties. Expected
-        to be called within a workflow and not directly.
+        to be called within a workflow and not directly
         :param cloud_account: The account from the clouds configuration to use
-        :param: name: Name of new project
-        :param: description: Description for new project
-        :param: is_enabled: Set if new project enabled or disabled
+        :param name: Name of new project
+        :param email: Contact email of new project
+        :param description: Description for new project
+        :param is_enabled: Set if new project enabled or disabled
         :return: status, optional project
         """
         details = ProjectDetails(
-            name=name, description=description, is_enabled=is_enabled
+            name=name, email=email, description=description, is_enabled=is_enabled
         )
         project = self._api.create_project(
             cloud_account=cloud_account, project_details=details

--- a/actions/src/project_action.py
+++ b/actions/src/project_action.py
@@ -54,6 +54,7 @@ class ProjectAction(Action):
         output = project if project else "The project could not be found."
         return bool(project), output
 
+    # pylint:disable=too-many-arguments
     def project_create(
         self,
         cloud_account: str,

--- a/lib/openstack_api/openstack_identity.py
+++ b/lib/openstack_api/openstack_identity.py
@@ -154,3 +154,16 @@ class OpenstackIdentity(OpenstackWrapperBase):
                 found_email = tag
                 break
         return found_email
+
+    def find_project_email(self, cloud_account: str, project_identifier: str):
+        """
+        Returns the contact email of a project
+        :param cloud_account: The clouds entry to use
+        :param project_identifier: The name or Openstack ID for the project
+        :return: The found email or None
+        """
+        found_email = None
+        project = self.find_project(cloud_account, project_identifier)
+        if project:
+            found_email = self.get_project_email(project)
+        return found_email

--- a/lib/openstack_api/openstack_query.py
+++ b/lib/openstack_api/openstack_query.py
@@ -202,6 +202,7 @@ class OpenstackQuery(OpenstackWrapperBase):
         """
         Returns a list of default property functions for use with 'parse_properties' above
         :param object_type: type of openstack object the functions will be used for e.g. server
+        :param cloud_account: The account from the clouds configuration to use
         :return: Dict[str, str] (each key containing html or plaintext table of results)
         """
 
@@ -223,6 +224,9 @@ class OpenstackQuery(OpenstackWrapperBase):
         if object_type == "floating_ip":
             return {
                 "project_name": lambda a: get_project_prop(a["project_id"], "name"),
+                "project_email": lambda a: self._identity_api.find_project_email(
+                    cloud_account, a["project_id"]
+                ),
             }
         raise ValueError(f"Unsupported object type '{object_type}'")
 

--- a/lib/structs/project_details.py
+++ b/lib/structs/project_details.py
@@ -5,6 +5,7 @@ from typing import Optional
 @dataclass
 class ProjectDetails:
     name: str
+    email: str
     description: str = ""
     is_enabled: Optional[bool] = None
     openstack_id: Optional[str] = None

--- a/tests/actions/test_project_actions.py
+++ b/tests/actions/test_project_actions.py
@@ -38,6 +38,8 @@ class TestProjectAction(OpenstackActionTestBase):
         expected_proj_params = {
             i: NonCallableMock() for i in ["name", "description", "is_enabled"]
         }
+        expected_proj_params.update({"email": "Test@Test.com"})
+
         # Check that default gets hard-coded in too
         packaged_proj = ProjectDetails(**expected_proj_params)
 
@@ -59,7 +61,7 @@ class TestProjectAction(OpenstackActionTestBase):
         self.identity_mock.create_project.return_value = None
 
         returned_values = self.action.project_create(
-            *{NonCallableMock() for _ in range(4)}
+            *{NonCallableMock() for _ in range(5)}
         )
         assert returned_values[0] is False
         assert returned_values[1] is None

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -11,6 +11,7 @@ from openstack_api.openstack_identity import OpenstackIdentity
 from structs.project_details import ProjectDetails
 
 
+# pylint:disable=too-many-public-methods
 class OpenstackIdentityTests(unittest.TestCase):
     """
     Runs various tests to ensure we are using the Openstack
@@ -45,7 +46,7 @@ class OpenstackIdentityTests(unittest.TestCase):
         )
 
     @raises(ValueError)
-    def test_create_project_email_missing_throws(self):
+    def test_create_project_invalid_email_throws(self):
         """
         Tests calling the API wrapper with an invalid email will throw
         """
@@ -252,3 +253,33 @@ class OpenstackIdentityTests(unittest.TestCase):
         )
         expected = self.identity_api.find_user.return_value
         assert returned == expected
+
+    def test_get_project_email(self):
+        """
+        Checks that get_project_email functions correctly
+        """
+        expected_email = "Test@Test.com"
+        mock_project = {"tags": ["Test", expected_email, "12123421"]}
+
+        email = self.instance.get_project_email(mock_project)
+
+        self.assertEqual(expected_email, email)
+
+    def test_find_project_email(self):
+        """
+        Checks that find_project_email functions correctly
+        """
+        expected_email = "Test@Test.com"
+        mock_project = {"tags": ["Test", expected_email, "12123421"]}
+
+        cloud_account, project_identifier = NonCallableMock(), NonCallableMock()
+        self.identity_api.find_project.return_value = mock_project
+        found = self.instance.find_project_email(
+            cloud_account=cloud_account, project_identifier=project_identifier
+        )
+
+        self.mocked_connection.assert_called_once_with(cloud_account)
+        self.identity_api.find_project.assert_called_once_with(
+            project_identifier.strip(), ignore_missing=True
+        )
+        self.assertEqual(expected_email, found)

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -33,7 +33,10 @@ class OpenstackIdentityTests(unittest.TestCase):
         Tests calling the API wrapper without a domain will throw
         """
         self.instance.create_project(
-            "", ProjectDetails(name="", description="", is_enabled=False)
+            "",
+            ProjectDetails(
+                name="", description="", email="Test@Test.com", is_enabled=False
+            ),
         )
 
     @raises(MissingMandatoryParamError)
@@ -92,7 +95,13 @@ class OpenstackIdentityTests(unittest.TestCase):
         """
 
         self.identity_api.create_project.side_effect = ConflictException
-        self.instance.create_project(NonCallableMock(), NonCallableMock())
+        project_details = ProjectDetails(
+            name=NonCallableMock(),
+            email="Test@Test.com",
+            description=NonCallableMock(),
+            is_enabled=NonCallableMock(),
+        )
+        self.instance.create_project(NonCallableMock(), project_details)
 
     @staticmethod
     @raises(MissingMandatoryParamError)

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -35,6 +35,27 @@ class OpenstackIdentityTests(unittest.TestCase):
             "", ProjectDetails(name="", description="", is_enabled=False)
         )
 
+    @raises(MissingMandatoryParamError)
+    def test_create_project_email_missing_throws(self):
+        """
+        Tests calling the API wrapper without an email will throw
+        """
+        self.instance.create_project(
+            "", ProjectDetails(name="Test", email="", description="", is_enabled=False)
+        )
+
+    @raises(ValueError)
+    def test_create_project_email_missing_throws(self):
+        """
+        Tests calling the API wrapper with an invalid email will throw
+        """
+        self.instance.create_project(
+            "",
+            ProjectDetails(
+                name="Test", email="NotAnEmail", description="", is_enabled=False
+            ),
+        )
+
     def test_create_project_forwards_result(self):
         """
         Tests that the params and result are forwarded as-is to/from the
@@ -43,6 +64,7 @@ class OpenstackIdentityTests(unittest.TestCase):
 
         expected_details = ProjectDetails(
             name=NonCallableMock(),
+            email="Test@Test.com",
             description=NonCallableMock(),
             is_enabled=NonCallableMock(),
         )
@@ -59,6 +81,7 @@ class OpenstackIdentityTests(unittest.TestCase):
             domain_id="default",
             description=expected_details.description,
             is_enabled=expected_details.is_enabled,
+            tags=[expected_details.email],
         )
 
     @raises(ConflictException)

--- a/tests/lib/test_openstack_query.py
+++ b/tests/lib/test_openstack_query.py
@@ -218,7 +218,7 @@ class OpenstackQueryTests(unittest.TestCase):
                 "group_by": "user_email",
             },
             "floating_ip": {
-                "properties_to_select": ["test2", "project_name"],
+                "properties_to_select": ["test2", "project_name", "project_email"],
                 "group_by": "project_id",
             },
         }
@@ -231,7 +231,7 @@ class OpenstackQueryTests(unittest.TestCase):
         """
         object_types = {
             "server": ["test2", "user_email"],
-            "floating_ip": ["test2", "project_name"],
+            "floating_ip": ["test2", "project_name", "project_email"],
         }
         for key, value in object_types.items():
             self._test_parse_and_output_table_no_grouping(


### PR DESCRIPTION
Adds an `email` parameter to the project.create action and puts it in the project tags. Also allows them to be listed in floating.ip.list.