### PR TITLE
Add missing timeouts for pylint

### DIFF
--- a/actions/src/hypervisor.py
+++ b/actions/src/hypervisor.py
@@ -208,6 +208,7 @@ class Hypervisor(OpenstackAction):
                     "fixed": not is_flexible,
                 }
             ),
+            timeout=300,
         )
 
         if request.ok:
@@ -252,6 +253,7 @@ class Hypervisor(OpenstackAction):
                     "filter": f'host.name=="{hypervisor_hostname}"',
                 }
             ),
+            timeout=300,
         )
         if request.ok:
             return True, f"Downtimes of Host {hypervisor_hostname} Removed"

--- a/lib/amphorae.py
+++ b/lib/amphorae.py
@@ -16,4 +16,5 @@ def get_amphorae(cloud_account: str):
         return requests.get(
             url,
             headers={"X-Auth-Token": conn.auth_token},
+            timeout=300,
         )

--- a/lib/jupyter_api/user_api.py
+++ b/lib/jupyter_api/user_api.py
@@ -41,6 +41,7 @@ class UserApi:
         result = requests.get(
             url=API_ENDPOINTS[endpoint] + "/hub/api/users",
             headers={"Authorization": f"token {auth_token}"},
+            timeout=300,
         )
 
         if result.status_code == 200:
@@ -73,6 +74,7 @@ class UserApi:
         result = requests.delete(
             url=API_ENDPOINTS[endpoint] + f"/hub/api/users/{user}",
             headers={"Authorization": f"token {auth_token}"},
+            timeout=300,
         )
 
         if result.status_code != 204:

--- a/lib/post_ticket.py
+++ b/lib/post_ticket.py
@@ -29,4 +29,5 @@ def post_ticket(
             "serviceDeskId": service_desk_id,  # Point this at relevant service desk
             "requestTypeId": request_type_id,
         },
+        timeout=300,
     )

--- a/tests/lib/jupyter/test_user_api.py
+++ b/tests/lib/jupyter/test_user_api.py
@@ -38,6 +38,7 @@ class UserApiTests(unittest.TestCase):
         requests.get.assert_called_once_with(
             url=API_ENDPOINTS[endpoint] + "/hub/api/users",
             headers={"Authorization": f"token {token}"},
+            timeout=300,
         )
         assert len(returned) == 1
         assert returned[0][0] == expected_name
@@ -58,6 +59,7 @@ class UserApiTests(unittest.TestCase):
         requests.get.assert_called_once_with(
             url=API_ENDPOINTS[endpoint] + "/hub/api/users",
             headers={"Authorization": f"token {token}"},
+            timeout=300,
         )
         assert len(returned) == 0
 
@@ -131,6 +133,7 @@ class UserApiTests(unittest.TestCase):
         requests.delete.assert_called_once_with(
             url=API_ENDPOINTS["dev"] + "/hub/api/users/test",
             headers={"Authorization": f"token {token}"},
+            timeout=300,
         )
 
     def test_remove_users_multiple_users(self, requests):
@@ -150,6 +153,7 @@ class UserApiTests(unittest.TestCase):
             assert requests.delete.call_args_list[i] == call(
                 url=API_ENDPOINTS["dev"] + f"/hub/api/users/test-{user_index}",
                 headers={"Authorization": f"token {token}"},
+                timeout=300,
             )
         assert requests.delete.call_count == (end_index - start_index + 1)
 


### PR DESCRIPTION
Adds missing timeouts to fix `missing-timeout` pylint errors after the recent update in v2.15.0.