### PR TITLE
Add initial PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+### Description:
+
+<!--
+This should be a brief one or two line description of the PR. Details should be contained in commit messages.
+-->
+
+### Special Notes:
+
+<!-- This section and header can be removed if not required.
+
+Examples of special notes that must be included in the PR:
+- Changes any parameter names, or allowed values
+- Renames any actions, workflows or sensors
+- Requires any additional config files placed onto the server
+
+Or anything else you may want to note:
+
+-->
+
+---
+
+### Submitter:
+
+Have you (where applicable):
+
+* [ ] Added unit tests?
+* [ ] Checked the latest commit runs on Dev?
+* [ ] Updated the example config file(s) and README?
+
+---
+
+### Reviewer
+
+Does this PR:
+
+* [ ] Place non-StackStorm code into the `lib` directory?
+* [ ] Have unit tests for the action/sensor and `lib` layers?
+* [ ] Have clear and obvious action parameter names and descriptions?


### PR DESCRIPTION
This template should help both submitters and reviewers by nudging them
to the various pack standards used within