### PR TITLE
Create workflow to delete FreeIPA users

### DIFF
--- a/actions/workflow.freeipa.user.delete.yaml
+++ b/actions/workflow.freeipa.user.delete.yaml
@@ -1,0 +1,26 @@
+name: workflow.freeipa.user.delete
+description: Deletes a given list of users
+enabled: true
+entry_point: workflows/freeipa.user.delete.yaml
+runner_type: orquesta
+
+parameters:
+  server_env:
+    description: The FreeIPA environment to delete users on
+    required: true
+    type: string
+    enum:
+      - prod
+      - dev
+  user_base_name:
+    description: The users to remove, or base name of the users to remove without the hyphen (e.g. "jupyter")
+    required: true
+    type: string
+  first_index:
+    description: The index of the first user to remove
+    required: false
+    type: integer
+  last_index:
+    description: The index of the last user to remove (inclusive).
+    required: false
+    type: integer

--- a/actions/workflows/freeipa.user.delete.yaml
+++ b/actions/workflows/freeipa.user.delete.yaml
@@ -1,0 +1,43 @@
+version: 1.0
+description: Deletes users on the FreeIPA server
+
+input:
+  - server_env
+  - user_base_name
+  - first_index
+  - last_index
+
+vars:
+  - usernames: null
+  - stdout: null
+
+tasks:
+  generate_users:
+    action: stackstorm_openstack.freeipa.generate.usernames
+      user_base_name=<% ctx(user_base_name) %>
+      user_start_index=<% ctx(first_index) %>
+      user_end_index=<% ctx(last_index) %>
+    next:
+        - when: <% succeeded() %>
+          publish:
+            - usernames: <% result().result %>
+          do:
+            - delete_users
+            - print_usernames
+
+  delete_users:
+    with: username in <% ctx(usernames) %>
+    action: freeipa.user_del
+      uid=<% item(username) %>
+      continue=False
+      connection=<% ctx().server_env %>
+
+  print_usernames:
+    with: username in <% ctx(usernames) %>
+    action: core.echo
+      message="<% item(username) %>"
+    next:
+      - publish: stdout=<% result().stdout %>
+
+output:
+  - stdout: <% ctx(stdout) %>


### PR DESCRIPTION
### Description:

Adds a workflow to delete users on a given FreeIPA server, based on the equivalent user creation workflow.

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
