### PR TITLE
MAINT: Add pytest to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,7 @@ python-dateutil
 dataclasses; python_version < '3.7'
 
 # for tests
+pylint
+# TODO drop these
 nose
 parameterized


### PR DESCRIPTION
### Description:
This will allow us to write against pytest instead of nose going forwards, so we have less to convert in the long-run

