### PR TITLE
MAINT: Switch away from nose in struct dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Many steps are available to run locally with the following setup:
   on commit and in the future run many automated tests.
 - If you are on Linux a helper script is included to setup and run Stackstorm unit tests.
   This is done by running `./run_tests.sh`
-- Additionally, tests can be run locally using `nose` through the IDE or CLI.
+- Additionally, tests can be run locally using `pytest` through the IDE or CLI.
 
 ## General Development Notes
 

--- a/tests/structs/test_smtp_account.py
+++ b/tests/structs/test_smtp_account.py
@@ -1,5 +1,7 @@
 import unittest
-from nose.tools import raises
+
+import pytest
+
 from structs.email.smtp_account import SMTPAccount
 
 
@@ -65,18 +67,18 @@ class TestEmailParams(unittest.TestCase):
         for key, val in expected_attrs.items():
             self.assertEqual(val, getattr(res, key))
 
-    @raises(KeyError)
     def test_from_pack_config_invalid_name(self):
         """
         Tests that from_pack_config() method works properly - when given an invalid smtp_account_name
         should raise an error if pack config does not contain entry matching smtp_account_name
         """
-        SMTPAccount.from_pack_config(self.mock_pack_config, "invalid-config")
+        with pytest.raises(KeyError):
+            SMTPAccount.from_pack_config(self.mock_pack_config, "invalid-config")
 
-    @raises(ValueError)
     def test_from_pack_config_invalid_pack(self):
         """
         Tests that from_pack_config() method works properly - when given an invalid pack_config
         should raise an error if pack config could not be found
         """
-        SMTPAccount.from_pack_config({}, "config1")
+        with pytest.raises(ValueError):
+            SMTPAccount.from_pack_config({}, "config1")


### PR DESCRIPTION
Nose is unsupported, and has broken with Python 3.11+, so switch away from this

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
