### PR TITLE
Make use of cloud domains enum

### DIFF
--- a/lib/enums/cloud_domains.py
+++ b/lib/enums/cloud_domains.py
@@ -1,0 +1,20 @@
+from enum import auto
+
+from enums.auto_name import _AutoName
+
+
+# pylint: disable=too-few-public-methods
+class CloudDomains(_AutoName):
+    """
+    Holds a list of domains where users can be found
+    """
+
+    PROD = auto()
+    DEV = auto()
+
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        return CloudDomains[val.upper()]

--- a/lib/openstack_query/managers/query_manager.py
+++ b/lib/openstack_query/managers/query_manager.py
@@ -2,6 +2,7 @@ from typing import Optional, Set, Any, List, Union, Dict
 
 from enums.query.query_output_types import QueryOutputTypes
 from enums.query.props.prop_enum import PropEnum
+from enums.cloud_domains import CloudDomains
 
 from structs.query.query_output_details import QueryOutputDetails
 from structs.query.query_preset_details import QueryPresetDetails
@@ -16,7 +17,7 @@ class QueryManager:
     Managers hold a query object and several methods which build and run specific queries
     """
 
-    def __init__(self, query: QueryWrapper, cloud_account: str):
+    def __init__(self, query: QueryWrapper, cloud_account: CloudDomains):
         self._query = query
         self._cloud_account = cloud_account
 

--- a/lib/openstack_query/managers/server_manager.py
+++ b/lib/openstack_query/managers/server_manager.py
@@ -6,6 +6,7 @@ from enums.query.query_presets import (
     QueryPresetsString,
 )
 from enums.query.props.server_properties import ServerProperties
+from enums.cloud_domains import CloudDomains
 
 from openstack_query.queries.server_query import ServerQuery
 from openstack_query.managers.query_manager import QueryManager
@@ -20,7 +21,7 @@ class ServerManager(QueryManager):
     Manager for querying Openstack Server objects.
     """
 
-    def __init__(self, cloud_account: str):
+    def __init__(self, cloud_account: CloudDomains):
         QueryManager.__init__(self, query=ServerQuery(), cloud_account=cloud_account)
 
     def search_all_servers(self, output_details: QueryOutputDetails) -> QueryReturn:

--- a/lib/openstack_query/query_methods.py
+++ b/lib/openstack_query/query_methods.py
@@ -2,7 +2,7 @@ from typing import Union, List, Any, Optional, Dict
 
 from enums.query.props.prop_enum import PropEnum
 from enums.query.query_presets import QueryPresets
-
+from enums.cloud_domains import CloudDomains
 
 from openstack_query.query_output import QueryOutput
 from openstack_query.query_builder import QueryBuilder
@@ -79,13 +79,13 @@ class QueryMethods:
 
     def run(
         self,
-        cloud_account: str,
+        cloud_account: CloudDomains,
         from_subset: Optional[List[OpenstackResourceObj]] = None,
         **kwargs
     ):
         """
         Public method that runs the query provided and outputs
-        :param cloud_account: The account from the clouds configuration to use
+        :param cloud_account: An Enum for the account from the clouds configuration to use
         :param from_subset: A subset of openstack resources to run query on instead of querying openstacksdk
         :param kwargs: keyword args that can be used to configure details of how query is run
             - valid kwargs specific to resource

--- a/lib/openstack_query/runners/query_runner.py
+++ b/lib/openstack_query/runners/query_runner.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
-
 from typing import Optional, List, Any, Callable
+
+from enums.cloud_domains import CloudDomains
 
 from exceptions.parse_query_error import ParseQueryError
 from openstack_api.openstack_wrapper_base import OpenstackWrapperBase
@@ -23,7 +24,7 @@ class QueryRunner(OpenstackWrapperBase):
 
     def run(
         self,
-        cloud_account: str,
+        cloud_account: CloudDomains,
         client_side_filter_func: Optional[ClientSideFilterFunc] = None,
         server_side_filters: Optional[ServerSideFilters] = None,
         from_subset: Optional[List[Any]] = None,
@@ -31,7 +32,7 @@ class QueryRunner(OpenstackWrapperBase):
     ) -> List[OpenstackResourceObj]:
         """
         Public method that runs the query by querying openstacksdk and then applying a filter function.
-        :param cloud_account: The account from the clouds configuration to use
+        :param cloud_account: An Enum for the account from the clouds configuration to use
         :param client_side_filter_func: An Optional function that we can use to limit the results after querying openstacksdk
         :param server_side_filters: An Optional set of filter kwargs to limit the results by when querying openstacksdk
         :param from_subset: A subset of openstack resources to run query on instead of querying openstacksdk
@@ -41,7 +42,7 @@ class QueryRunner(OpenstackWrapperBase):
             runner of interest.
         """
 
-        with self._connection_cls(cloud_account) as conn:
+        with self._connection_cls(cloud_account.name.lower()) as conn:
             resource_objects = (
                 self._parse_subset(conn, from_subset)
                 if from_subset

--- a/tests/enums/test_cloud_domains.py
+++ b/tests/enums/test_cloud_domains.py
@@ -1,0 +1,19 @@
+from parameterized import parameterized
+
+from enums.cloud_domains import CloudDomains
+
+
+@parameterized(["prod", "PROD", "PrOD"])
+def test_prod_serialization(val):
+    """
+    Tests that variants of STFC can be serialized
+    """
+    assert CloudDomains.from_string(val) is CloudDomains.PROD
+
+
+@parameterized(["dev", "DeV", "DEV"])
+def test_dev_serialization(val):
+    """
+    Tests that variants of DEFAULT can be serialized
+    """
+    assert CloudDomains.from_string(val) is CloudDomains.DEV

--- a/tests/lib/openstack_query/runners/test_query_runner.py
+++ b/tests/lib/openstack_query/runners/test_query_runner.py
@@ -28,9 +28,11 @@ class QueryRunnerTests(unittest.TestCase):
         mock_apply_client_side_filter.return_value = ["openstack-resource-1"]
 
         mock_client_side_filter_func = MagicMock()
+        mock_cloud_domain = MagicMock()
+        mock_cloud_domain.name = "test"
 
         res = self.instance.run(
-            cloud_account="test",
+            cloud_account=mock_cloud_domain,
             client_side_filter_func=mock_client_side_filter_func,
             **{"arg1": "val1", "arg2": "val2"}
         )
@@ -55,9 +57,11 @@ class QueryRunnerTests(unittest.TestCase):
         mock_run_query.return_value = ["openstack-resource-1"]
         self.instance._run_query = mock_run_query
         mock_client_side_filter_func = MagicMock()
+        mock_user_domain = MagicMock()
+        mock_user_domain.name = "test"
 
         res = self.instance.run(
-            cloud_account="test",
+            cloud_account=mock_user_domain,
             client_side_filter_func=mock_client_side_filter_func,
             server_side_filters="some-filter-kwargs",
             **{"arg1": "val1", "arg2": "val2"}
@@ -85,9 +89,11 @@ class QueryRunnerTests(unittest.TestCase):
         ]
         mock_apply_filter_func.return_value = ["parsed-openstack-resource-1"]
         mock_client_side_filter_func = MagicMock()
+        mock_cloud_domain = MagicMock()
+        mock_cloud_domain.name = "test"
 
         res = self.instance.run(
-            cloud_account="test",
+            cloud_account=mock_cloud_domain,
             client_side_filter_func=mock_client_side_filter_func,
             from_subset=["openstack-resource-1", "openstack-resource-2"],
         )


### PR DESCRIPTION


### Description:
Added a Cloud Domain Enum for setting cloud domain for actions
Changed cloud_account typing for each method in `openstack_query` module that uses it from string to CloudDomain Enum 

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
