### PR TITLE
Async jupyter code

### DIFF
--- a/lib/jupyter_api/user_api.py
+++ b/lib/jupyter_api/user_api.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from typing import List, Dict
 
+import httpx
 import pytz
-import requests
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 
@@ -29,7 +29,7 @@ class UserApi:
         """
         Gets the list of all users from the JupyterHub API
         """
-        result = requests.get(
+        result = httpx.get(
             url=API_ENDPOINTS[endpoint] + "/hub/api/users",
             headers={"Authorization": f"token {auth_token}"},
             timeout=300,
@@ -50,7 +50,7 @@ class UserApi:
             self._delete_single_user(endpoint, auth_token, user)
 
     def _delete_single_user(self, endpoint: str, auth_token: str, user: str):
-        result = requests.delete(
+        result = httpx.delete(
             url=API_ENDPOINTS[endpoint] + f"/hub/api/users/{user}",
             headers={"Authorization": f"token {auth_token}"},
             timeout=300,
@@ -68,7 +68,7 @@ class UserApi:
             self._create_single_user(endpoint, auth_token, user)
 
     def _create_single_user(self, endpoint: str, auth_token: str, user: str):
-        result = requests.post(
+        result = httpx.post(
             url=API_ENDPOINTS[endpoint] + f"/hub/api/users/{user}",
             headers={"Authorization": f"token {auth_token}"},
             timeout=60,
@@ -88,7 +88,7 @@ class UserApi:
             self._start_single_server(endpoint, auth_token, user)
 
     def _start_single_server(self, endpoint: str, auth_token: str, user: str):
-        result = requests.post(
+        result = httpx.post(
             url=API_ENDPOINTS[endpoint] + f"/hub/api/users/{user}/server",
             headers={"Authorization": f"token {auth_token}"},
             timeout=60,
@@ -108,7 +108,7 @@ class UserApi:
             self._stop_single_server(endpoint, auth_token, user)
 
     def _stop_single_server(self, endpoint: str, auth_token: str, user: str):
-        result = requests.delete(
+        result = httpx.delete(
             url=API_ENDPOINTS[endpoint] + f"/hub/api/users/{user}/server",
             headers={"Authorization": f"token {auth_token}"},
             timeout=60,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-openstackclient == 5.7.0
 tabulate
 requests
 dataclasses; python_version < '3.7'
+httpx

--- a/tests/lib/jupyter/test_server_api.py
+++ b/tests/lib/jupyter/test_server_api.py
@@ -8,27 +8,27 @@ from jupyter_api.user_api import UserApi
 from structs.jupyter_users import JupyterUsers
 
 
-@patch("jupyter_api.user_api.requests")
+@patch("jupyter_api.user_api.httpx")
 class UserApiTests(unittest.TestCase):
     def setUp(self) -> None:
         self.api = UserApi()
 
-    def test_start_servers_single_user(self, requests):
+    def test_start_servers_single_user(self, httpx):
         """
         Tests that the start_servers method calls the correct endpoint
         """
         token = NonCallableMock()
         user_names = JupyterUsers(name="test", start_index=None, end_index=None)
-        requests.post.return_value.status_code = 201
+        httpx.post.return_value.status_code = 201
 
         self.api.start_servers("dev", token, user_names)
-        requests.post.assert_called_once_with(
+        httpx.post.assert_called_once_with(
             url=API_ENDPOINTS["dev"] + "/hub/api/users/test/server",
             headers={"Authorization": f"token {token}"},
             timeout=60,
         )
 
-    def test_start_servers_multiple_users(self, requests):
+    def test_start_servers_multiple_users(self, httpx):
         """
         Tests that the start_servers method calls the correct endpoint
         and usernames
@@ -38,16 +38,16 @@ class UserApiTests(unittest.TestCase):
         user_names = JupyterUsers(
             name="test", start_index=start_index, end_index=end_index
         )
-        requests.post.return_value.status_code = 201
+        httpx.post.return_value.status_code = 201
 
         self.api.start_servers("dev", token, user_names)
         for i, user_index in enumerate(range(start_index, end_index + 1)):
-            assert requests.post.call_args_list[i] == call(
+            assert httpx.post.call_args_list[i] == call(
                 url=API_ENDPOINTS["dev"] + f"/hub/api/users/test-{user_index}/server",
                 headers={"Authorization": f"token {token}"},
                 timeout=60,
             )
-        assert requests.post.call_count == (end_index - start_index + 1)
+        assert httpx.post.call_count == (end_index - start_index + 1)
 
     @raises(RuntimeError)
     def test_start_servers_missing_start_index(self, _):
@@ -73,33 +73,33 @@ class UserApiTests(unittest.TestCase):
         with assert_raises_regexp(RuntimeError, "must be less than"):
             self.api.start_servers("dev", "token", user_names)
 
-    def test_start_servers_handles_error(self, requests):
+    def test_start_servers_handles_error(self, httpx):
         """
         Tests that the start_servers method logs an error if the request fails
         """
         token = NonCallableMock()
         user_names = JupyterUsers(name="test", start_index=None, end_index=None)
-        requests.post.return_value.status_code = 500
+        httpx.post.return_value.status_code = 500
 
         with self.assertRaisesRegex(RuntimeError, "Failed to request server"):
             self.api.start_servers("dev", token, user_names)
 
-    def test_stop_servers_single_user(self, requests):
+    def test_stop_servers_single_user(self, httpx):
         """
         Tests that the stop_servers method calls the correct endpoint
         """
         token = NonCallableMock()
         user_names = JupyterUsers(name="test", start_index=None, end_index=None)
-        requests.delete.return_value.status_code = 204
+        httpx.delete.return_value.status_code = 204
 
         self.api.stop_servers("dev", token, user_names)
-        requests.delete.assert_called_once_with(
+        httpx.delete.assert_called_once_with(
             url=API_ENDPOINTS["dev"] + "/hub/api/users/test/server",
             headers={"Authorization": f"token {token}"},
             timeout=60,
         )
 
-    def test_stop_servers_multiple_users(self, requests):
+    def test_stop_servers_multiple_users(self, httpx):
         """
         Tests that the stop_servers method calls the correct endpoint
         and usernames
@@ -109,16 +109,16 @@ class UserApiTests(unittest.TestCase):
         user_names = JupyterUsers(
             name="test", start_index=start_index, end_index=end_index
         )
-        requests.delete.return_value.status_code = 204
+        httpx.delete.return_value.status_code = 204
 
         self.api.stop_servers("dev", token, user_names)
         for i, user_index in enumerate(range(start_index, end_index + 1)):
-            assert requests.delete.call_args_list[i] == call(
+            assert httpx.delete.call_args_list[i] == call(
                 url=API_ENDPOINTS["dev"] + f"/hub/api/users/test-{user_index}/server",
                 headers={"Authorization": f"token {token}"},
                 timeout=60,
             )
-        assert requests.delete.call_count == (end_index - start_index + 1)
+        assert httpx.delete.call_count == (end_index - start_index + 1)
 
     @raises(RuntimeError)
     def test_stop_servers_missing_start_index(self, _):
@@ -144,13 +144,13 @@ class UserApiTests(unittest.TestCase):
         with assert_raises_regexp(RuntimeError, "must be less than"):
             self.api.stop_servers("dev", "token", user_names)
 
-    def test_stop_servers_handles_error(self, requests):
+    def test_stop_servers_handles_error(self, httpx):
         """
         Tests that the stop_servers method logs an error if the request fails
         """
         token = NonCallableMock()
         user_names = JupyterUsers(name="test", start_index=None, end_index=None)
-        requests.delete.return_value.status_code = 500
+        httpx.delete.return_value.status_code = 500
 
         with self.assertRaisesRegex(RuntimeError, "Failed to stop server"):
             self.api.stop_servers("dev", token, user_names)

--- a/tests/lib/jupyter/test_user_api.py
+++ b/tests/lib/jupyter/test_user_api.py
@@ -110,10 +110,10 @@ class UserApiTests(unittest.TestCase):
         """
         token = NonCallableMock()
         user_names = JupyterUsers(name="test", start_index=None, end_index=None)
-        httpx.delete.return_value.status_code = 204
+        async_client = httpx.AsyncClient.return_value.__aenter__.return_value
 
         self.api.delete_users("dev", token, user_names)
-        httpx.delete.assert_called_once_with(
+        async_client.delete.assert_called_once_with(
             url=API_ENDPOINTS["dev"] + "/hub/api/users/test",
             headers={"Authorization": f"token {token}"},
             timeout=300,
@@ -129,16 +129,16 @@ class UserApiTests(unittest.TestCase):
         user_names = JupyterUsers(
             name="test", start_index=start_index, end_index=end_index
         )
-        httpx.delete.return_value.status_code = 204
+        async_client = httpx.AsyncClient.return_value.__aenter__.return_value
 
         self.api.delete_users("dev", token, user_names)
         for i, user_index in enumerate(range(start_index, end_index + 1)):
-            assert httpx.delete.call_args_list[i] == call(
+            assert async_client.delete.call_args_list[i] == call(
                 url=API_ENDPOINTS["dev"] + f"/hub/api/users/test-{user_index}",
                 headers={"Authorization": f"token {token}"},
                 timeout=300,
             )
-        assert httpx.delete.call_count == (end_index - start_index + 1)
+        assert async_client.delete.call_count == (end_index - start_index + 1)
 
     @raises(RuntimeError)
     def test_remove_users_missing_start_index(self, _):


### PR DESCRIPTION
### Description:
Converts the synchronous delete user / stop server code to be async so Python doesn't block waiting for n containers to stop

Fixes: #62 

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
