### PR TITLE
Jupyter start stop servers

### DIFF
--- a/actions/jupyter.server.start.yaml
+++ b/actions/jupyter.server.start.yaml
@@ -1,0 +1,32 @@
+name: jupyter.server.start
+description: Starts servers for the given list of users
+
+enabled: true
+entry_point: src/jupyter.py
+runner_type: python-script
+
+parameters:
+  submodule:
+    default: server_start
+    immutable: true
+    type: string
+  jupyter_env:
+    description: The environment to start servers from
+    required: true
+    type: string
+    enum:
+      - dev
+      - prod
+      - training
+  user:
+    description: The users to start servers for, or base name of the users without the hyphen (e.g. "jupyter")
+    required: true
+    type: string
+  first_index:
+    description: The index of the first user server to start
+    required: false
+    type: integer
+  last_index:
+    description: The index of the last user server to start (inclusive)
+    required: false
+    type: integer

--- a/actions/jupyter.server.stop.yaml
+++ b/actions/jupyter.server.stop.yaml
@@ -1,0 +1,32 @@
+name: jupyter.server.stop
+description: Stops servers for the given list of users
+
+enabled: true
+entry_point: src/jupyter.py
+runner_type: python-script
+
+parameters:
+  submodule:
+    default: server_stop
+    immutable: true
+    type: string
+  jupyter_env:
+    description: The environment to stop servers from
+    required: true
+    type: string
+    enum:
+      - dev
+      - prod
+      - training
+  user:
+    description: The users to stop servers for, or base name of the users without the hyphen (e.g. "jupyter")
+    required: true
+    type: string
+  first_index:
+    description: The index of the first user server to stop
+    required: false
+    type: integer
+  last_index:
+    description: The index of the last user server to stop (inclusive)
+    required: false
+    type: integer

--- a/actions/src/jupyter.py
+++ b/actions/src/jupyter.py
@@ -48,3 +48,33 @@ class Jupyter(Action):
         token = get_token(jupyter_env, jupyter_keys)
         user_details = JupyterUsers(user, first_index, last_index)
         self._api.create_users(jupyter_env, token, user_details)
+
+    def server_start(
+        self,
+        jupyter_env: str,
+        user: str,
+        first_index: Optional[int] = None,
+        last_index: Optional[int] = None,
+    ):
+        """
+        Start servers for users from the given environment
+        """
+        jupyter_keys = self.config["jupyter"]
+        token = get_token(jupyter_env, jupyter_keys)
+        user_details = JupyterUsers(user, first_index, last_index)
+        self._api.start_servers(jupyter_env, token, user_details)
+
+    def server_stop(
+        self,
+        jupyter_env: str,
+        user: str,
+        first_index: Optional[int] = None,
+        last_index: Optional[int] = None,
+    ):
+        """
+        Stop servers for users from the given environment
+        """
+        jupyter_keys = self.config["jupyter"]
+        token = get_token(jupyter_env, jupyter_keys)
+        user_details = JupyterUsers(user, first_index, last_index)
+        self._api.stop_servers(jupyter_env, token, user_details)

--- a/tests/lib/jupyter/test_server_api.py
+++ b/tests/lib/jupyter/test_server_api.py
@@ -1,0 +1,134 @@
+import unittest
+from unittest.mock import patch, NonCallableMock, call
+
+from nose.tools import assert_raises_regexp, raises
+
+from jupyter_api.api_endpoints import API_ENDPOINTS
+from jupyter_api.user_api import UserApi
+from structs.jupyter_users import JupyterUsers
+
+
+@patch("jupyter_api.user_api.requests")
+class UserApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api = UserApi()
+
+    def test_start_servers_single_user(self, requests):
+        """
+        Tests that the start_servers method calls the correct endpoint
+        """
+        token = NonCallableMock()
+        user_names = JupyterUsers(name="test", start_index=None, end_index=None)
+        requests.post.return_value.status_code = 201
+
+        self.api.start_servers("dev", token, user_names)
+        requests.post.assert_called_once_with(
+            url=API_ENDPOINTS["dev"] + "/hub/api/users/test/server",
+            headers={"Authorization": f"token {token}"},
+            timeout=60,
+        )
+
+    def test_start_servers_multiple_users(self, requests):
+        """
+        Tests that the start_servers method calls the correct endpoint
+        and usernames
+        """
+        token = NonCallableMock()
+        start_index, end_index = 1, 10
+        user_names = JupyterUsers(
+            name="test", start_index=start_index, end_index=end_index
+        )
+        requests.post.return_value.status_code = 201
+
+        self.api.start_servers("dev", token, user_names)
+        for i, user_index in enumerate(range(start_index, end_index + 1)):
+            assert requests.post.call_args_list[i] == call(
+                url=API_ENDPOINTS["dev"] + f"/hub/api/users/test-{user_index}/server",
+                headers={"Authorization": f"token {token}"},
+                timeout=60,
+            )
+        assert requests.post.call_count == (end_index - start_index + 1)
+
+    @raises(RuntimeError)
+    def test_start_servers_missing_start_index(self, _):
+        """
+        Tests that the start_servers method raises an error if the start_index is not provided
+        """
+        user_names = JupyterUsers(name="test", start_index=None, end_index=1)
+        self.api.start_servers("dev", "token", user_names)
+
+    @raises(RuntimeError)
+    def test_start_servers_missing_end_index(self, _):
+        """
+        Tests that the start_servers method raises an error if the end_index is not provided
+        """
+        user_names = JupyterUsers(name="test", start_index=1, end_index=None)
+        self.api.start_servers("dev", "token", user_names)
+
+    def test_start_servers_incorrect_order(self, _):
+        """
+        Tests that the start_servers method raises an error if the end_index is greater than start
+        """
+        user_names = JupyterUsers(name="test", start_index=2, end_index=1)
+        with assert_raises_regexp(RuntimeError, "must be less than"):
+            self.api.start_servers("dev", "token", user_names)
+
+    def test_stop_servers_single_user(self, requests):
+        """
+        Tests that the stop_servers method calls the correct endpoint
+        """
+        token = NonCallableMock()
+        user_names = JupyterUsers(name="test", start_index=None, end_index=None)
+        requests.delete.return_value.status_code = 204
+
+        self.api.stop_servers("dev", token, user_names)
+        requests.delete.assert_called_once_with(
+            url=API_ENDPOINTS["dev"] + "/hub/api/users/test/server",
+            headers={"Authorization": f"token {token}"},
+            timeout=60,
+        )
+
+    def test_stop_servers_multiple_users(self, requests):
+        """
+        Tests that the stop_servers method calls the correct endpoint
+        and usernames
+        """
+        token = NonCallableMock()
+        start_index, end_index = 1, 10
+        user_names = JupyterUsers(
+            name="test", start_index=start_index, end_index=end_index
+        )
+        requests.delete.return_value.status_code = 204
+
+        self.api.stop_servers("dev", token, user_names)
+        for i, user_index in enumerate(range(start_index, end_index + 1)):
+            assert requests.delete.call_args_list[i] == call(
+                url=API_ENDPOINTS["dev"] + f"/hub/api/users/test-{user_index}/server",
+                headers={"Authorization": f"token {token}"},
+                timeout=60,
+            )
+        assert requests.delete.call_count == (end_index - start_index + 1)
+
+    @raises(RuntimeError)
+    def test_stop_servers_missing_start_index(self, _):
+        """
+        Tests that the stop_servers method raises an error if the start_index is not provided
+        """
+        user_names = JupyterUsers(name="test", start_index=None, end_index=1)
+        self.api.stop_servers("dev", "token", user_names)
+
+    @raises(RuntimeError)
+    def test_stop_servers_missing_end_index(self, _):
+        """
+        Tests that the stop_servers method raises an error if the end_index is not provided
+        """
+        user_names = JupyterUsers(name="test", start_index=1, end_index=None)
+        self.api.stop_servers("dev", "token", user_names)
+
+    def test_stop_servers_incorrect_order(self, _):
+        """
+        Tests that the stop_servers method raises an error if the end_index is greater than start
+        """
+        user_names = JupyterUsers(name="test", start_index=2, end_index=1)
+        with assert_raises_regexp(RuntimeError, "must be less than"):
+            self.api.stop_servers("dev", "token", user_names)

--- a/tests/lib/jupyter/test_server_api.py
+++ b/tests/lib/jupyter/test_server_api.py
@@ -73,6 +73,17 @@ class UserApiTests(unittest.TestCase):
         with assert_raises_regexp(RuntimeError, "must be less than"):
             self.api.start_servers("dev", "token", user_names)
 
+    def test_start_servers_handles_error(self, requests):
+        """
+        Tests that the start_servers method logs an error if the request fails
+        """
+        token = NonCallableMock()
+        user_names = JupyterUsers(name="test", start_index=None, end_index=None)
+        requests.post.return_value.status_code = 500
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to request server"):
+            self.api.start_servers("dev", token, user_names)
+
     def test_stop_servers_single_user(self, requests):
         """
         Tests that the stop_servers method calls the correct endpoint
@@ -132,3 +143,14 @@ class UserApiTests(unittest.TestCase):
         user_names = JupyterUsers(name="test", start_index=2, end_index=1)
         with assert_raises_regexp(RuntimeError, "must be less than"):
             self.api.stop_servers("dev", "token", user_names)
+
+    def test_stop_servers_handles_error(self, requests):
+        """
+        Tests that the stop_servers method logs an error if the request fails
+        """
+        token = NonCallableMock()
+        user_names = JupyterUsers(name="test", start_index=None, end_index=None)
+        requests.delete.return_value.status_code = 500
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to stop server"):
+            self.api.stop_servers("dev", token, user_names)


### PR DESCRIPTION
### Description:

Adds actions to start and stop default servers for Jupyter users, and tests, similar to those for creating and deleting users.

### Special Notes:

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
