### PR TITLE
BUG: fix project create yaql type issue

### DIFF
--- a/actions/workflow.project.create.internal.yaml
+++ b/actions/workflow.project.create.internal.yaml
@@ -30,14 +30,14 @@ parameters:
     type: boolean
   admin_user_list:
     required: false
-    default: null
+    default: []
     type: array
     items:
       type: string
     description: Comma seperated list of Users (IDs or Names) to assign administrator access to
   stfc_user_list:
     required: false
-    default: null
+    default: []
     type: array
     description: List of Users (stfc domain) (IDs or Names) to give local user access
   network_name:


### PR DESCRIPTION
creating a project fails when admin or stfc user box left empty - null isn't a list so the workflow fails - change to using an empty list as default value
sorry - didn't catch this in the previous bugfix PR

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
