### PR TITLE
Create workflows for Jupyter user setup/deletion

### DIFF
--- a/actions/workflow.jupyter.user.cleanup.yaml
+++ b/actions/workflow.jupyter.user.cleanup.yaml
@@ -1,0 +1,27 @@
+name: workflow.jupyter.user.cleanup
+description: Stops servers and deletes a given list of JupyterHub users
+enabled: true
+entry_point: workflows/jupyter.user.cleanup.yaml
+runner_type: orquesta
+
+parameters:
+  jupyter_env:
+    description: The Jupyter environment to clean up users on
+    required: true
+    type: string
+    enum:
+      - prod
+      - dev
+      - training
+  user_base_name:
+    description: The users to clean up, or base name of the users to clean up without the hyphen (e.g. "jupyter")
+    required: true
+    type: string
+  first_index:
+    description: The index of the first user to clean up
+    required: false
+    type: integer
+  last_index:
+    description: The index of the last user to clean up (inclusive).
+    required: false
+    type: integer

--- a/actions/workflow.jupyter.user.prepare.yaml
+++ b/actions/workflow.jupyter.user.prepare.yaml
@@ -1,0 +1,27 @@
+name: workflow.jupyter.user.prepare
+description: Creates a list of JupyterHub users, and starts up servers for each user
+enabled: true
+entry_point: workflows/jupyter.user.prepare.yaml
+runner_type: orquesta
+
+parameters:
+  jupyter_env:
+    description: The Jupyter environment to prepare users on
+    required: true
+    type: string
+    enum:
+      - prod
+      - dev
+      - training
+  user_base_name:
+    description: The users to prepare, or base name of the users to prepare without the hyphen (e.g. "jupyter")
+    required: true
+    type: string
+  first_index:
+    description: The index of the first user to prepare
+    required: false
+    type: integer
+  last_index:
+    description: The index of the last user to prepare (inclusive).
+    required: false
+    type: integer

--- a/actions/workflows/jupyter.user.cleanup.yaml
+++ b/actions/workflows/jupyter.user.cleanup.yaml
@@ -1,0 +1,27 @@
+version: 1.0
+description: Stops servers and deletes a list of JupyterHub users
+
+input:
+  - jupyter_env
+  - user_base_name
+  - first_index
+  - last_index
+
+tasks:
+  stop_jupyter_servers:
+    action: stackstorm_openstack.jupyter.server.stop
+      user=<% ctx(user_base_name) %>
+      first_index=<% ctx(first_index) %>
+      last_index=<% ctx(last_index) %>
+      jupyter_env=<% ctx(jupyter_env) %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - delete_jupyter_users
+
+  delete_jupyter_users:
+    action: stackstorm_openstack.jupyter.user.delete
+      user=<% ctx(user_base_name) %>
+      first_index=<% ctx(first_index) %>
+      last_index=<% ctx(last_index) %>
+      jupyter_env=<% ctx(jupyter_env) %>

--- a/actions/workflows/jupyter.user.prepare.yaml
+++ b/actions/workflows/jupyter.user.prepare.yaml
@@ -1,0 +1,27 @@
+version: 1.0
+description: Creates a list of JupyterHub users, and starts up servers for each user
+
+input:
+  - jupyter_env
+  - user_base_name
+  - first_index
+  - last_index
+
+tasks:
+  create_jupyter_users:
+    action: stackstorm_openstack.jupyter.user.create
+      user=<% ctx(user_base_name) %>
+      first_index=<% ctx(first_index) %>
+      last_index=<% ctx(last_index) %>
+      jupyter_env=<% ctx(jupyter_env) %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - start_jupyter_servers
+
+  start_jupyter_servers:
+    action: stackstorm_openstack.jupyter.server.start
+      user=<% ctx(user_base_name) %>
+      first_index=<% ctx(first_index) %>
+      last_index=<% ctx(last_index) %>
+      jupyter_env=<% ctx(jupyter_env) %>


### PR DESCRIPTION
### Description:

Depends on #52

Adds two workflows to combine Jupyter user creation/starting servers, and user deletion/stopping servers.

### Special Notes:

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
