### PR TITLE
Add action to create Jupyter users

### DIFF
--- a/actions/jupyter.user.create.yaml
+++ b/actions/jupyter.user.create.yaml
@@ -1,0 +1,32 @@
+name: jupyter.user.create
+description: Creates the given list of users
+
+enabled: true
+entry_point: src/jupyter.py
+runner_type: python-script
+
+parameters:
+  submodule:
+    default: user_create
+    immutable: true
+    type: string
+  jupyter_env:
+    description: The environment to create users from
+    required: true
+    type: string
+    enum:
+      - dev
+      - prod
+      - training
+  user:
+    description: The users to create, or base name of the users to create without the hyphen (e.g. "jupyter")
+    required: true
+    type: string
+  first_index:
+    description: The index of the first user to create
+    required: false
+    type: integer
+  last_index:
+    description: The index of the last user to create (inclusive)
+    required: false
+    type: integer

--- a/actions/src/jupyter.py
+++ b/actions/src/jupyter.py
@@ -1,6 +1,7 @@
 from typing import Dict, Callable, Optional
 
 from jupyter_api.user_api import UserApi
+from jupyter_api.get_token import get_token
 from st2common.runners.base_action import Action
 from structs.jupyter_users import JupyterUsers
 
@@ -29,18 +30,21 @@ class Jupyter(Action):
         Delete users from the given environment
         """
         jupyter_keys = self.config["jupyter"]
-
-        key_name = None
-        env = jupyter_env.casefold()
-        if env == "prod".casefold():
-            key_name = "prod_token"
-        if env == "training".casefold():
-            key_name = "training_token"
-        if env == "dev".casefold():
-            key_name = "dev_token"
-        if not key_name:
-            raise KeyError("Unknown Jupyter environment")
-
-        token = jupyter_keys[key_name]
+        token = get_token(jupyter_env, jupyter_keys)
         user_details = JupyterUsers(user, first_index, last_index)
         self._api.delete_users(jupyter_env, token, user_details)
+
+    def user_create(
+        self,
+        jupyter_env: str,
+        user: str,
+        first_index: Optional[int] = None,
+        last_index: Optional[int] = None,
+    ):
+        """
+        Create users from the given environment
+        """
+        jupyter_keys = self.config["jupyter"]
+        token = get_token(jupyter_env, jupyter_keys)
+        user_details = JupyterUsers(user, first_index, last_index)
+        self._api.create_users(jupyter_env, token, user_details)

--- a/lib/jupyter_api/get_token.py
+++ b/lib/jupyter_api/get_token.py
@@ -1,0 +1,22 @@
+def get_token(
+    jupyter_env: str,
+    jupyter_keys: str,
+) -> str:
+    """
+    Returns the appropriate API token based on the Jupyter environment
+    :param jupyter_env: The Jupyter environment name
+    :param jupyter_keys: Dictionary of Jupyter API tokens
+    """
+    key_name = None
+    env = jupyter_env.casefold()
+    if env == "prod".casefold():
+        key_name = "prod_token"
+    if env == "training".casefold():
+        key_name = "training_token"
+    if env == "dev".casefold():
+        key_name = "dev_token"
+    if not key_name:
+        raise KeyError("Unknown Jupyter environment")
+
+    token = jupyter_keys[key_name]
+    return token

--- a/lib/jupyter_api/user_api.py
+++ b/lib/jupyter_api/user_api.py
@@ -45,18 +45,7 @@ class UserApi:
         """
         Removes the given user(s) from the JupyterHub API
         """
-        if users.start_index or users.end_index:
-            if not (users.start_index and users.end_index):
-                raise RuntimeError("Both start_index and end_index must be provided")
-            if users.start_index > users.end_index:
-                raise RuntimeError("start_index must be less than end_index")
-
-        user_list = (
-            [f"{users.name}-{i}" for i in range(users.start_index, users.end_index + 1)]
-            if users.start_index
-            else [users.name]
-        )
-
+        user_list = self._get_user_list(users)
         for user in user_list:
             self._delete_single_user(endpoint, auth_token, user)
 
@@ -69,6 +58,42 @@ class UserApi:
 
         if result.status_code != 204:
             raise RuntimeError(f"Failed to remove user {user}: {result.text}")
+
+    def create_users(self, endpoint: str, auth_token: str, users: JupyterUsers) -> None:
+        """
+        Creates the given user(s) from the JupyterHub API
+        """
+        user_list = self._get_user_list(users)
+        for user in user_list:
+            self._create_single_user(endpoint, auth_token, user)
+
+    def _create_single_user(self, endpoint: str, auth_token: str, user: str):
+        result = requests.post(
+            url=API_ENDPOINTS[endpoint] + f"/hub/api/users/{user}",
+            headers={"Authorization": f"token {auth_token}"},
+            timeout=60,
+        )
+
+        if result.status_code != 201:
+            raise RuntimeError(f"Failed to create user {user}: {result.text}")
+
+    @staticmethod
+    def _get_user_list(users: JupyterUsers) -> List[str]:
+        """
+        Creates list of users from name and indices
+        """
+        if users.start_index or users.end_index:
+            if not (users.start_index and users.end_index):
+                raise RuntimeError("Both start_index and end_index must be provided")
+            if users.start_index > users.end_index:
+                raise RuntimeError("start_index must be less than end_index")
+
+        user_list = (
+            [f"{users.name}-{i}" for i in range(users.start_index, users.end_index + 1)]
+            if users.start_index
+            else [users.name]
+        )
+        return user_list
 
     @staticmethod
     def _pack_users(users: List[Dict]) -> List[JupyterLastUsed]:

--- a/tests/actions/test_jupyter_actions.py
+++ b/tests/actions/test_jupyter_actions.py
@@ -47,3 +47,24 @@ class TestJupyterActions(OpenstackActionTestBase):
     @raises(KeyError)
     def test_user_delete_throws_unknown_env(self):
         self.action.user_delete("unknown", NonCallableMock())
+
+    @parameterized.expand(["prod", "dev", "training"])
+    def test_user_create_gets_correct_key(self, endpoint):
+        token = self.jupyter_keys[endpoint]
+
+        users, start_index, end_index = (
+            NonCallableMock(),
+            NonCallableMock(),
+            NonCallableMock(),
+        )
+        expected = JupyterUsers(users, start_index, end_index)
+        self.action.action_service.get_value = Mock()
+        self.action.user_create(endpoint, users, start_index, end_index)
+
+        self.user_mock.create_users.assert_called_once_with(
+            endpoint=endpoint, auth_token=token, users=expected
+        )
+
+    @raises(KeyError)
+    def test_user_create_throws_unknown_env(self):
+        self.action.user_create("unknown", NonCallableMock())


### PR DESCRIPTION
### Description:

Adds an action and tests for creating a range of Jupyter users, based on the similar user deletion action.

Includes changes based on #45

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
