### PR TITLE
Remove hard-coded domain from project creation step

### DIFF
--- a/lib/openstack_api/openstack_identity.py
+++ b/lib/openstack_api/openstack_identity.py
@@ -33,8 +33,6 @@ class OpenstackIdentity(OpenstackWrapperBase):
             try:
                 return conn.identity.create_project(
                     name=project_details.name,
-                    # This is intentionally hard-coded as it's very rare we create something in another domain
-                    domain_id="default",
                     description=project_details.description,
                     is_enabled=project_details.is_enabled,
                     tags=[project_details.email],

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -91,7 +91,6 @@ class OpenstackIdentityTests(unittest.TestCase):
         assert found == self.identity_api.create_project.return_value
         self.identity_api.create_project.assert_called_once_with(
             name=expected_details.name,
-            domain_id="default",
             description=expected_details.description,
             is_enabled=expected_details.is_enabled,
             tags=[expected_details.email],


### PR DESCRIPTION
The hardcoded parameter isn't required, and will fail as "default"
cannot be found.