### PR TITLE
Openstack Add Server Actions

### DIFF
--- a/actions/server.list.yaml
+++ b/actions/server.list.yaml
@@ -1,0 +1,65 @@
+---
+description: List all servers
+enabled: true
+entry_point: src/server_query_actions.py
+name: server.list
+parameters:
+  timeout:
+    default: 5400
+  submodule:
+    default: "search_all"
+    immutable: true
+    type: string
+  cloud_account:
+    description: "The clouds.yaml account to use whilst performing this action"
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  properties_to_select:
+    default:
+      - "flavor_id"
+      - "hypervisor_id"
+      - "image_id"
+      - "project_id"
+      - "server_creation_date"
+      - "server_description"
+      - "server_id"
+      - "server_last_updated_date"
+      - "server_name"
+      - "server_status"
+      - "user_id"
+    type: array
+    description: "
+    A comma-spaced list of server properties to display for the resulting servers - leave empty for all properties. One of:
+      - 'flavor_id'
+      - 'hypervisor_id'
+      - 'image_id'
+      - 'project_id'
+      - 'server_creation_date'
+      - 'server_description'
+      - 'server_id'
+      - 'server_last_updated_date'
+      - 'server_name'
+      - 'server_status'
+      - 'user_id'
+    Anything else will raise an error"
+    required: false
+  output_type:
+    default: "to_str"
+    type: string
+    enum:
+      - "to_html"
+      - "to_object_list"
+      - "to_list"
+      - "to_str"
+    description: "
+    A string representing how to return the results of the query
+      - 'to_html' - a tabulate table (in html)
+      - 'to_list' - properties dicts as a python list
+      - 'to_object_list - as a list of openstack resources
+      - 'to_str' - a tabulate table"
+    required: true
+runner_type: python-script

--- a/actions/server.search.by.datetime.yaml
+++ b/actions/server.search.by.datetime.yaml
@@ -1,0 +1,103 @@
+---
+description: Query servers based on a datetime property (e.g. created-at or last-updated)
+enabled: true
+entry_point: src/server_query_actions.py
+name: server.search.by.datetime
+parameters:
+  timeout:
+    default: 5400
+  submodule:
+    default: "search_by_datetime"
+    immutable: true
+    type: string
+  cloud_account:
+    description: "The clouds.yaml account to use whilst performing this action"
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  properties_to_select:
+    default:
+      - 'flavor_id'
+      - 'hypervisor_id'
+      - 'image_id'
+      - 'project_id'
+      - 'server_creation_date'
+      - 'server_description'
+      - 'server_id'
+      - 'server_last_updated_date'
+      - 'server_name'
+      - 'server_status'
+      - 'user_id'
+    type: array
+    description: "
+    A comma-spaced list of server properties to display for the resulting servers - leave empty for all properties. One of:
+      - 'flavor_id'
+      - 'hypervisor_id'
+      - 'image_id'
+      - 'project_id'
+      - 'server_creation_date'
+      - 'server_description'
+      - 'server_id'
+      - 'server_last_updated_date'
+      - 'server_name'
+      - 'server_status'
+      - 'user_id'
+    Anything else will raise an error"
+    required: false
+  output_type:
+    default: "to_str"
+    type: string
+    enum:
+      - "to_html"
+      - "to_object_list"
+      - "to_list"
+      - "to_str"
+    description: "
+    A string representing how to return the results of the query
+      - 'to_html' - a tabulate table (in html)
+      - 'to_list' - properties dicts as a python list
+      - 'to_object_list - as a list of openstack resources
+      - 'to_str' - a tabulate table"
+    required: true
+  property_to_search_by:
+    description: "choose datetime property to base the query on"
+    default: "server_creation_date"
+    type: string
+    required: true
+    enum:
+      - "server_creation_date"
+      - "server_last_updated_date"
+  search_mode:
+    description: "what to mode to use to search by"
+    default: "older_than"
+    type: string
+    required: true
+    enum:
+      - "older_than"
+      - "older_than_or_equal_to"
+      - "younger_than"
+      - "younger_than_or_equal_to"
+  days:
+    description: "(Optional) Number of relative days from now threshold"
+    type: integer
+    default: 0
+    required: false
+  hours:
+    description: "(Optional) Number of relative hours from now threshold"
+    type: integer
+    default: 0
+    required: false
+  minutes:
+    description: "(Optional) Number of relative minutes from now threshold"
+    type: integer
+    default: 0
+    required: false
+  seconds:
+    description: "(Optional) Number of relative seconds from now threshold"
+    type: integer
+    default: 0
+    required: false
+runner_type: python-script

--- a/actions/server.search.by.property.yaml
+++ b/actions/server.search.by.property.yaml
@@ -1,0 +1,88 @@
+---
+description: Search for servers with a selected property matching, or not matching given value(s)
+enabled: true
+entry_point: src/server_query_actions.py
+name: server.search.by.property
+parameters:
+  timeout:
+    default: 5400
+  submodule:
+    default: "search_by_property"
+    immutable: true
+    type: string
+  cloud_account:
+    description: The clouds.yaml account to use whilst performing this action
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  properties_to_select:
+    default:
+      - "flavor_id"
+      - "hypervisor_id"
+      - "image_id"
+      - "project_id"
+      - "server_creation_date"
+      - "server_description"
+      - "server_id"
+      - "server_last_updated_date"
+      - "server_name"
+      - "server_status"
+      - "user_id"
+    type: array
+    description: "
+    A comma-spaced list of server properties to display for the resulting servers - leave empty for all properties. One of:
+      - 'flavor_id'
+      - 'hypervisor_id'
+      - 'image_id'
+      - 'project_id'
+      - 'server_creation_date'
+      - 'server_description'
+      - 'server_id'
+      - 'server_last_updated_date'
+      - 'server_name'
+      - 'server_status'
+      - 'user_id'
+    Anything else will raise an error"
+    required: false
+  output_type:
+    default: "to_str"
+    type: string
+    enum:
+      - "to_html"
+      - "to_object_list"
+      - "to_list"
+      - "to_str"
+    description: "
+    A string representing how to return the results of the query
+      - 'to_html' - a tabulate table (in html)
+      - 'to_list' - properties dicts as a python list
+      - 'to_object_list - as a list of openstack resources
+      - 'to_str' - a tabulate table"
+    required: true
+  property_to_search_by:
+    default: "server_name"
+    description: "choose property to search by"
+    enum:
+      - "flavor_id"
+      - "hypervisor_id"
+      - "image_id"
+      - "server_description"
+      - "server_id"
+      - "server_name"
+      - "server_status"
+      - "user_id"
+    type: string
+    required: true
+  search_mode:
+    default: true
+    description: "True means return matching, False means return not matching"
+    required: true
+    type: boolean
+  values:
+    description: "a comma-spaced list of values to search for"
+    required: true
+    type: array
+runner_type: python-script

--- a/actions/server.search.by.regex.yaml
+++ b/actions/server.search.by.regex.yaml
@@ -1,0 +1,83 @@
+---
+description: Search for servers property using regex pattern, or not matching given value(s)
+enabled: true
+entry_point: src/server_query_actions.py
+name: server.search.by.regex
+parameters:
+  timeout:
+    default: 5400
+  submodule:
+    default: "search_by_regex"
+    immutable: true
+    type: string
+  cloud_account:
+    description: The clouds.yaml account to use whilst performing this action
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  properties_to_select:
+    default:
+      - "flavor_id"
+      - "hypervisor_id"
+      - "image_id"
+      - "project_id"
+      - "server_creation_date"
+      - "server_description"
+      - "server_id"
+      - "server_last_updated_date"
+      - "server_name"
+      - "server_status"
+      - "user_id"
+    type: array
+    description: "
+    A comma-spaced list of server properties to display for the resulting servers - leave empty for all properties. One of:
+      - 'flavor_id'
+      - 'hypervisor_id'
+      - 'image_id'
+      - 'project_id'
+      - 'server_creation_date'
+      - 'server_description'
+      - 'server_id'
+      - 'server_last_updated_date'
+      - 'server_name'
+      - 'server_status'
+      - 'user_id'
+    Anything else will raise an error"
+    required: false
+  output_type:
+    default: "to_str"
+    type: string
+    enum:
+      - "to_html"
+      - "to_object_list"
+      - "to_list"
+      - "to_str"
+    description: "
+    A string representing how to return the results of the query
+      - 'to_html' - a tabulate table (in html)
+      - 'to_list' - properties dicts as a python list
+      - 'to_object_list - as a list of openstack resources
+      - 'to_str' - a tabulate table"
+    required: true
+  property_to_search_by:
+    default: "server_name"
+    description: "choose property to search by"
+    enum:
+      - "flavor_id"
+      - "hypervisor_id"
+      - "image_id"
+      - "server_description"
+      - "server_id"
+      - "server_name"
+      - "server_status"
+      - "user_id"
+    type: string
+    required: true
+  pattern:
+    description: "the regex pattern to use - must be compatible with python regex 're' module"
+    required: true
+    type: string
+runner_type: python-script

--- a/actions/src/server_query_actions.py
+++ b/actions/src/server_query_actions.py
@@ -1,0 +1,27 @@
+from typing import Callable
+from st2common.runners.base_action import Action
+from enums.cloud_domains import CloudDomains
+from openstack_query.managers.server_manager import ServerManager
+
+# pylint: disable=too-few-public-methods
+
+
+class ServerQueryActions(Action):
+    """
+    Stackstorm Action class that dynamically dispatches actions related to Server Queries to the corresponding
+    method in the ServerManager class
+    Actions that will be handled by this class follow the format server.search.*
+    """
+
+    def run(self, submodule: str, cloud_account: str, **kwargs):
+        """
+        Dynamically dispatches to the method wanted
+        :param submodule: submodule name which corresponds to method in self
+        :param cloud_account: A string representing the cloud domain from the clouds configuration to use
+        :param kwargs: All user-defined kwargs to pass to the query
+        """
+
+        cloud_account_enum = CloudDomains.from_string(cloud_account)
+        server_manager = ServerManager(cloud_account=cloud_account_enum)
+        query_func: Callable = getattr(server_manager, submodule)
+        return query_func(**kwargs)

--- a/lib/custom_types/openstack_query/aliases.py
+++ b/lib/custom_types/openstack_query/aliases.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Any, Dict, Union, Literal
+from typing import List, Callable, Any, Dict, Union
 from enums.query.props.prop_enum import PropEnum
 from enums.query.query_presets import QueryPresets
 
@@ -32,7 +32,8 @@ ServerSideFilterMappings = Dict[QueryPresets, PropToServerSideFilterFunc]
 
 # type alias for mapping presets to valid properties that can be used with them
 # can also accept a literal ['*'] to indicate preset works for all enum values
-PresetPropMappings = Union[List[PropEnum], List[Literal["*"]]]
+# NOTE: can't use Literal typing for ['*'] with python 3.6 so using generic List
+PresetPropMappings = Union[List[PropEnum], List]
 
 # type alias for project identifier - either name/id or Project object
 ProjectIdentifier = Union[str, Project]

--- a/lib/enums/query/props/server_properties.py
+++ b/lib/enums/query/props/server_properties.py
@@ -1,5 +1,6 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
+from exceptions.parse_query_error import ParseQueryError
 
 # pylint: disable=too-few-public-methods
 
@@ -20,3 +21,16 @@ class ServerProperties(PropEnum):
     SERVER_NAME = auto()
     SERVER_STATUS = auto()
     USER_ID = auto()
+
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return ServerProperties[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find Server Property {val}. "
+                f"Available properties are {','.join([prop.name for prop in ServerProperties])}"
+            ) from err

--- a/lib/enums/query/query_output_types.py
+++ b/lib/enums/query/query_output_types.py
@@ -1,4 +1,5 @@
 from enum import Enum, auto
+from exceptions.parse_query_error import ParseQueryError
 
 
 # pylint: disable=too-few-public-methods
@@ -11,3 +12,16 @@ class QueryOutputTypes(Enum):
     TO_OBJECT_LIST = auto()
     TO_LIST = auto()
     TO_STR = auto()
+
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return QueryOutputTypes[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find return type flag {val}. "
+                f"Available flags are {','.join([prop.name for prop in QueryOutputTypes])}"
+            ) from err

--- a/lib/enums/query/query_presets.py
+++ b/lib/enums/query/query_presets.py
@@ -1,4 +1,5 @@
 from enum import Enum, auto
+from exceptions.parse_query_error import ParseQueryError
 
 
 class QueryPresets(Enum):
@@ -13,6 +14,19 @@ class QueryPresetsGeneric(QueryPresets):
     EQUAL_TO = auto()
     NOT_EQUAL_TO = auto()
 
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return QueryPresetsGeneric[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find preset type {val}. "
+                f"Available preset types are {','.join([prop.name for prop in QueryPresetsGeneric])}"
+            ) from err
+
 
 class QueryPresetsInteger(QueryPresets):
     """
@@ -23,6 +37,19 @@ class QueryPresetsInteger(QueryPresets):
     GREATER_THAN_OR_EQUAL_TO = auto()
     LESS_THAN = auto()
     LESS_THAN_OR_EQUAL_TO = auto()
+
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return QueryPresetsInteger[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find preset type {val}. "
+                f"Available preset types are {','.join([prop.name for prop in QueryPresetsInteger])}"
+            ) from err
 
 
 class QueryPresetsDateTime(QueryPresets):
@@ -35,6 +62,19 @@ class QueryPresetsDateTime(QueryPresets):
     YOUNGER_THAN = auto()
     YOUNGER_THAN_OR_EQUAL_TO = auto()
 
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return QueryPresetsDateTime[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find preset type {val}. "
+                f"Available preset types are {','.join([prop.name for prop in QueryPresetsDateTime])}"
+            ) from err
+
 
 class QueryPresetsString(QueryPresets):
     """
@@ -44,3 +84,16 @@ class QueryPresetsString(QueryPresets):
     ANY_IN = auto()
     MATCHES_REGEX = auto()
     NOT_ANY_IN = auto()
+
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return QueryPresetsString[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find preset type {val}. "
+                f"Available preset types are {','.join([prop.name for prop in QueryPresetsString])}"
+            ) from err

--- a/lib/openstack_query/managers/query_manager.py
+++ b/lib/openstack_query/managers/query_manager.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set
+from typing import Optional, Set, List
 
 from enums.query.query_output_types import QueryOutputTypes
 from enums.query.props.prop_enum import PropEnum
@@ -81,3 +81,35 @@ class QueryManager:
                 prop=preset_details.prop,
                 **preset_details.args
             )
+
+    def _get_output_details(
+        self,
+        prop_enum_cls: PropEnum,
+        properties_to_select: List[str],
+        output_type: str,
+        **_
+    ) -> QueryOutputDetails:
+        """
+        method to parse string inputs that make-up output details form stackstorm action and create QueryOutputDetails
+        dataclass
+        :param properties_to_select: A list of strings which represent properties
+        :param prop_enum_cls: The enum class which holds corresponding enums for property strings
+        :param output_type: A string representing how to output the results
+        """
+        return QueryOutputDetails(
+            properties_to_select=self._parse_properties_to_select_strings(
+                properties_to_select, prop_enum_cls
+            ),
+            output_type=QueryOutputTypes.from_string(output_type),
+        )
+
+    @staticmethod
+    def _parse_properties_to_select_strings(
+        properties_to_select: List[str], prop_enum_cls: PropEnum
+    ) -> List[PropEnum]:
+        """
+        method to parse 'properties_to_select' list of strings from a stackstorm 'search' action.
+        :param properties_to_select: A list of strings which represent properties
+        :param prop_enum_cls: The enum class which holds corresponding enums for property strings
+        """
+        return list({prop_enum_cls.from_string(prop) for prop in properties_to_select})

--- a/tests/actions/test_server_query_actions.py
+++ b/tests/actions/test_server_query_actions.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch, NonCallableMock, MagicMock
+from parameterized import parameterized
+from src.server_query_actions import ServerQueryActions
+from tests.actions.openstack_action_test_base import OpenstackActionTestBase
+
+from enums.query.query_output_types import QueryOutputTypes
+from enums.cloud_domains import CloudDomains
+from enums.query.props.server_properties import ServerProperties
+
+from structs.query.query_output_details import QueryOutputDetails
+
+
+class TestServerQueryActions(OpenstackActionTestBase):
+    """
+    Unit tests for server.search.* actions
+    """
+
+    action_cls = ServerQueryActions
+
+    def setUp(self):
+        super().setUp()
+        self.action: ServerQueryActions = self.get_action_instance()
+        self.args = {
+            "cloud_account": "dev",
+            "properties_to_select": ["server_id", "server_name"],
+            "return_type": "to_str",
+            "kwarg1": NonCallableMock(),
+            "kwarg2": NonCallableMock(),
+        }
+
+    @parameterized.expand(
+        [
+            "search_all",
+            "search_by_datetime",
+            "search_by_property",
+            "search_by_regex",
+        ]
+    )
+    def test_run(self, method_name):
+        """
+        Tests that run method can dispatch to ServerManager methods
+        """
+        assert hasattr(self.action._server_manager, method_name)
+
+        self.action._server_manager = MagicMock()
+        mock_method = getattr(self.action._server_manager.return_value, method_name)
+
+        self.action.run(submodule=method_name, **self.args)
+
+        self.action._server_manager.assert_called_once_with(CloudDomains.DEV)
+        mock_method.assert_called_once_with(
+            output_details=QueryOutputDetails(
+                properties_to_select=[
+                    ServerProperties.SERVER_ID,
+                    ServerProperties.SERVER_NAME,
+                ],
+                output_type=QueryOutputTypes.TO_STR,
+            ),
+            kwarg1=self.args["kwarg1"],
+            kwarg2=self.args["kwarg2"],
+        )

--- a/tests/enums/test_query_output_types.py
+++ b/tests/enums/test_query_output_types.py
@@ -1,0 +1,35 @@
+from parameterized import parameterized
+
+from enums.query.query_output_types import QueryOutputTypes
+
+
+@parameterized(["to_HTML", "To_HtMl", "to_html"])
+def test_to_html_serialization(val):
+    """
+    Tests that variants of TO_HTML can be serialized
+    """
+    assert QueryOutputTypes.from_string(val) is QueryOutputTypes.TO_HTML
+
+
+@parameterized(["to_OBJECT_LIST", "To_ObJecT_LisT", "to_object_list"])
+def test_to_object_list_serialization(val):
+    """
+    Tests that variants of TO_OBJECT_LIST can be serialized
+    """
+    assert QueryOutputTypes.from_string(val) is QueryOutputTypes.TO_OBJECT_LIST
+
+
+@parameterized(["to_LIST", "To_LiSt", "to_list"])
+def test_to_list_serialization(val):
+    """
+    Tests that variants of TO_LIST can be serialized
+    """
+    assert QueryOutputTypes.from_string(val) is QueryOutputTypes.TO_LIST
+
+
+@parameterized(["to_Str", "To_StR", "to_str"])
+def test_to_str_serialization(val):
+    """
+    Tests that variants of TO_STR can be serialized
+    """
+    assert QueryOutputTypes.from_string(val) is QueryOutputTypes.TO_STR

--- a/tests/enums/test_query_presets.py
+++ b/tests/enums/test_query_presets.py
@@ -1,0 +1,132 @@
+from parameterized import parameterized
+
+from enums.query.query_presets import (
+    QueryPresetsGeneric,
+    QueryPresetsInteger,
+    QueryPresetsString,
+    QueryPresetsDateTime,
+)
+
+
+@parameterized(["equal_to", "Equal_To", "EqUaL_tO"])
+def test_equal_to_serialization(val):
+    """
+    Tests that variants of EQUAL_TO can be serialized
+    """
+    assert QueryPresetsGeneric.from_string(val) is QueryPresetsGeneric.EQUAL_TO
+
+
+@parameterized(["not_equal_to", "Not_Equal_To", "NoT_EqUaL_tO"])
+def test_not_equal_to_serialization(val):
+    """
+    Tests that variants of NOT_EQUAL_TO can be serialized
+    """
+    assert QueryPresetsGeneric.from_string(val) is QueryPresetsGeneric.NOT_EQUAL_TO
+
+
+@parameterized(["greater_than", "Greater_Than", "GrEaTer_ThAn"])
+def test_greater_than_serialization(val):
+    """
+    Tests that variants of GREATER_THAN can be serialized
+    """
+    assert QueryPresetsInteger.from_string(val) is QueryPresetsInteger.GREATER_THAN
+
+
+@parameterized(
+    ["greater_than_or_equal_to", "Greater_Than_Or_Equal_To", "GrEaTer_ThAn_Or_EqUaL_tO"]
+)
+def test_greater_than_or_equal_to_serialization(val):
+    """
+    Tests that variants of GREATER_THAN_OR_EQUAL_TO can be serialized
+    """
+    assert (
+        QueryPresetsInteger.from_string(val)
+        is QueryPresetsInteger.GREATER_THAN_OR_EQUAL_TO
+    )
+
+
+@parameterized(["less_than", "Less_Than", "LeSs_ThAn"])
+def test_less_than_serialization(val):
+    """
+    Tests that variants of LESS_THAN can be serialized
+    """
+    assert QueryPresetsInteger.from_string(val) is QueryPresetsInteger.LESS_THAN
+
+
+@parameterized(
+    ["less_than_or_equal_to", "Less_Than_Or_Equal_To", "LeSs_ThAn_Or_EqUaL_tO"]
+)
+def test_less_than_or_equal_to_serialization(val):
+    """
+    Tests that variants of LESS_THAN_OR_EQUAL_TO can be serialized
+    """
+    assert (
+        QueryPresetsInteger.from_string(val)
+        is QueryPresetsInteger.LESS_THAN_OR_EQUAL_TO
+    )
+
+
+@parameterized(["older_than", "Older_Than", "OlDeR_ThAn"])
+def test_older_than_serialization(val):
+    """
+    Tests that variants of OLDER_THAN can be serialized
+    """
+    assert QueryPresetsDateTime.from_string(val) is QueryPresetsDateTime.OLDER_THAN
+
+
+@parameterized(
+    ["older_than_or_equal_to", "Older_Than_Or_Equal_To", "OlDeR_ThAn_Or_EqUaL_To"]
+)
+def test_older_than_or_equal_to_serialization(val):
+    """
+    Tests that variants of OLDER_THAN_OR_EQUAL_TO can be serialized
+    """
+    assert (
+        QueryPresetsDateTime.from_string(val)
+        is QueryPresetsDateTime.OLDER_THAN_OR_EQUAL_TO
+    )
+
+
+@parameterized(["younger_than", "Younger_Than", "YoUnGeR_ThAn"])
+def test_younger_than_serialization(val):
+    """
+    Tests that variants of YOUNGER_THAN can be serialized
+    """
+    assert QueryPresetsDateTime.from_string(val) is QueryPresetsDateTime.YOUNGER_THAN
+
+
+@parameterized(
+    ["younger_than_or_equal_to", "Younger_Than_Or_Equal_To", "YoUngEr_ThAn_Or_EqUaL_To"]
+)
+def test_older_than_or_equal_to_serialization(val):
+    """
+    Tests that variants of YOUNGER_THAN_OR_EQUAL_TO can be serialized
+    """
+    assert (
+        QueryPresetsDateTime.from_string(val)
+        is QueryPresetsDateTime.YOUNGER_THAN_OR_EQUAL_TO
+    )
+
+
+@parameterized(["any_in", "Any_In", "AnY_In"])
+def test_any_in_serialization(val):
+    """
+    Tests that variants of ANY_IN can be serialized
+    """
+    assert QueryPresetsString.from_string(val) is QueryPresetsString.ANY_IN
+
+
+@parameterized(["not_any_in", "Not_Any_In", "NoT_AnY_In"])
+def test_any_in_serialization(val):
+    """
+    Tests that variants of NOT_ANY_IN can be serialized
+    """
+    assert QueryPresetsString.from_string(val) is QueryPresetsString.NOT_ANY_IN
+
+
+@parameterized(["matches_regex", "Matches_Regex", "MaTcHeS_ReGeX"])
+def test_any_in_serialization(val):
+    """
+    Tests that variants of MATCHES_REGEX can be serialized
+    """
+    assert QueryPresetsString.from_string(val) is QueryPresetsString.MATCHES_REGEX

--- a/tests/enums/test_server_properties.py
+++ b/tests/enums/test_server_properties.py
@@ -1,0 +1,95 @@
+from parameterized import parameterized
+
+from enums.query.props.server_properties import ServerProperties
+
+
+@parameterized(["flavor_id", "Flavor_ID", "FlAvOr_Id"])
+def test_flavor_id_serialization(val):
+    """
+    Tests that variants of FLAVOR_ID can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.FLAVOR_ID
+
+
+@parameterized(["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID"])
+def test_hypervisor_id_serialization(val):
+    """
+    Tests that variants of HYPERVISOR_ID can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.HYPERVISOR_ID
+
+
+@parameterized(["image_id", "Image_ID", "ImaGe_iD"])
+def test_image_id_serialization(val):
+    """
+    Tests that variants of IMAGE_ID can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.IMAGE_ID
+
+
+@parameterized(["project_id", "Project_Id", "PrOjEcT_Id"])
+def test_project_id_serialization(val):
+    """
+    Tests that variants of PROJECT_ID can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.PROJECT_ID
+
+
+@parameterized(["server_creation_date", "Server_Creation_Date", "SeRvEr_CrEaTiOn_DAte"])
+def test_server_creation_date_serialization(val):
+    """
+    Tests that variants of SERVER_CREATION_DATE can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.SERVER_CREATION_DATE
+
+
+@parameterized(["server_description", "Server_Description", "SeRvEr_DeScrIpTion"])
+def test_server_description_serialization(val):
+    """
+    Tests that variants of SERVER_DESCRIPTION can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.SERVER_DESCRIPTION
+
+
+@parameterized(["server_id", "Server_Id", "SeRvEr_iD"])
+def test_server_id_serialization(val):
+    """
+    Tests that variants of SERVER_ID can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.SERVER_ID
+
+
+@parameterized(
+    ["server_last_updated_date", "Server_Last_Updated_Date", "SerVer_LasT_UpDatED_DaTe"]
+)
+def test_server_last_updated_date_serialization(val):
+    """
+    Tests that variants of SERVER_LAST_UPDATED_DATE can be serialized
+    """
+    assert (
+        ServerProperties.from_string(val) is ServerProperties.SERVER_LAST_UPDATED_DATE
+    )
+
+
+@parameterized(["server_name", "Server_NaMe", "Server_Name"])
+def test_server_name_serialization(val):
+    """
+    Tests that variants of SERVER_NAME can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.SERVER_NAME
+
+
+@parameterized(["server_status", "Server_Status", "SerVer_StAtUs"])
+def test_server_status_serialization(val):
+    """
+    Tests that variants of SERVER_STATUS can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.SERVER_STATUS
+
+
+@parameterized(["user_id", "User_Id", "UsEr_iD"])
+def test_user_id_serialization(val):
+    """
+    Tests that variants of USER_ID can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.USER_ID

--- a/tests/lib/openstack_query/managers/test_query_manager.py
+++ b/tests/lib/openstack_query/managers/test_query_manager.py
@@ -1,9 +1,11 @@
 import unittest
-from unittest.mock import MagicMock, patch, NonCallableMock
+from unittest.mock import MagicMock, patch, NonCallableMock, call
 from parameterized import parameterized
 
 from openstack_query.managers.query_manager import QueryManager
 from enums.query.query_output_types import QueryOutputTypes
+
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 from tests.lib.openstack_query.mocks.mocked_structs import (
     MOCKED_OUTPUT_DETAILS,
@@ -88,3 +90,50 @@ class QueryManagerTests(unittest.TestCase):
             prop=MOCKED_PRESET_DETAILS.prop,
             **MOCKED_PRESET_DETAILS.args,
         )
+
+    @patch(
+        "openstack_query.managers.query_manager.QueryManager._parse_properties_to_select_strings"
+    )
+    def test_get_output_details(self, mock_parse_properties_to_select):
+        """
+        tests that get_output_details works expectedly
+        method should output a QueryOutputDetails dataclass with appropriate attributes set
+        """
+        mock_enum_cls = MagicMock()
+        mock_parse_properties_to_select.return_value = [
+            MockProperties.PROP_1,
+            MockProperties.PROP_2,
+        ]
+
+        res = self.instance._get_output_details(
+            properties_to_select=["prop-1", "prop-2"],
+            prop_enum_cls=mock_enum_cls,
+            output_type="to_str",
+        )
+        mock_parse_properties_to_select.assert_called_once_with(
+            ["prop-1", "prop-2"], mock_enum_cls
+        )
+        self.assertEqual(res, MOCKED_OUTPUT_DETAILS)
+
+    def test_parse_properties_to_select_strings(self):
+        """
+        tests that parse_properties_to_select_strings works expectedly
+        should return a call parse_property_string for each prop_string in input list
+        """
+        mock_prop_enum_cls = MagicMock()
+        mock_prop_enum_cls.from_string.side_effect = ["prop-enum-1", "prop-enum-2"]
+
+        res = self.instance._parse_properties_to_select_strings(
+            properties_to_select=["prop-1", "prop-2"], prop_enum_cls=mock_prop_enum_cls
+        )
+        mock_prop_enum_cls.from_string.assert_has_calls(
+            [
+                call("prop-1"),
+                call("prop-2"),
+            ]
+        )
+
+        # issues due to list ordering - hence these asserts
+        self.assertEqual(len(res), 2)
+        self.assertIn("prop-enum-1", res)
+        self.assertIn("prop-enum-2", res)

--- a/tests/lib/openstack_query/managers/test_server_manager.py
+++ b/tests/lib/openstack_query/managers/test_server_manager.py
@@ -6,15 +6,15 @@ from openstack_query.managers.server_manager import ServerManager
 from enums.query.query_presets import (
     QueryPresetsDateTime,
     QueryPresetsString,
+    QueryPresetsGeneric,
 )
-
 from enums.query.props.server_properties import ServerProperties
-
+from enums.query.query_output_types import QueryOutputTypes
 from structs.query.query_preset_details import QueryPresetDetails
-from tests.lib.openstack_query.mocks.mocked_structs import MOCKED_OUTPUT_DETAILS
 
 
 @patch("openstack_query.managers.query_manager.QueryManager._build_and_run_query")
+@patch("openstack_query.managers.query_manager.QueryManager._get_output_details")
 class ServerManagerTests(unittest.TestCase):
     """
     Runs various tests to ensure that ServerManager class methods function expectedly
@@ -32,31 +32,58 @@ class ServerManagerTests(unittest.TestCase):
         # pylint:disable=protected-access
         self.instance._query = self.query
 
-    def test_search_all_servers(self, mock_build_and_run_query):
+    def test_search_all(self, mock_get_output_details, mock_build_and_run_query):
         """
-        Tests that search_all_servers method functions expectedly
+        Tests that search_all method functions expectedly
         Runs a query to get all servers, returns query results
         """
         mock_query_return = NonCallableMock()
         mock_build_and_run_query.return_value = mock_query_return
 
-        res = self.instance.search_all_servers(MOCKED_OUTPUT_DETAILS)
+        mock_output_details = MagicMock()
+        mock_get_output_details.return_value = mock_output_details
+
+        mock_kwargs = {
+            "properties_to_select": ["server_name", "server_id"],
+            "output_type": QueryOutputTypes.TO_STR,
+        }
+
+        res = self.instance.search_all(**mock_kwargs)
         mock_build_and_run_query.assert_called_once_with(
-            preset_details=None, output_details=MOCKED_OUTPUT_DETAILS
+            preset_details=None, output_details=mock_output_details
         )
+
         self.assertEqual(res, mock_query_return)
 
-    def test_search_servers_older_than_relative_to_now(self, mock_build_and_run_query):
+    def test_search_by_datetime(
+        self, mock_get_output_details, mock_build_and_run_query
+    ):
         """
-        Tests that search_servers_older_than_relative_to_now method functions expectedly
-        Runs a query to get all servers older than a relative time (e.g. older than 60 days)
+        Tests that search_by_datetime method functions expectedly
+        Run a datetime query - in this case get all servers older than a relative time
         """
         mock_query_return = NonCallableMock()
         mock_build_and_run_query.return_value = mock_query_return
 
-        res = self.instance.search_servers_older_than_relative_to_now(
-            MOCKED_OUTPUT_DETAILS, days=10, hours=10, minutes=1
+        mock_output_details = MagicMock()
+        mock_get_output_details.return_value = mock_output_details
+
+        mock_kwargs = {
+            "properties_to_select": ["server_name", "server_id"],
+            "output_type": QueryOutputTypes.TO_STR,
+        }
+
+        res = self.instance.search_by_datetime(
+            search_mode="older_than",
+            property_to_search_by="server_creation_date",
+            query_args={
+                "days": 10,
+                "hours": 10,
+                "minutes": 1,
+            },
+            **mock_kwargs
         )
+
         mock_build_and_run_query.assert_called_once_with(
             preset_details=QueryPresetDetails(
                 preset=QueryPresetsDateTime.OLDER_THAN,
@@ -68,133 +95,117 @@ class ServerManagerTests(unittest.TestCase):
                     "seconds": 0,
                 },
             ),
-            output_details=MOCKED_OUTPUT_DETAILS,
+            output_details=mock_output_details,
         )
         self.assertEqual(res, mock_query_return)
 
-    def test_search_servers_younger_than_relative_to_now(
-        self, mock_build_and_run_query
+    def test_search_by_property_with_single_value(
+        self, mock_get_output_details, mock_build_and_run_query
     ):
         """
-        Tests that search_servers_younger_than_relative_to_now method functions expectedly
-        Runs a query to get all servers younger than a relative time (e.g. younger than 60 days)
+        Tests that search_by_property method functions expectedly - with single value list
+        Runs a property query - in this case get servers with matching image_id
+        Should build and run a query using EQUAL_TO preset
         """
         mock_query_return = NonCallableMock()
         mock_build_and_run_query.return_value = mock_query_return
 
-        res = self.instance.search_servers_younger_than_relative_to_now(
-            MOCKED_OUTPUT_DETAILS, days=10, hours=10, minutes=1
+        mock_output_details = MagicMock()
+        mock_get_output_details.return_value = mock_output_details
+
+        mock_kwargs = {
+            "properties_to_select": ["server_name", "server_id"],
+            "output_type": QueryOutputTypes.TO_STR,
+        }
+
+        res = self.instance.search_by_property(
+            search_mode=True,
+            property_to_search_by="image_id",
+            values=["image-id1"],
+            **mock_kwargs
         )
+
+        # should call build with EQUAL_TO and args with keyword value instead
         mock_build_and_run_query.assert_called_once_with(
             preset_details=QueryPresetDetails(
-                preset=QueryPresetsDateTime.YOUNGER_THAN,
-                prop=ServerProperties.SERVER_CREATION_DATE,
-                args={
-                    "days": 10,
-                    "hours": 10,
-                    "minutes": 1,
-                    "seconds": 0,
-                },
+                preset=QueryPresetsGeneric.EQUAL_TO,
+                prop=ServerProperties.IMAGE_ID,
+                args={"value": "image-id1"},
             ),
-            output_details=MOCKED_OUTPUT_DETAILS,
+            output_details=mock_output_details,
         )
         self.assertEqual(res, mock_query_return)
 
-    def test_search_servers_last_updated_before_relative_to_now(
-        self, mock_build_and_run_query
+    def test_search_by_property_with_multiple_values(
+        self, mock_get_output_details, mock_build_and_run_query
     ):
         """
-        Tests that search_servers_last_updated_before_relative_to_now method functions expectedly
-        Runs a query to get all servers that have had their last status changed before than a relative time
-        (e.g. days=60 => 60 days ago or older)
+        Tests that search_by_property method functions expectedly - with single value list
+        Runs a property query - in this case get servers with matching image_id
         """
         mock_query_return = NonCallableMock()
         mock_build_and_run_query.return_value = mock_query_return
 
-        res = self.instance.search_servers_last_updated_before_relative_to_now(
-            MOCKED_OUTPUT_DETAILS, days=10, hours=10, minutes=1
-        )
-        mock_build_and_run_query.assert_called_once_with(
-            preset_details=QueryPresetDetails(
-                preset=QueryPresetsDateTime.OLDER_THAN,
-                prop=ServerProperties.SERVER_LAST_UPDATED_DATE,
-                args={
-                    "days": 10,
-                    "hours": 10,
-                    "minutes": 1,
-                    "seconds": 0,
-                },
-            ),
-            output_details=MOCKED_OUTPUT_DETAILS,
-        )
-        self.assertEqual(res, mock_query_return)
+        mock_output_details = MagicMock()
+        mock_get_output_details.return_value = mock_output_details
 
-    def test_search_servers_last_updated_after_relative_to_now(
-        self, mock_build_and_run_query
-    ):
-        """
-        Tests that search_servers_last_updated_after_relative_to_now method functions expectedly
-        Runs a query to get all servers that have had their last status changed after than a relative time
-        (e.g. days=60 => 60 days ago or earlier)
-        """
-        mock_query_return = NonCallableMock()
-        mock_build_and_run_query.return_value = mock_query_return
+        mock_kwargs = {
+            "properties_to_select": ["server_name", "server_id"],
+            "output_type": QueryOutputTypes.TO_STR,
+        }
 
-        res = self.instance.search_servers_last_updated_after_relative_to_now(
-            MOCKED_OUTPUT_DETAILS, days=10, hours=10, minutes=1
+        res = self.instance.search_by_property(
+            search_mode=True,
+            property_to_search_by="image_id",
+            values=["image-id1", "image-id2"],
+            **mock_kwargs
         )
-        mock_build_and_run_query.assert_called_once_with(
-            preset_details=QueryPresetDetails(
-                preset=QueryPresetsDateTime.YOUNGER_THAN,
-                prop=ServerProperties.SERVER_LAST_UPDATED_DATE,
-                args={
-                    "days": 10,
-                    "hours": 10,
-                    "minutes": 1,
-                    "seconds": 0,
-                },
-            ),
-            output_details=MOCKED_OUTPUT_DETAILS,
-        )
-        self.assertEqual(res, mock_query_return)
 
-    def test_search_servers_name_in(self, mock_build_and_run_query):
-        """
-        Tests that search_servers_name_in method functions expectedly
-        Runs a query to get all servers that match a given list of names
-        """
-        mock_query_return = NonCallableMock()
-        mock_build_and_run_query.return_value = mock_query_return
-        res = self.instance.search_servers_name_in(
-            MOCKED_OUTPUT_DETAILS, names=["name1", "name2"]
-        )
         mock_build_and_run_query.assert_called_once_with(
             preset_details=QueryPresetDetails(
                 preset=QueryPresetsString.ANY_IN,
-                prop=ServerProperties.SERVER_NAME,
-                args={"values": ["name1", "name2"]},
+                prop=ServerProperties.IMAGE_ID,
+                args={"values": ["image-id1", "image-id2"]},
             ),
-            output_details=MOCKED_OUTPUT_DETAILS,
+            output_details=mock_output_details,
         )
         self.assertEqual(res, mock_query_return)
 
-    def test_search_servers_name_not_in(self, mock_build_and_run_query):
+    @patch("openstack_query.managers.server_manager.re")
+    def test_search_by_regex(
+        self, mock_re, mock_get_output_details, mock_build_and_run_query
+    ):
         """
-        Tests that search_servers_name_not_in method functions expectedly
-        Runs a query to get all servers that don't match a given list of names
+        Tests that search_by_regex method functions expectedly - with single regex pattern
+        Runs a regex pattern query - in this case gets servers with matching pattern on name
         """
         mock_query_return = NonCallableMock()
         mock_build_and_run_query.return_value = mock_query_return
 
-        res = self.instance.search_servers_name_not_in(
-            MOCKED_OUTPUT_DETAILS, names=["name1", "name2"]
+        mock_re_return = NonCallableMock()
+        mock_re.compile.return_value = mock_re_return
+
+        mock_output_details = MagicMock()
+        mock_get_output_details.return_value = mock_output_details
+
+        mock_kwargs = {
+            "properties_to_select": ["server_name", "server_id"],
+            "output_type": QueryOutputTypes.TO_STR,
+        }
+
+        res = self.instance.search_by_regex(
+            property_to_search_by="server_name",
+            pattern="some-regex-pattern",
+            **mock_kwargs
         )
+
         mock_build_and_run_query.assert_called_once_with(
             preset_details=QueryPresetDetails(
-                preset=QueryPresetsString.NOT_ANY_IN,
+                preset=QueryPresetsString.MATCHES_REGEX,
                 prop=ServerProperties.SERVER_NAME,
-                args={"values": ["name1", "name2"]},
+                args={"value": mock_re_return},
             ),
-            output_details=MOCKED_OUTPUT_DETAILS,
+            output_details=mock_output_details,
         )
+
         self.assertEqual(res, mock_query_return)


### PR DESCRIPTION
### Description:
A more updated version of the PR than #76 

Server Actions include the following actions:
`server.search.by.property` - allow user to give a property, and one or more values to search for/against
`server.search.by.regex` - same as before but will allow entering a regex pattern instead of a comma-spaced set of values
`server.search.by.datetime` - allow user to give a datetime property 
    - either `server_creation_date` or `server_last_updated_date` and search for older_than / younger_than etc

Future PR to add these actions for each new Manager object 
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
