### PR TITLE
Add email.floating.ip.users action

### DIFF
--- a/actions/email.floating.ip.users.yaml
+++ b/actions/email.floating.ip.users.yaml
@@ -1,0 +1,129 @@
+---
+description: Sends email notifications to floating ip project contacts based on a given query.
+enabled: true
+entry_point: src/email_actions.py
+name: email.floating.ip.users
+parameters:
+  timeout:
+    default: 3600
+  submodule:
+    default: email_floating_ip_users
+    immutable: true
+    type: string
+  cloud_account:
+    description: "The clouds.yaml account to use whilst performing this action"
+    type: string
+    default: ""
+    required: true
+  project_identifier:
+    type: string
+    description: "Project (Name or ID) to search in - leave empty for all projects"
+    required: false
+    default: ""
+  query_preset:
+    description: "Name of a preset query - e.g fips_older_than: list all floating ips older than"
+    type: string
+    default: "fips_older_than"
+    enum:
+      - "all_fips"
+      - "fips_older_than"
+      - "fips_younger_than"
+      - "fips_last_updated_before"
+      - "fips_last_updated_after"
+      - "fips_id_in"
+      - "fips_id_not_in"
+      - "fips_name_in"
+      - "fips_name_not_in"
+      - "fips_name_contains"
+      - "fips_name_not_contains"
+      - "fips_down"
+      - "fips_down_before"
+    required: true
+  properties_to_select:
+    type: array
+    description: "Properties to display for floating ips, must include project_email"
+    required: true
+    default:
+      - "id"
+      - "name"
+      - "status"
+      - "project_name"
+      - "project_email"
+  email_from:
+    type: string
+    description: "Email address to send email from"
+    required: true
+    default: "cloud-support@stfc.ac.uk"
+    immutable: true
+  email_cc:
+    description: "Email Addresses to Cc in (comma separated)"
+    required: false
+    type: array
+  header:
+    type: string
+    description: "Email Header filepath"
+    required: true
+    default: "/opt/stackstorm/packs/stackstorm_openstack/email_templates/header.html"
+  message:
+    type: string
+    description: "Email message to put in the body"
+    required: true
+  footer:
+    type: string
+    description: "Email footer filepath"
+    required: true
+    default: "/opt/stackstorm/packs/stackstorm_openstack/email_templates/footer.html"
+  attachment_filepaths:
+    description: "Filepaths to email attachments (comma separated)"
+    required: false
+    type: array
+  subject:
+    type: string
+    description: "Email subject"
+    required: true
+    default: "Test Message"
+  smtp_account:
+    type: string
+    description: "SMTP Account to use. Must be configured in in the pack settings."
+    required: true
+    default: "default"
+  send_as_html:
+    type: boolean
+    description: "Send email body as HTML"
+    required: true
+    default: true
+  test_override:
+    type: boolean
+    description: "Overrides email sending to a single address for testing purposes (Will only send a subset of emails if there are lots of them)"
+    required: true
+    default: false
+  test_override_email:
+    type: array
+    description: "Email to send the output to if test_override is checked"
+    required: true
+    default:
+      - ""
+  names:
+    type: array
+    description: "Names to search openstack_resource (ignored unless query_preset=name_in, or name_contains etc)"
+    required: true
+    default:
+      - ""
+  ids:
+    type: array
+    description: "ID to search openstack_resource (ignored unless query_preset=id_in etc)"
+    required: true
+    default:
+      - ""
+  name_snippets:
+    type: array
+    description: "Name snippets to search openstack_resource (ignored unless query_preset=name_contains etc)"
+    required: true
+    default:
+      - ""
+  days:
+    type: integer
+    description: "Number of days threshold for selecting floating ips (ignored unless submodule=fips_older_than or fips_younger_than"
+    required: true
+    default: 60
+runner_type: python-script

--- a/actions/src/email_actions.py
+++ b/actions/src/email_actions.py
@@ -1,5 +1,6 @@
 from typing import Callable, Dict, List
 from email_api.email_api import EmailApi
+from openstack_api.openstack_floating_ip import OpenstackFloatingIP
 from openstack_api.openstack_query import OpenstackQuery
 from openstack_api.openstack_server import OpenstackServer
 
@@ -12,6 +13,9 @@ class EmailActions(Action):
         self._api: EmailApi = config.get("email_api", EmailApi())
         self._server_api: OpenstackServer = config.get(
             "openstack_server_api", OpenstackServer()
+        )
+        self._floating_ip_api: OpenstackServer = config.get(
+            "openstack_floating_ip_api", OpenstackFloatingIP()
         )
         self._query_api: OpenstackQuery = config.get(
             "openstack_query_api", OpenstackQuery()
@@ -86,7 +90,7 @@ class EmailActions(Action):
         **kwargs,
     ):
         """
-        Finds all servers belonging to a project (or all servers if project is empty)
+        Finds all servers matching a query and then sends emails to their users
         :param: cloud_account: The account from the clouds configuration to use
         :param: project_identifier: The project this applies to (or empty for all servers)
         :param: query_preset: The query to use when searching for servers
@@ -104,13 +108,13 @@ class EmailActions(Action):
         :param: send_as_html (Bool): If true will send in HTML format
         :return:
         """
-        if not "user_email" in properties_to_select:
+        if "user_email" not in properties_to_select:
             raise ValueError("properties_to_select must contain 'user_email'")
 
         # Ensure only a valid query preset is used when there is no project
-        # (try and prevent mistakingly emailing loads of people)
+        # (try and prevent mistakenly emailing loads of people)
         if project_identifier == "":
-            if not query_preset in OpenstackServer.SEARCH_QUERY_PRESETS_NO_PROJECT:
+            if query_preset not in OpenstackServer.SEARCH_QUERY_PRESETS_NO_PROJECT:
                 raise ValueError(
                     f"project_identifier needed for the query type '{query_preset}'"
                 )
@@ -125,6 +129,88 @@ class EmailActions(Action):
             "server",
             properties_to_select,
             "user_email",
+            send_as_html,
+        )
+
+        for key, value in emails.items():
+            separator = "<br><br>" if send_as_html else "\n\n"
+            emails[key] = f"{message}{separator}{value}"
+
+        return self._api.send_emails(
+            smtp_accounts=self.config.get("smtp_accounts", None),
+            emails=emails,
+            subject=subject,
+            email_from=email_from,
+            email_cc=email_cc,
+            header=header,
+            footer=footer,
+            attachment_filepaths=attachment_filepaths,
+            smtp_account=smtp_account,
+            test_override=test_override,
+            test_override_email=test_override_email,
+            send_as_html=send_as_html,
+        )
+
+    # pylint:disable=too-many-arguments,too-many-locals
+    def email_floating_ip_users(
+        self,
+        cloud_account: str,
+        project_identifier: str,
+        query_preset: str,
+        message: str,
+        properties_to_select: List[str],
+        subject: str,
+        email_from: str,
+        email_cc: List[str],
+        header: str,
+        footer: str,
+        attachment_filepaths: List[str],
+        smtp_account: str,
+        test_override: bool,
+        test_override_email: List[str],
+        send_as_html: bool,
+        **kwargs,
+    ):
+        """
+        Finds all floating ips matching a query and then sends emails to their project's contact
+        :param: cloud_account: The account from the clouds configuration to use
+        :param: project_identifier: The project this applies to (or empty for all servers)
+        :param: query_preset: The query to use when searching for servers
+        :param: message: Message to add to the body of emails sent
+        :param: properties_to_select: The list of properties to select and output from the found servers
+        :param: subject (String): Subject of the emails
+        :param: email_from (String): Sender Email, subject (String): Email Subject,
+        :param: email_cc (List[String]): Email addresses to Cc
+        :param: header (String): filepath to header file,
+        :param: footer (String): filepath to footer file,
+        :param: attachment (List): list of attachment filepaths,
+        :param: smtp_account (String): email config to use,
+        :param: test_override (Boolean): send all emails to test emails
+        :param: test_override_email (List[String]): send to this email if test_override enabled
+        :param: send_as_html (Bool): If true will send in HTML format
+        :return:
+        """
+        if "project_email" not in properties_to_select:
+            raise ValueError("properties_to_select must contain 'project_email'")
+
+        # Ensure only a valid query preset is used when there is no project
+        # (try and prevent mistakenly emailing loads of people)
+        if project_identifier == "":
+            if query_preset not in OpenstackFloatingIP.SEARCH_QUERY_PRESETS_NO_PROJECT:
+                raise ValueError(
+                    f"project_identifier needed for the query type '{query_preset}'"
+                )
+
+        servers = self._floating_ip_api[f"search_{query_preset}"](
+            cloud_account, project_identifier, **kwargs
+        )
+
+        emails = self._query_api.parse_and_output_table(
+            cloud_account,
+            servers,
+            "floating_ip",
+            properties_to_select,
+            "project_email",
             send_as_html,
         )
 

--- a/tests/actions/test_email_actions.py
+++ b/tests/actions/test_email_actions.py
@@ -1,5 +1,6 @@
 from unittest.mock import create_autospec, NonCallableMock
 from email_api.email_api import EmailApi
+from openstack_api.openstack_floating_ip import OpenstackFloatingIP
 
 from openstack_api.openstack_server import OpenstackServer
 from openstack_api.openstack_query import OpenstackQuery
@@ -29,12 +30,19 @@ class TestServerActions(OpenstackActionTestBase):
         # calls will go to the same mock
         self.server_mock.__getitem__ = OpenstackServer.__getitem__
 
+        self.floating_ip_mock = create_autospec(OpenstackFloatingIP)
+
+        # Want to keep mock of __getitem__ otherwise all f"search_{query_preset}"
+        # calls will go to the same mock
+        self.floating_ip_mock.__getitem__ = OpenstackFloatingIP.__getitem__
+
         self.query_mock = create_autospec(OpenstackQuery)
 
         self.action: EmailActions = self.get_action_instance(
             api_mocks={
-                "openstack_server_api": self.server_mock,
                 "email_api": self.email_mock,
+                "openstack_server_api": self.server_mock,
+                "openstack_floating_ip_api": self.floating_ip_mock,
                 "openstack_query_api": self.query_mock,
             },
         )
@@ -77,7 +85,7 @@ class TestServerActions(OpenstackActionTestBase):
             attachment_filepaths=[],
             smtp_account="",
             test_override=False,
-            test_override_email="",
+            test_override_email=[""],
             send_as_html=False,
             days=60,
             ids=None,
@@ -103,7 +111,7 @@ class TestServerActions(OpenstackActionTestBase):
             attachment_filepaths=[],
             smtp_account="",
             test_override=False,
-            test_override_email="",
+            test_override_email=[""],
             send_as_html=False,
             days=60,
             ids=None,
@@ -113,8 +121,8 @@ class TestServerActions(OpenstackActionTestBase):
 
     def test_email_server_users_no_project(self):
         """
-        Tests the action that sends emails to server does not give a value error when project is
-        required for the query type
+        Tests the action that sends emails to server users does not give a value error when a project
+        is required for the query type
         """
 
         i = 0
@@ -134,7 +142,7 @@ class TestServerActions(OpenstackActionTestBase):
 
     def test_email_server_users_no_project_error(self):
         """
-        Tests the action that sends emails to server users gives a value error when project is
+        Tests the action that sends emails to server users gives a value error when a project is
         required for the query type
         """
 
@@ -147,9 +155,103 @@ class TestServerActions(OpenstackActionTestBase):
         for query_preset in should_not_pass:
             self._check_email_server_users_raises(query_preset)
 
+    @raises(ValueError)
+    def test_email_floating_ip_users_no_email_error(self):
+        """
+        Tests the action that sends emails to floating ip users gives a value error when user_email
+        is not present in the `properties_to_select`
+        """
+        self.action.email_server_users(
+            cloud_account="test_account",
+            project_identifier="",
+            query_preset="fips_older_than",
+            message="Message",
+            properties_to_select=["id"],
+            subject="Subject",
+            email_from="testemail",
+            email_cc=[],
+            header="",
+            footer="",
+            attachment_filepaths=[],
+            smtp_account="",
+            test_override=False,
+            test_override_email=[""],
+            send_as_html=False,
+            days=60,
+            ids=None,
+            names=None,
+            name_snippets=None,
+        )
+
+    def _email_floating_ip_users(self, query_preset: str):
+        """
+        Helper for checking email_floating_ip_users works correctly
+        """
+        return self.action.email_floating_ip_users(
+            cloud_account="test_account",
+            project_identifier="",
+            query_preset=query_preset,
+            message="Message",
+            properties_to_select=["project_email"],
+            subject="Subject",
+            email_from="testemail",
+            email_cc=[],
+            header="",
+            footer="",
+            attachment_filepaths=[],
+            smtp_account="",
+            test_override=False,
+            test_override_email=[""],
+            send_as_html=False,
+            days=60,
+            ids=None,
+            names=None,
+            name_snippets=None,
+        )
+
+    def test_email_floating_ip_users_no_project(self):
+        """
+        Tests the action that sends emails to floating ip users does not give a value error when a project
+        is required for the query type
+        """
+
+        i = 0
+        for query_preset in OpenstackFloatingIP.SEARCH_QUERY_PRESETS_NO_PROJECT:
+            self._email_floating_ip_users(query_preset)
+            i += 1
+            self.assertEqual(self.email_mock.send_emails.call_count, i)
+
+    @raises(ValueError)
+    def _check_email_floating_ip_users_raises(self, query_preset):
+        """
+        Helper for checking email_floating_ip_users raises a ValueError when needed
+        (needed to allow multiple to be checked in the same test otherwise it stops
+         after the first error)
+        """
+        self.assertRaises(ValueError, self._email_floating_ip_users(query_preset))
+
+    def test_email_floating_ip_users_no_project_error(self):
+        """
+        Tests the action that sends emails to floating ip users gives a value error when a project
+        is required for the query type
+        """
+
+        # Should raise an error for all but a few queries
+        should_pass = OpenstackFloatingIP.SEARCH_QUERY_PRESETS_NO_PROJECT
+        should_not_pass = OpenstackFloatingIP.SEARCH_QUERY_PRESETS
+        for x in should_pass:
+            should_not_pass.remove(x)
+
+        for query_preset in should_not_pass:
+            self._check_email_floating_ip_users_raises(query_preset)
+
     def test_run_method(self):
         """
         Tests that run can dispatch to the Stackstorm facing methods
         """
-        expected_methods = ["send_email", "email_server_users"]
+        expected_methods = [
+            "send_email",
+            "email_server_users",
+            "email_floating_ip_users",
+        ]
         self._test_run_dynamic_dispatch(expected_methods)


### PR DESCRIPTION
Adds email.floating.ip.users action for emailing the contact emails for projects following a query that list floating ips.

Currently a draft as untested.