### PR TITLE
Add immutable project flag

### DIFF
--- a/actions/project.create.yaml
+++ b/actions/project.create.yaml
@@ -28,4 +28,8 @@ parameters:
     default: true
     description: Project is enabled or not
     type: boolean
+  immutable:
+    default: false
+    description: Project is immutable or not
+    type: boolean
 runner_type: python-script

--- a/actions/project.delete.yaml
+++ b/actions/project.delete.yaml
@@ -18,4 +18,9 @@ parameters:
     type: string
     default: ''
     required: true
+  delete:
+    description: Check this to actually delete instead of just returning the project
+    type: boolean
+    default: false
+    required: true
 runner_type: python-script

--- a/actions/project.update.yaml
+++ b/actions/project.update.yaml
@@ -38,4 +38,12 @@ parameters:
       - "unchanged"
       - "true"
       - "false"
+  immutable:
+    description: Project is immutable or not
+    type: string
+    default: "unchanged"
+    enum:
+      - "unchanged"
+      - "true"
+      - "false"
 runner_type: python-script

--- a/actions/src/project_actions.py
+++ b/actions/src/project_actions.py
@@ -72,6 +72,7 @@ class ProjectAction(Action):
         email: str,
         description: str,
         is_enabled: bool,
+        immutable: bool,
     ) -> Tuple[bool, Optional[Project]]:
         """
         Find and return a given project's properties. Expected
@@ -81,10 +82,15 @@ class ProjectAction(Action):
         :param email: Contact email of new project
         :param description: Description for new project
         :param is_enabled: Set if new project enabled or disabled
+        :param immutable: Set if new project is immutable or not
         :return: status, optional project
         """
         details = ProjectDetails(
-            name=name, email=email, description=description, is_enabled=is_enabled
+            name=name,
+            email=email,
+            description=description,
+            is_enabled=is_enabled,
+            immutable=immutable,
         )
         project = self._identity_api.create_project(
             cloud_account=cloud_account, project_details=details
@@ -127,6 +133,7 @@ class ProjectAction(Action):
         email: str,
         description: str,
         is_enabled: str,
+        immutable: str,
     ) -> Tuple[bool, Optional[Project]]:
         """
         Find and update a given project's properties.
@@ -136,16 +143,23 @@ class ProjectAction(Action):
         :param email: Contact email of the project
         :param description: Description of the project
         :param is_enabled: Enable or disable the project (takes values of unchanged, true or false)
+        :param immutable: Make the project immutable or not (takes values of unchanged, true or false)
         :return: status, optional project
         """
-        is_enabled_value = None
-        if is_enabled.casefold() == "true".casefold():
-            is_enabled_value = True
-        elif is_enabled.casefold() == "false".casefold():
-            is_enabled_value = False
+
+        def convert_to_optional_bool(value: str) -> Optional[bool]:
+            if value.casefold() == "true".casefold():
+                return True
+            if value.casefold() == "false".casefold():
+                return False
+            return None
 
         details = ProjectDetails(
-            name=name, email=email, description=description, is_enabled=is_enabled_value
+            name=name,
+            email=email,
+            description=description,
+            is_enabled=convert_to_optional_bool(is_enabled),
+            immutable=convert_to_optional_bool(immutable),
         )
         project = self._identity_api.update_project(
             cloud_account=cloud_account,

--- a/actions/src/project_actions.py
+++ b/actions/src/project_actions.py
@@ -44,14 +44,6 @@ class ProjectAction(Action):
                        chances of accidental deletion
         :return: The result of the operation
         """
-        if delete:
-            delete_ok = self._identity_api.delete_project(
-                cloud_account=cloud_account, project_identifier=project_identifier
-            )
-            # Currently, we only handle one error, other throws will propagate upwards
-            err = "" if delete_ok else "The specified project was not found"
-            return delete_ok, err
-
         project = self._identity_api.find_mandatory_project(
             cloud_account=cloud_account, project_identifier=project_identifier
         )
@@ -63,9 +55,17 @@ class ProjectAction(Action):
             group_by="",
             get_html=False,
         )
+
+        if delete:
+            delete_ok = self._identity_api.delete_project(
+                cloud_account=cloud_account, project_identifier=project_identifier
+            )
+            # Currently, we only handle one error, other throws will propagate upwards
+            message = f"The following project has been deleted:\n\n{project_string}"
+            return delete_ok, message
         return (
             False,
-            f"Tick the delete checkbox to delete the project: \n\n{project_string}",
+            f"Tick the delete checkbox to delete the project:\n\n{project_string}",
         )
 
     def project_find(

--- a/actions/workflow.project.create.external.yaml
+++ b/actions/workflow.project.create.external.yaml
@@ -21,6 +21,10 @@ parameters:
     required: true
     type: string
     description: Project Description
+  project_immutable:
+    default: false
+    description: Project is immutable or not
+    type: boolean
   admin_user_list:
     required: true
     type: array

--- a/actions/workflow.project.create.internal.yaml
+++ b/actions/workflow.project.create.internal.yaml
@@ -21,6 +21,10 @@ parameters:
     required: true
     type: string
     description: Project Description
+  project_immutable:
+    default: false
+    description: Project is immutable or not
+    type: boolean
   admin_user_list:
     required: true
     type: array

--- a/actions/workflows/project.create.external.yaml
+++ b/actions/workflows/project.create.external.yaml
@@ -8,6 +8,7 @@ input:
   - project_name
   - project_email
   - project_description
+  - project_immutable
   - admin_user_list
   - stfc_user_list
 
@@ -39,6 +40,7 @@ tasks:
       project_name=<% ctx().project_name %>
       project_email=<% ctx().project_email %>
       project_description=<% ctx().project_description %>
+      project_immutable=<% ctx().project_immutable %>
       admin_user_list=<% ctx().admin_user_list %>
       stfc_user_list=<% ctx().stfc_user_list %>
       network_name="External"

--- a/actions/workflows/project.create.internal.yaml
+++ b/actions/workflows/project.create.internal.yaml
@@ -7,6 +7,7 @@ input:
   - project_name
   - project_email
   - project_description
+  - project_immutable
   - admin_user_list
   - stfc_user_list
   - network_name: "Internal"
@@ -23,6 +24,7 @@ tasks:
       name=<% ctx().project_name %>
       email=<% ctx().project_email %>
       description=<% ctx().project_description %>
+      immutable=<% ctx().project_immutable %>
     next:
       - when: <% succeeded() %>
         publish:

--- a/lib/openstack_api/openstack_identity.py
+++ b/lib/openstack_api/openstack_identity.py
@@ -253,6 +253,7 @@ class OpenstackIdentity(OpenstackWrapperBase):
         """
         project = self.find_mandatory_project(cloud_account, project_identifier)
         project_tags = project["tags"]
+        project_immutable = self.is_project_immutable(project)
 
         params_to_update = {}
         if project_details.name:
@@ -277,7 +278,7 @@ class OpenstackIdentity(OpenstackWrapperBase):
             )
             params_to_update.update({"tags": project_tags})
 
-        if self.is_project_immutable(project):
+        if project_immutable:
             # Ensure only change is to the immutability
             if params_to_update.keys() != {"tags"}:
                 raise ValueError(

--- a/lib/openstack_api/openstack_identity.py
+++ b/lib/openstack_api/openstack_identity.py
@@ -29,13 +29,17 @@ class OpenstackIdentity(OpenstackWrapperBase):
         if "@" not in project_details.email:
             raise ValueError("The project contact email is invalid")
 
+        tags = [project_details.email]
+        if project_details.immutable:
+            tags.append("immutable")
+
         with self._connection_cls(cloud_account) as conn:
             try:
                 return conn.identity.create_project(
                     name=project_details.name,
                     description=project_details.description,
                     is_enabled=project_details.is_enabled,
-                    tags=[project_details.email],
+                    tags=tags,
                 )
             except ConflictException as err:
                 # Strip out frames that are noise by rethrowing
@@ -172,24 +176,30 @@ class OpenstackIdentity(OpenstackWrapperBase):
         self,
         project_tags: List[str],
         select_func: Callable[[str], bool],
-        new_value: str,
+        new_value: Optional[str],
     ) -> List[str]:
         """
         Returns an updated list of project tags after adding or updating one
         :param project_tags: The project tags
         :param select_func: Function that determines whether a tag should be selected
-        :param new_value: New value of the tag
+        :param new_value: New value of the tag, if None will remove the tag completely
         :return: The index of found tag or None
         """
         tag_index = self._find_project_tag_index(project_tags, select_func)
         if tag_index is not None:
-            project_tags[tag_index] = new_value
+            if new_value is not None:
+                project_tags[tag_index] = new_value
+            else:
+                del project_tags[tag_index]
         else:
             project_tags.append(new_value)
         return project_tags
 
-    def _select_project_email(self, tag):
+    def _select_project_email(self, tag) -> bool:
         return "@" in tag
+
+    def _select_project_immutable(self, tag) -> bool:
+        return tag == "immutable"
 
     def get_project_email(self, project: Project) -> Optional[str]:
         """
@@ -198,6 +208,17 @@ class OpenstackIdentity(OpenstackWrapperBase):
         :return: The found email or None
         """
         return self.find_project_tag(project["tags"], self._select_project_email)
+
+    def is_project_immutable(self, project: Project) -> bool:
+        """
+        Returns whether a given project is immutable or not
+        :param project: The project to check
+        :return: Whether the project is immutable
+        """
+        return (
+            self.find_project_tag(project["tags"], self._select_project_immutable)
+            == "immutable"
+        )
 
     def find_project_email(
         self, cloud_account: str, project_identifier: str
@@ -228,6 +249,7 @@ class OpenstackIdentity(OpenstackWrapperBase):
         :return: A clouds project, or None if it was unsuccessful
         """
         project = self.find_mandatory_project(cloud_account, project_identifier)
+        project_tags = project["tags"]
 
         params_to_update = {}
         if project_details.name:
@@ -240,10 +262,17 @@ class OpenstackIdentity(OpenstackWrapperBase):
             if "@" not in project_details.email:
                 raise ValueError("The project contact email is invalid")
 
-            new_tags = self.update_project_tag(
-                project["tags"], self._select_project_email, project_details.email
+            project_tags = self.update_project_tag(
+                project_tags, self._select_project_email, project_details.email
             )
-            params_to_update.update({"tags": new_tags})
+            params_to_update.update({"tags": project_tags})
+        if project_details.immutable is not None:
+            project_tags = self.update_project_tag(
+                project_tags,
+                self._select_project_immutable,
+                "immutable" if project_details.immutable else None,
+            )
+            params_to_update.update({"tags": project_tags})
 
         with self._connection_cls(cloud_account) as conn:
             # This update_project does not currently update tags for some reason

--- a/lib/structs/project_details.py
+++ b/lib/structs/project_details.py
@@ -9,3 +9,4 @@ class ProjectDetails:
     description: str = ""
     is_enabled: Optional[bool] = None
     openstack_id: Optional[str] = None
+    immutable: Optional[bool] = None

--- a/tests/actions/test_project_actions.py
+++ b/tests/actions/test_project_actions.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, create_autospec, NonCallableMock
+from unittest.mock import create_autospec, NonCallableMock
 
 from openstack_api.openstack_identity import OpenstackIdentity
 from openstack_api.openstack_project import OpenstackProject
@@ -84,12 +84,33 @@ class TestProjectAction(OpenstackActionTestBase):
         Tests that on successful deletion it returns the correct status and string
         """
         self.identity_mock.delete_project.return_value = True
+        self.identity_mock.find_mandatory_project.return_value = NonCallableMock()
         returned_values = self.action.project_delete(
-            cloud_account=NonCallableMock(),
-            project_identifier=NonCallableMock(),
+            cloud_account="test",
+            project_identifier="ProjectID",
             delete=True,
         )
-        assert returned_values == (True, "")
+        self.identity_mock.find_mandatory_project.assert_called_once_with(
+            cloud_account="test", project_identifier="ProjectID"
+        )
+        self.query_mock.parse_and_output_table.assert_called_once_with(
+            cloud_account="test",
+            items=[self.identity_mock.find_mandatory_project.return_value],
+            object_type="project",
+            properties_to_select=["id", "name", "description", "email"],
+            group_by="",
+            get_html=False,
+        )
+        self.identity_mock.delete_project.assert_called_once_with(
+            cloud_account="test", project_identifier="ProjectID"
+        )
+        self.assertEqual(
+            returned_values,
+            (
+                True,
+                f"The following project has been deleted:\n\n{self.query_mock.parse_and_output_table.return_value}",
+            ),
+        )
 
     def test_project_delete_safeguard(self):
         """
@@ -102,7 +123,6 @@ class TestProjectAction(OpenstackActionTestBase):
             project_identifier="ProjectID",
             delete=False,
         )
-        self.identity_mock.delete_project.assert_not_called()
         self.identity_mock.find_mandatory_project.assert_called_once_with(
             cloud_account="test", project_identifier="ProjectID"
         )
@@ -114,7 +134,17 @@ class TestProjectAction(OpenstackActionTestBase):
             group_by="",
             get_html=False,
         )
-        self.assertEqual(returned_values, (False, ANY))
+        self.identity_mock.delete_project.assert_not_called()
+        self.assertEqual(
+            returned_values,
+            (
+                False,
+                (
+                    f"Tick the delete checkbox to delete the project:"
+                    f"\n\n{self.query_mock.parse_and_output_table.return_value}"
+                ),
+            ),
+        )
 
     def test_project_find_success(self):
         """

--- a/tests/actions/test_project_actions.py
+++ b/tests/actions/test_project_actions.py
@@ -48,7 +48,8 @@ class TestProjectAction(OpenstackActionTestBase):
         Tests that create project forwards the result when successful
         """
         expected_proj_params = {
-            i: NonCallableMock() for i in ["name", "description", "is_enabled"]
+            i: NonCallableMock()
+            for i in ["name", "description", "is_enabled", "immutable"]
         }
         expected_proj_params.update({"email": "Test@Test.com"})
 
@@ -73,7 +74,7 @@ class TestProjectAction(OpenstackActionTestBase):
         self.identity_mock.create_project.return_value = None
 
         returned_values = self.action.project_create(
-            *{NonCallableMock() for _ in range(5)}
+            *{NonCallableMock() for _ in range(6)}
         )
         assert returned_values[0] is False
         assert returned_values[1] is None
@@ -111,7 +112,8 @@ class TestProjectAction(OpenstackActionTestBase):
         Tests that update project forwards the result when successful
         """
         expected_proj_params = {
-            i: NonCallableMock() for i in ["name", "description", "is_enabled"]
+            i: NonCallableMock()
+            for i in ["name", "description", "is_enabled", "immutable"]
         }
         expected_proj_params.update({"email": "Test@Test.com"})
 
@@ -121,7 +123,9 @@ class TestProjectAction(OpenstackActionTestBase):
         # Ensure is_enabled is assigned if specefied
         for value in ["unchanged", "true", "false"]:
             expected_proj_params["is_enabled"] = value
+            expected_proj_params["immutable"] = value
             packaged_proj.is_enabled = None if value == "unchanged" else value == "true"
+            packaged_proj.immutable = None if value == "unchanged" else value == "true"
 
             returned_values = self.action.project_update(
                 cloud_account="foo", project_identifier="bar", **expected_proj_params

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -96,6 +96,34 @@ class OpenstackIdentityTests(unittest.TestCase):
             tags=[expected_details.email],
         )
 
+    def test_create_project_immutable(self):
+        """
+        Tests that the params and result are forwarded as-is to/from the
+        create_project API
+        """
+
+        expected_details = ProjectDetails(
+            name=NonCallableMock(),
+            email="Test@Test.com",
+            description=NonCallableMock(),
+            is_enabled=NonCallableMock(),
+            immutable=True,
+        )
+
+        found = self.instance.create_project(
+            cloud_account="test", project_details=expected_details
+        )
+
+        self.mocked_connection.assert_called_once_with("test")
+
+        assert found == self.identity_api.create_project.return_value
+        self.identity_api.create_project.assert_called_once_with(
+            name=expected_details.name,
+            description=expected_details.description,
+            is_enabled=expected_details.is_enabled,
+            tags=[expected_details.email, "immutable"],
+        )
+
     @raises(ConflictException)
     def test_create_project_forwards_conflict_exception(self):
         """
@@ -146,6 +174,7 @@ class OpenstackIdentityTests(unittest.TestCase):
         """
 
         self.instance.find_project = Mock()
+        self.instance.find_project.return_value = self.MockProject(tags=[])
         self.identity_api.delete_project.return_value = None
 
         identifier = NonCallableMock()

--- a/tests/lib/test_openstack_identity.py
+++ b/tests/lib/test_openstack_identity.py
@@ -282,6 +282,20 @@ class OpenstackIdentityTests(unittest.TestCase):
 
         self.assertEqual(expected_email, email)
 
+    def test_is_project_immutable(self):
+        """
+        Checks that get_project_email functions correctly
+        """
+        mock_project = {"tags": ["Test", "Test@Test.com", "12123421"]}
+        immutable = self.instance.is_project_immutable(mock_project)
+
+        self.assertEqual(immutable, False)
+
+        mock_project = {"tags": ["Test", "Test@Test.com", "immutable", "12123421"]}
+        immutable = self.instance.is_project_immutable(mock_project)
+
+        self.assertEqual(immutable, True)
+
     def test_find_project_email(self):
         """
         Checks that find_project_email functions correctly
@@ -327,6 +341,7 @@ class OpenstackIdentityTests(unittest.TestCase):
             email="Test@Test.com",
             description=NonCallableMock(),
             is_enabled=NonCallableMock(),
+            immutable=None,
         )
 
         result = self.instance.update_project(
@@ -362,6 +377,7 @@ class OpenstackIdentityTests(unittest.TestCase):
             email="Test@Test.com",
             description=NonCallableMock(),
             is_enabled=NonCallableMock(),
+            immutable=NonCallableMock(),
         )
 
         result = self.instance.update_project(
@@ -372,7 +388,8 @@ class OpenstackIdentityTests(unittest.TestCase):
 
         self.mocked_connection.assert_called_with("test")
         mock_project.set_tags.assert_called_once_with(
-            self.identity_api, ["sometag", "anothertag", expected_details.email]
+            self.identity_api,
+            ["sometag", "anothertag", expected_details.email, "immutable"],
         )
 
         assert result == self.identity_api.update_project.return_value
@@ -381,7 +398,7 @@ class OpenstackIdentityTests(unittest.TestCase):
             name=expected_details.name,
             description=expected_details.description,
             is_enabled=expected_details.is_enabled,
-            tags=["sometag", "anothertag", expected_details.email],
+            tags=["sometag", "anothertag", expected_details.email, "immutable"],
         )
 
     def test_update_project_email(self):


### PR DESCRIPTION
### Description:

Adds an immutable option to project create action/workflows and ensures projects that have the flag in their tags are not deleted by project.delete. Also ensures they cannot be updated by project.update except to remove the immutable flag itself. Finally a 'delete' checkbox is added to project.delete which by default is unchecked so that the action only prints out the project it found to reduce the chances of accidental deletion.

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?

Closes #20 