### PR TITLE
Add list of cloud options to all actions

### DIFF
--- a/actions/checks.old.snapshots.yaml
+++ b/actions/checks.old.snapshots.yaml
@@ -9,9 +9,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_id:
     description: ID of the project to be scanned for the above security group details (*Requires one of)
     default: ""

--- a/actions/checks.security.groups.yaml
+++ b/actions/checks.security.groups.yaml
@@ -9,9 +9,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   ip_prefix:
     description: The IPs that are allowed to access the port range specified in max and min port. This should be given in a CIDR format e.g. 0.0.0.0/0 for all internet
     default: ""

--- a/actions/correctness.find.floating.ips.in.non.existent.projects.yaml
+++ b/actions/correctness.find.floating.ips.in.non.existent.projects.yaml
@@ -12,7 +12,10 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
 runner_type: python-script

--- a/actions/correctness.find.images.in.non.existent.projects.yaml
+++ b/actions/correctness.find.images.in.non.existent.projects.yaml
@@ -12,7 +12,10 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
 runner_type: python-script

--- a/actions/correctness.find.non.existent.floating.ips.yaml
+++ b/actions/correctness.find.non.existent.floating.ips.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: "Project (Name or ID) to search in - leave empty for all projects"

--- a/actions/correctness.find.non.existent.images.yaml
+++ b/actions/correctness.find.non.existent.images.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: "Project (Name or ID) to search in - leave empty for all projects"

--- a/actions/correctness.find.non.existent.servers.yaml
+++ b/actions/correctness.find.non.existent.servers.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: "Project (Name or ID) to search in - leave empty for all projects"

--- a/actions/correctness.find.servers.in.non.existent.projects.yaml
+++ b/actions/correctness.find.servers.in.non.existent.projects.yaml
@@ -12,7 +12,10 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
 runner_type: python-script

--- a/actions/email.floating.ip.users.yaml
+++ b/actions/email.floating.ip.users.yaml
@@ -13,7 +13,6 @@ parameters:
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
     type: string
-    default: ""
     required: true
   project_identifier:
     type: string

--- a/actions/email.image.users.yaml
+++ b/actions/email.image.users.yaml
@@ -13,8 +13,11 @@ parameters:
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
     type: string
-    default: ""
     required: true
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: "Project (Name or ID) to search in - leave empty for all projects"

--- a/actions/email.server.users.yaml
+++ b/actions/email.server.users.yaml
@@ -13,8 +13,11 @@ parameters:
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
     type: string
-    default: ""
     required: true
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: Project (Name or ID) to search in - leave empty for all projects

--- a/actions/floating.ip.create.yaml
+++ b/actions/floating.ip.create.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   network_identifier:
     description: "Network to allocate floating IP from (Name or ID)"
     required: true

--- a/actions/floating.ip.get.yaml
+++ b/actions/floating.ip.get.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   ip:
     description: "Floating IP address to look-up"
     required: true

--- a/actions/floating.ip.list.yaml
+++ b/actions/floating.ip.list.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: Project (Name or ID) to search in - leave empty for all projects

--- a/actions/hypervisor.list.yaml
+++ b/actions/hypervisor.list.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   query_preset:
     type: string
     description: "Name of a preset query - e.g hvs_older_than: list all hvs older than"

--- a/actions/image.list.yaml
+++ b/actions/image.list.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: "Project (Name or ID) to search in - leave empty for all projects"

--- a/actions/network.create.yaml
+++ b/actions/network.create.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project to create a new Network in (Name or ID)
     required: True

--- a/actions/network.delete.yaml
+++ b/actions/network.delete.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   network_identifier:
     default: Network Name or ID to delete
     type: string

--- a/actions/network.find.yaml
+++ b/actions/network.find.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   network_identifier:
     description: Network Name or ID
     required: True

--- a/actions/network.rbac.create.yaml
+++ b/actions/network.rbac.create.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: The project to which the RBAC policy will be enforced (name or ID)
     required: true

--- a/actions/network.rbac.delete.yaml
+++ b/actions/network.rbac.delete.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   rbac_identifier:
     description: RBAC policy Name or Openstack ID
     required: True

--- a/actions/network.rbac.search.yaml
+++ b/actions/network.rbac.search.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: The project name or ID these policies apply to
     required: True

--- a/actions/project.create.yaml
+++ b/actions/project.create.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   name:
     description: New project Name
     required: true

--- a/actions/project.delete.yaml
+++ b/actions/project.delete.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project Name or Openstack ID to delete
     type: string

--- a/actions/project.find.yaml
+++ b/actions/project.find.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project to find (name or Openstack ID)
     required: true

--- a/actions/project.list.yaml
+++ b/actions/project.list.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   query_preset:
     type: string
     description: "Name of a preset query - e.g project_name_contains: list all projects with particular strings in their name"

--- a/actions/project.update.yaml
+++ b/actions/project.update.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project to update (name or Openstack ID)
     required: true

--- a/actions/quota.set.yaml
+++ b/actions/quota.set.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project (Name or ID)
     required: true

--- a/actions/role.add.yaml
+++ b/actions/role.add.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project (Name or ID)
     required: true

--- a/actions/role.remove.yaml
+++ b/actions/role.remove.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project name (Name or ID)
     required: true

--- a/actions/role.validate.user.yaml
+++ b/actions/role.validate.user.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project (Name or ID)
     required: true

--- a/actions/router.add.interface.yaml
+++ b/actions/router.add.interface.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project (Name or ID) to search in
     required: true

--- a/actions/router.create.yaml
+++ b/actions/router.create.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project (Name or ID) to search in
     required: true

--- a/actions/router.get.yaml
+++ b/actions/router.get.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: Project (Name or ID) to search in
     required: true

--- a/actions/security.group.create.yaml
+++ b/actions/security.group.create.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   group_name:
     description: New security group name
     required: true

--- a/actions/security.group.find.yaml
+++ b/actions/security.group.find.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: The name of Openstack ID of the associated project
     required: true

--- a/actions/security.group.list.yaml
+++ b/actions/security.group.list.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: The name of Openstack ID of the associated project
     required: true

--- a/actions/security.group.rule.create.yaml
+++ b/actions/security.group.rule.create.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     description: The name of Openstack ID of the associated project
     required: true

--- a/actions/server.list.yaml
+++ b/actions/server.list.yaml
@@ -12,9 +12,12 @@ parameters:
     immutable: true
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_identifier:
     type: string
     description: Project (Name or ID) to search in - leave empty for all projects

--- a/actions/subnet.create.yaml
+++ b/actions/subnet.create.yaml
@@ -12,6 +12,10 @@ parameters:
     description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   network:
     required: True
     description: Network for subnet (Name or ID)

--- a/actions/user.get.email.yaml
+++ b/actions/user.get.email.yaml
@@ -10,9 +10,12 @@ parameters:
     type: string
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ''
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   user:
     description: "User to get email address for (name or ID)"
     required: true

--- a/actions/user.list.yaml
+++ b/actions/user.list.yaml
@@ -11,10 +11,13 @@ parameters:
     type: string
     immutable: true
   cloud_account:
-    description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
+    description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   user_domain:
     type: string
     description: "Domain (Name or ID) to search in"

--- a/actions/workflow.checks.old.snapshots.yaml
+++ b/actions/workflow.checks.old.snapshots.yaml
@@ -5,9 +5,12 @@ name: workflow.check.old.snapshots
 parameters:
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_id:
     description: ID of the project to be scanned for the above security group details (*Requires one of)
     default: ""

--- a/actions/workflow.checks.security.groups.yaml
+++ b/actions/workflow.checks.security.groups.yaml
@@ -5,9 +5,12 @@ name: workflow.check.security.groups
 parameters:
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   ip_prefix:
     description: The IPs that are allowed to access the port range specified below
     default: ""

--- a/actions/workflow.email.errored.server.users.yaml
+++ b/actions/workflow.email.errored.server.users.yaml
@@ -4,10 +4,13 @@ entry_point: workflows/email.errored.server.users.yaml
 name: workflow.email.errored.server.users
 parameters:
   cloud_account:
-    description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
+    description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_id:
     description: "Project (Name or ID) to search in - leave empty for all projects"
     default: ""

--- a/actions/workflow.email.shutoff.server.users.yaml
+++ b/actions/workflow.email.shutoff.server.users.yaml
@@ -4,10 +4,13 @@ entry_point: workflows/email.shutoff.server.users.yaml
 name: workflow.email.shutoff.server.users
 parameters:
   cloud_account:
-    description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
+    description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_id:
     description: "Project (Name or ID) to search in - leave empty for all projects"
     default: ""

--- a/actions/workflow.email.stale.server.users.yaml
+++ b/actions/workflow.email.stale.server.users.yaml
@@ -4,10 +4,13 @@ entry_point: workflows/email.stale.server.users.yaml
 name: workflow.email.stale.server.users
 parameters:
   cloud_account:
-    description: "The clouds.yaml account to use whilst performing this action"
-    default: ""
+    description: The clouds.yaml account to use whilst performing this action
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_id:
     description: "Project (Name or ID) to search in - leave empty for all projects"
     default: ""

--- a/actions/workflow.project.create.external.yaml
+++ b/actions/workflow.project.create.external.yaml
@@ -6,9 +6,12 @@ name: workflow.project.create.external
 parameters:
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_name:
     required: true
     type: string

--- a/actions/workflow.project.create.internal.yaml
+++ b/actions/workflow.project.create.internal.yaml
@@ -6,9 +6,12 @@ name: workflow.project.create.internal
 parameters:
   cloud_account:
     description: The clouds.yaml account to use whilst performing this action
-    default: ""
     required: true
     type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
   project_name:
     required: true
     type: string


### PR DESCRIPTION
### Description:
This switches all the actions to use a preselected cloud account. Currently we have dev and prod, with dev selected by default. This saves the user having to remember the possible environments and and any typos.

Fixes: #49 

### Special Notes:
This will require a complete uninstall / reinstall for the pack to pick up the changes once merged

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
