### PR TITLE
Switch lib email api

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,12 +29,7 @@ jobs:
       - name: Run Tests
         run: cd $GITHUB_WORKSPACE && ./run_tests.sh
 
-      - name: Generate Coverage
-        run: |
-          python3 -m pip install coverage~=4.4
-          coverage xml
-
       - name: Submit Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/lib/email_api/emailer.py
+++ b/lib/email_api/emailer.py
@@ -30,9 +30,9 @@ class Emailer:
         Path(__file__).resolve().parent.parent.parent / "email_attachments"
     )
 
-    def __init__(self, smtp_account: SMTPAccount):
-        self._smtp_account = smtp_account
-        self._template_handler = TemplateHandler()
+    def __init__(self, smtp_account: SMTPAccount, template_handler=TemplateHandler()):
+        self.smtp_account = smtp_account
+        self._template_handler = template_handler
 
     def send_emails(self, emails: List[EmailParams]):
         """
@@ -43,7 +43,7 @@ class Emailer:
         logger.debug("connecting to SMTP server")
 
         with SMTP_SSL(
-            self._smtp_account.server, self._smtp_account.port, timeout=60
+            self.smtp_account.server, self.smtp_account.port, timeout=60
         ) as server:
             server.ehlo()
             logger.info("SMTP server connection established")
@@ -73,14 +73,14 @@ class Emailer:
                 server.sendmail(
                     email_params.email_from,
                     send_to,
-                    self._build_email(email_params).as_string(),
+                    self.build_email_header(email_params).as_string(),
                 )
 
             logger.info(
                 "sending complete - time elapsed: %s seconds", time.time() - start
             )
 
-    def _build_email(self, email_params: EmailParams) -> MIMEMultipart:
+    def build_email_header(self, email_params: EmailParams) -> MIMEMultipart:
         """
         Helper function to setup email as MIMEMultipart
         :param email_params: A dataclass holding parameters for building an email
@@ -88,19 +88,18 @@ class Emailer:
         msg = MIMEMultipart()
         msg["Subject"] = Header(email_params.subject, "utf-8")
         msg["From"] = email_params.email_from
-        msg["To"] = ", ".join(email_params.email_to)
+        msg["To"] = ", ".join(email_params.email_to) if email_params.email_to else None
+        msg["Cc"] = ", ".join(email_params.email_cc) if email_params.email_cc else None
         msg["Date"] = formatdate(localtime=True)
         msg["reply-to"] = email_params.email_from
-        if email_params.email_cc:
-            msg["Cc"] = ", ".join(email_params.email_cc)
         msg.attach(
-            self._build_email_body(email_params.email_templates, email_params.as_html)
+            self.build_email_body(email_params.email_templates, email_params.as_html)
         )
         if email_params.attachment_filepaths:
-            msg = self._attach_files(msg, email_params.attachment_filepaths)
+            msg = self.attach_files(msg, email_params.attachment_filepaths)
         return msg
 
-    def _build_email_body(self, templates: List[EmailTemplateDetails], as_html):
+    def build_email_body(self, templates: List[EmailTemplateDetails], as_html):
         """
         Helper function to setup email body from templates
         :param templates: A list of dataclasses holding template information to build emails from
@@ -120,7 +119,7 @@ class Emailer:
             return MIMEText(msg_body, "html")
         return MIMEText(msg_body, "plain", "utf-8")
 
-    def _attach_files(self, msg: MIMEMultipart, filepaths: List[str]) -> MIMEMultipart:
+    def attach_files(self, msg: MIMEMultipart, filepaths: List[str]) -> MIMEMultipart:
         """
         Loads and adds attachments to an email message
         :param msg: The message object for the email

--- a/lib/email_api/emailer.py
+++ b/lib/email_api/emailer.py
@@ -73,14 +73,14 @@ class Emailer:
                 server.sendmail(
                     email_params.email_from,
                     send_to,
-                    self.build_email_header(email_params).as_string(),
+                    self.build_email(email_params).as_string(),
                 )
 
             logger.info(
                 "sending complete - time elapsed: %s seconds", time.time() - start
             )
 
-    def build_email_header(self, email_params: EmailParams) -> MIMEMultipart:
+    def build_email(self, email_params: EmailParams) -> MIMEMultipart:
         """
         Helper function to setup email as MIMEMultipart
         :param email_params: A dataclass holding parameters for building an email

--- a/lib/email_api/template_handler.py
+++ b/lib/email_api/template_handler.py
@@ -28,13 +28,15 @@ class TemplateHandler:
         Path(__file__).resolve().parent.parent.parent / "email_templates"
     )
 
-    def __init__(self):
+    def __init__(self, template_metadata=None):
         self._template_env = Environment(
             loader=FileSystemLoader(self.EMAIL_TEMPLATE_ROOT_DIR)
         )
 
-        self._template_metadata = self._load_all_metadata(
-            self.EMAIL_TEMPLATE_METADATA_FP
+        self._template_metadata = (
+            template_metadata
+            if template_metadata
+            else self._load_all_metadata(self.EMAIL_TEMPLATE_METADATA_FP)
         )
 
     @staticmethod

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = lib

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,8 @@
 [pytest]
 pythonpath = lib
+testpaths = tests
+python_files = *.py
+python_functions = test_*
+
+# Ensure code coverage is reported
+addopts = --cov=. --cov-append --cov-report xml:coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ dataclasses; python_version < '3.7'
 # for tests
 nose
 parameterized
+pytest
+pytest-cov

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,9 +10,10 @@ fi
 
 # Monkey patch nose to pytest until upstream has switched
 echo "PATCH: Replace nosetests with pytest"
-sed -ri 's/nosetests-\$\{NOSE_OPTS\[@\]\}/pytest/g' "$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests"
+sed -ri 's/nosetests \$\{NOSE_OPTS\[@\]\}/pytest/g' "$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests"
 
-PYTHON_PATH=$PYTHON_PATH:"$REPO_DIR/lib" "$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c
+export PYTHONPATH="$PYTHONPATH:$REPO_DIR/lib"
+"$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c
 
 # Generate coverage to consume locally
 python -m pip install coverage~=4.4

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,7 +14,3 @@ sed -ri 's/nosetests \$\{NOSE_OPTS\[@\]\}/pytest/g' "$ST2_REPO_PATH/st2common/bi
 
 export PYTHONPATH="$PYTHONPATH:$REPO_DIR/lib"
 "$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c
-
-# Generate coverage to consume locally
-python -m pip install coverage~=4.4
-coverage xml

--- a/tests/lib/email_api/test_email_actions.py
+++ b/tests/lib/email_api/test_email_actions.py
@@ -4,8 +4,6 @@ from unittest.mock import patch, NonCallableMock
 from email_api.email_actions import EmailActions
 from structs.email.email_template_details import EmailTemplateDetails
 
-# pylint:disable=protected-access
-
 
 class TestEmailActions(unittest.TestCase):
     """

--- a/tests/lib/email_api/test_emailer.py
+++ b/tests/lib/email_api/test_emailer.py
@@ -1,219 +1,221 @@
-import unittest
+from email.mime.multipart import MIMEMultipart
 from pathlib import Path
-from unittest.mock import patch, call, MagicMock, mock_open
+from unittest.mock import patch, call, MagicMock, mock_open, NonCallableMock
 
-from nose.tools import raises
-from parameterized import parameterized
+import pytest
 
 from email_api.emailer import Emailer
 
-# pylint:disable=protected-access
+
+@pytest.fixture(name="template_handler", scope="function")
+def template_handler_fixture():
+    return MagicMock()
 
 
-class TestEmailer(unittest.TestCase):
+@pytest.fixture(name="instance")
+def instance_fixture(template_handler):
+    mock_smtp_account = MagicMock()
+    return Emailer(mock_smtp_account, template_handler)
+
+
+@patch("email_api.emailer.Emailer.build_email_header")
+@patch("email_api.emailer.SMTP_SSL")
+def test_send_emails(mock_smtp_ssl, mock_build_email, instance):
     """
-    Tests that methods in Emailer class work expectedly
+    Tests that send_emails method works expectedly
+    Should setup SMTP_SSL connection to web server, and
+    iterate through list of EmailParams call sendmail for each
     """
+    mock_template_1 = MagicMock()
+    mock_template_1.template_name = "mock_template_1"
 
-    def setUp(self) -> None:
-        """setup for tests"""
-        self.mock_smtp_account = MagicMock()
-        with patch("email_api.emailer.TemplateHandler") as mock_template_handler:
-            self.template_handler = mock_template_handler
-            self.instance = Emailer(mock_template_handler)
+    mock_template_2 = MagicMock()
+    mock_template_2.template_name = "mock_template_2"
 
-    @patch("email_api.emailer.Emailer._build_email")
-    @patch("email_api.emailer.SMTP_SSL")
-    def test_send_emails(self, mock_smtp_ssl, mock_build_email):
-        """
-        Tests that send_emails method works expectedly
-        Should setup SMTP_SSL connection to web server, and
-        iterate through list of EmailParams call sendmail for each
-        """
-        mock_template_1 = MagicMock()
-        mock_template_1.template_name = "mock_template_1"
+    mock_email_param = MagicMock()
+    mock_email_param.email_to = ("test1@example.com",)
+    mock_email_param.email_from = "from@example.com"
+    mock_email_param.email_cc = ("cc1@example.com", "cc2@example.com")
+    mock_email_param.email_templates = [mock_template_1, mock_template_2]
 
-        mock_template_2 = MagicMock()
-        mock_template_2.template_name = "mock_template_2"
+    mock_email_param2 = MagicMock()
+    mock_email_param2.email_to = ("test2@example.com",)
+    mock_email_param2.email_from = "from@example.com"
+    mock_email_param2.email_cc = None
+    mock_email_param2.email_templates = [mock_template_1]
 
-        mock_email_param = MagicMock()
-        mock_email_param.email_to = ("test1@example.com",)
-        mock_email_param.email_from = "from@example.com"
-        mock_email_param.email_cc = ("cc1@example.com", "cc2@example.com")
-        mock_email_param.email_templates = [mock_template_1, mock_template_2]
+    mock_server = mock_smtp_ssl.return_value.__enter__.return_value
 
-        mock_email_param2 = MagicMock()
-        mock_email_param2.email_to = ("test2@example.com",)
-        mock_email_param2.email_from = "from@example.com"
-        mock_email_param2.email_cc = None
-        mock_email_param2.email_templates = [mock_template_1]
+    instance.send_emails(
+        emails=[mock_email_param, mock_email_param2],
+    )
+    mock_smtp_ssl.assert_called_once_with(
+        instance.smtp_account.server,
+        instance.smtp_account.port,
+        timeout=60,
+    )
 
-        mock_server = mock_smtp_ssl.return_value.__enter__.return_value
+    mock_server.ehlo.assert_called_once()
 
-        self.instance.send_emails(
-            emails=[mock_email_param, mock_email_param2],
-        )
-        mock_smtp_ssl.assert_called_once_with(
-            self.instance._smtp_account.server,
-            self.instance._smtp_account.port,
-            timeout=60,
-        )
-
-        mock_server.ehlo.assert_called_once()
-
-        mock_server.sendmail.assert_has_calls(
-            [
-                call(
-                    mock_email_param.email_from,
-                    ("test1@example.com", "cc1@example.com", "cc2@example.com"),
-                    mock_build_email.return_value.as_string.return_value,
-                ),
-                call(
-                    mock_email_param2.email_from,
-                    ("test2@example.com",),
-                    mock_build_email.return_value.as_string.return_value,
-                ),
-            ]
-        )
-
-        mock_build_email.assert_has_calls(
-            [
-                call(mock_email_param),
-                call().as_string(),
-                call(mock_email_param2),
-                call().as_string(),
-            ]
-        )
-
-    # pylint:disable=too-many-arguments
-
-    @parameterized.expand(
+    mock_server.sendmail.assert_has_calls(
         [
-            ("with ccs & attachments", ("cc1@example.com"), ["fp1", "fp2"]),
-            ("no ccs & attachments", None, ["fp1", "fp2"]),
-            ("with ccs & no attachments", ("cc1@example.com", "cc2@example.com"), None),
-            ("no ccs & no attachments", None, None),
-        ]
-    )
-    @patch("email_api.emailer.Emailer._build_email_body")
-    @patch("email_api.emailer.Emailer._attach_files")
-    @patch("email_api.emailer.MIMEMultipart")
-    def test_build_email(
-        self,
-        _,
-        mock_ccs,
-        mock_attachment_filepaths,
-        mock_mime_multipart,
-        mock_attach_files,
-        mock_build_email_body,
-    ):
-        """
-        Tests that build_email works expectedly when given no attachments to add
-        Should build email by setting up metadata, then building message body from templates
-        """
-        mock_email_params = MagicMock()
-        mock_email_params.email_cc.return_value = mock_ccs
-        mock_email_params.attachment_filepaths = mock_attachment_filepaths
-
-        res = self.instance._build_email(mock_email_params)
-
-        mock_mime_multipart.assert_called_once()
-
-        mock_build_email_body.assert_called_once_with(
-            mock_email_params.email_templates, mock_email_params.as_html
-        )
-
-        if mock_attachment_filepaths:
-            mock_attach_files.assert_called_once_with(
-                mock_mime_multipart.return_value, mock_email_params.attachment_filepaths
-            )
-            self.assertEqual(res, mock_attach_files.return_value)
-        else:
-            self.assertEqual(res, mock_mime_multipart.return_value)
-
-    @parameterized.expand(
-        [("test_with_as_html_true", True), ("test_with_as_html_false", False)]
-    )
-    @patch("email_api.emailer.MIMEText")
-    def test_build_email_body(self, _, as_html, mock_mime_text):
-        template_details_1 = MagicMock()
-        template_details_2 = MagicMock()
-        template_list = [template_details_1, template_details_2]
-
-        self.instance._template_handler.render_html_template.side_effect = [
-            "template-render-html-1\n",
-            "template-render-html-2\n",
-        ]
-
-        self.instance._template_handler.render_plaintext_template.side_effect = [
-            "template-render-plaintext-1\n",
-            "template-render-plaintext-2\n",
-        ]
-
-        res = self.instance._build_email_body(template_list, as_html=as_html)
-        if as_html:
-            self.assertEqual(
-                self.instance._template_handler.render_html_template.call_args_list,
-                [call(template_details_1), call(template_details_2)],
-            )
-            mock_mime_text.assert_called_once_with(
-                "template-render-html-1\ntemplate-render-html-2\n", "html"
-            )
-        else:
-            self.assertEqual(
-                self.instance._template_handler.render_plaintext_template.call_args_list,
-                [call(template_details_1), call(template_details_2)],
-            )
-            mock_mime_text.assert_called_once_with(
-                "template-render-plaintext-1\ntemplate-render-plaintext-2\n",
-                "plain",
-                "utf-8",
-            )
-        self.assertEqual(res, mock_mime_text.return_value)
-
-    @patch("builtins.open", new_callable=mock_open, read_data="data")
-    @patch("email_api.emailer.MIMEApplication")
-    def test_attach_files(self, mock_mime_application, mock_file):
-        """
-        Tests that attach_files method works expectedly - with valid filepaths
-        method should open file and add as attachment to given MIMEMultipart instance (msg)
-        """
-        mock_msg = MagicMock()
-        mock_filepaths = ["path/to/file1.txt", "path/to/file2.md"]
-
-        mock_mime_application.side_effect = [{}, {}]
-
-        res = self.instance._attach_files(mock_msg, mock_filepaths)
-        assert mock_file.call_args_list == [
             call(
-                Path(f"{self.instance.EMAIL_ATTACHMENTS_ROOT_DIR}/path/to/file1.txt"),
-                "rb",
+                mock_email_param.email_from,
+                ("test1@example.com", "cc1@example.com", "cc2@example.com"),
+                mock_build_email.return_value.as_string.return_value,
             ),
             call(
-                Path(f"{self.instance.EMAIL_ATTACHMENTS_ROOT_DIR}/path/to/file2.md"),
-                "rb",
+                mock_email_param2.email_from,
+                ("test2@example.com",),
+                mock_build_email.return_value.as_string.return_value,
             ),
         ]
+    )
 
-        mock_mime_application.assert_has_calls(
-            [call("data", Name="file1.txt"), call("data", Name="file2.md")]
+    mock_build_email.assert_has_calls(
+        [
+            call(mock_email_param),
+            call().as_string(),
+            call(mock_email_param2),
+            call().as_string(),
+        ]
+    )
+
+
+@patch("builtins.open", new_callable=mock_open, read_data="data")
+@patch("email_api.emailer.MIMEApplication")
+def test_attach_files(mock_mime_application, mock_file, instance):
+    """
+    Tests that attach_files method works expectedly - with valid filepaths
+    method should open file and add as attachment to given MIMEMultipart instance (msg)
+    """
+    mock_msg = MagicMock()
+    mock_filepaths = ["path/to/file1.txt", "path/to/file2.md"]
+
+    mock_mime_application.side_effect = [{}, {}]
+
+    res = instance.attach_files(mock_msg, mock_filepaths)
+    assert mock_file.call_args_list == [
+        call(
+            Path(f"{instance.EMAIL_ATTACHMENTS_ROOT_DIR}/path/to/file1.txt"),
+            "rb",
+        ),
+        call(
+            Path(f"{instance.EMAIL_ATTACHMENTS_ROOT_DIR}/path/to/file2.md"),
+            "rb",
+        ),
+    ]
+
+    mock_mime_application.assert_has_calls(
+        [call("data", Name="file1.txt"), call("data", Name="file2.md")]
+    )
+
+    mock_msg.attach.assert_has_calls(
+        [
+            call({"Content-Disposition": "attachment; filename=file1.txt"}),
+            call({"Content-Disposition": "attachment; filename=file2.md"}),
+        ]
+    )
+    assert res == mock_msg
+
+
+@patch("builtins.open", side_effect=FileNotFoundError())
+def test_attach_files_invalid_fp(_, instance):
+    """
+    Tests that attach_files method works expectedly - with invalid filepaths
+    should raise a RuntimeError
+    """
+    mock_msg = NonCallableMock()
+    mock_filepaths = ["invalid/path"]
+
+    with pytest.raises(RuntimeError):
+        instance.attach_files(mock_msg, mock_filepaths)
+
+
+@patch("email_api.emailer.Emailer.build_email_body")
+def test_build_email_header_fields(mock_build_email_body, instance):
+    """
+    Tests that build_email works expectedly when given no attachments to add
+    Should build email by setting up metadata, then building message body from templates
+    """
+    mock_email_params = MagicMock()
+    mock_email_params.email_to = ["to1@example.com", "to2@example.com"]
+    mock_email_params.email_cc = ["cc1@example.com", "cc2@example.com"]
+    mock_email_params.attachment_filepaths = None
+    mock_email_params.subject = "subject1"
+
+    res = instance.build_email_header(mock_email_params)
+
+    mock_build_email_body.assert_called_once_with(
+        mock_email_params.email_templates, mock_email_params.as_html
+    )
+
+    assert isinstance(res, MIMEMultipart)
+    assert res.get_payload() == [mock_build_email_body.return_value]
+    assert res["To"] == "to1@example.com, to2@example.com"
+    assert res["Cc"] == "cc1@example.com, cc2@example.com"
+    assert res["From"] == mock_email_params.email_from
+    assert res["reply-to"] == mock_email_params.email_from
+    assert res["Subject"] == mock_email_params.subject
+
+
+@patch("email_api.emailer.Emailer.build_email_body")
+@patch("email_api.emailer.Emailer.attach_files")
+@patch("email_api.emailer.MIMEMultipart")
+def test_build_email_with_attachments(
+    mock_mime_multipart, mock_attach_files, _, instance
+):
+    """
+    Tests that build_email works expectedly when given no attachments to add
+    Should build email by setting up metadata, then building message body from templates
+    """
+    mock_email_params = MagicMock()
+    mock_email_params.attachment_filepaths = NonCallableMock()
+    instance.build_email_header(mock_email_params)
+    mock_attach_files.assert_called_once_with(
+        mock_mime_multipart.return_value, mock_email_params.attachment_filepaths
+    )
+
+
+@pytest.mark.parametrize("as_html", [True, False])
+@patch("email_api.emailer.MIMEText")
+def test_build_email_body(mock_mime_text, as_html, instance, template_handler):
+
+    template_details_1 = MagicMock()
+    template_details_2 = MagicMock()
+    template_list = [template_details_1, template_details_2]
+
+    template_handler.render_html_template.side_effect = [
+        "template-render-html-1\n",
+        "template-render-html-2\n",
+    ]
+
+    template_handler.render_plaintext_template.side_effect = [
+        "template-render-plaintext-1\n",
+        "template-render-plaintext-2\n",
+    ]
+
+    res = instance.build_email_body(template_list, as_html=as_html)
+    if as_html:
+        assert template_handler.render_html_template.call_count == 2
+        assert template_handler.render_plaintext_template.call_count == 0
+        assert template_handler.render_html_template.call_args_list == [
+            call(template_details_1),
+            call(template_details_2),
+        ]
+        mock_mime_text.assert_called_once_with(
+            "template-render-html-1\ntemplate-render-html-2\n", "html"
         )
-
-        mock_msg.attach.assert_has_calls(
-            [
-                call({"Content-Disposition": "attachment; filename=file1.txt"}),
-                call({"Content-Disposition": "attachment; filename=file2.md"}),
-            ]
+    else:
+        assert template_handler.render_html_template.call_count == 0
+        assert template_handler.render_plaintext_template.call_count == 2
+        assert template_handler.render_plaintext_template.call_args_list == [
+            call(template_details_1),
+            call(template_details_2),
+        ]
+        mock_mime_text.assert_called_once_with(
+            "template-render-plaintext-1\ntemplate-render-plaintext-2\n",
+            "plain",
+            "utf-8",
         )
-        self.assertEqual(res, mock_msg)
-
-    @raises(RuntimeError)
-    @patch("builtins.open", side_effect=FileNotFoundError())
-    def test_attach_files_invalid_fp(self, _):
-        """
-        Tests that attach_files method works expectedly - with invalid filepaths
-        should raise a RuntimeError
-        """
-        mock_msg = MagicMock()
-        mock_filepaths = ["invalid/path"]
-        self.instance._attach_files(mock_msg, mock_filepaths)
+    assert res == mock_mime_text.return_value

--- a/tests/lib/email_api/test_emailer.py
+++ b/tests/lib/email_api/test_emailer.py
@@ -9,11 +9,20 @@ from email_api.emailer import Emailer
 
 @pytest.fixture(name="template_handler", scope="function")
 def template_handler_fixture():
+    """
+    Returns a mock TemplateHandler instance, this will
+    generate a new mock for each test, but getting the
+    template_handler fixture will return the same mock
+    """
     return MagicMock()
 
 
 @pytest.fixture(name="instance")
 def instance_fixture(template_handler):
+    """
+    Returns a mock Emailer instance, with a mocked
+    template injected
+    """
     mock_smtp_account = MagicMock()
     return Emailer(mock_smtp_account, template_handler)
 
@@ -180,6 +189,11 @@ def test_build_email_with_attachments(
 @pytest.mark.parametrize("as_html", [True, False])
 @patch("email_api.emailer.MIMEText")
 def test_build_email_body(mock_mime_text, as_html, instance, template_handler):
+    """
+    Tests that build email body renders the
+    expected templates and places them into the
+    expected MIMEText object
+    """
     template_details_1 = MagicMock()
     template_details_2 = MagicMock()
     template_list = [template_details_1, template_details_2]

--- a/tests/lib/email_api/test_emailer.py
+++ b/tests/lib/email_api/test_emailer.py
@@ -18,7 +18,7 @@ def instance_fixture(template_handler):
     return Emailer(mock_smtp_account, template_handler)
 
 
-@patch("email_api.emailer.Emailer.build_email_header")
+@patch("email_api.emailer.Emailer.build_email")
 @patch("email_api.emailer.SMTP_SSL")
 def test_send_emails(mock_smtp_ssl, mock_build_email, instance):
     """
@@ -144,7 +144,7 @@ def test_build_email_header_fields(mock_build_email_body, instance):
     mock_email_params.attachment_filepaths = None
     mock_email_params.subject = "subject1"
 
-    res = instance.build_email_header(mock_email_params)
+    res = instance.build_email(mock_email_params)
 
     mock_build_email_body.assert_called_once_with(
         mock_email_params.email_templates, mock_email_params.as_html
@@ -171,7 +171,7 @@ def test_build_email_with_attachments(
     """
     mock_email_params = MagicMock()
     mock_email_params.attachment_filepaths = NonCallableMock()
-    instance.build_email_header(mock_email_params)
+    instance.build_email(mock_email_params)
     mock_attach_files.assert_called_once_with(
         mock_mime_multipart.return_value, mock_email_params.attachment_filepaths
     )
@@ -180,7 +180,6 @@ def test_build_email_with_attachments(
 @pytest.mark.parametrize("as_html", [True, False])
 @patch("email_api.emailer.MIMEText")
 def test_build_email_body(mock_mime_text, as_html, instance, template_handler):
-
     template_details_1 = MagicMock()
     template_details_2 = MagicMock()
     template_list = [template_details_1, template_details_2]

--- a/tests/lib/email_api/test_template_handler.py
+++ b/tests/lib/email_api/test_template_handler.py
@@ -14,6 +14,9 @@ from structs.email.email_template_details import EmailTemplateDetails
 
 @pytest.fixture(name="mock_template_metadata", scope="module")
 def mock_template_metadata_fixture():
+    """
+    Returns a mock template metadata dict for the email API to use
+    """
     return {
         "mock-template": {
             "html_filepath": "/path/to/file.html",
@@ -31,6 +34,10 @@ def mock_template_metadata_fixture():
 
 @pytest.fixture(name="instance")
 def instance_fixture(mock_template_metadata):
+    """
+    Returns a template parsing instance with the mock template metadata
+    injected for testing
+    """
     instance = TemplateHandler(mock_template_metadata)
     instance._template_env = MagicMock()
     return instance

--- a/tests/lib/email_api/test_template_handler.py
+++ b/tests/lib/email_api/test_template_handler.py
@@ -1,9 +1,8 @@
-import unittest
 from unittest.mock import patch, mock_open, NonCallableMock, MagicMock
-from parameterized import parameterized
 
+import pytest
 from yaml import YAMLError
-from nose.tools import raises
+
 
 from jinja2.exceptions import TemplateError, TemplateNotFound
 from exceptions.email_template_error import EmailTemplateError
@@ -13,303 +12,317 @@ from structs.email.email_template_details import EmailTemplateDetails
 # pylint:disable=protected-access
 
 
-class TestTemplateHandler(unittest.TestCase):
+@pytest.fixture(name="mock_template_metadata", scope="module")
+def mock_template_metadata_fixture():
+    return {
+        "mock-template": {
+            "html_filepath": "/path/to/file.html",
+            "plaintext_filepath": "/path/to/file.txt",
+            "schema": {"attr1": None, "attr2": "abc", "attr3": "def"},
+        },
+        "mock-template-no-schema": {
+            "html_filepath": "/path/to/file2.html",
+            "plaintext_filepath": "/path/to/file2.txt",
+            "schema": None,
+        },
+        "mock-template-misconfigured": {"schema": None},
+    }
+
+
+@pytest.fixture(name="instance")
+def instance_fixture(mock_template_metadata):
+    instance = TemplateHandler(mock_template_metadata)
+    instance._template_env = MagicMock()
+    return instance
+
+
+@patch("email_api.template_handler.safe_load")
+@patch("builtins.open", new_callable=mock_open)
+def test_load_all_metadata_valid(mock_file, mock_yaml_load, instance):
     """
-    Tests that methods in TemplateHandler class works expectedly
+    Test that load_all_metadata method functions expectedly
+    Reads yaml file containing metadata info set in EMAIL_TEMPLATE_METADATA_FP
+    """
+    safe_load_out = NonCallableMock()
+    mock_yaml_load.return_value = safe_load_out
+
+    res = instance._load_all_metadata("some-fp")
+    mock_file.assert_called_once_with("some-fp", "r", encoding="utf-8")
+    mock_yaml_load.assert_called_once_with(mock_file.return_value)
+    assert res == safe_load_out
+
+
+@patch("email_api.template_handler.safe_load")
+@patch("builtins.open", new_callable=mock_open)
+def test_load_all_metadata_invalid(_, mock_yaml_load, instance):
+    """
+    Tests that load_all_metadata method functions expectedly
+    Raises error if yaml file cannot be read
     """
 
-    def setUp(self) -> None:
-        """setup for tests"""
-        self.mock_template_metadata = {
-            "mock-template": {
-                "html_filepath": "/path/to/file.html",
-                "plaintext_filepath": "/path/to/file.txt",
-                "schema": {"attr1": None, "attr2": "abc", "attr3": "def"},
-            },
-            "mock-template-no-schema": {
-                "html_filepath": "/path/to/file2.html",
-                "plaintext_filepath": "/path/to/file2.txt",
-                "schema": None,
-            },
-            "mock-template-misconfigured": {"schema": None},
-        }
-        self.mock_template_env = MagicMock()
+    mock_yaml_load.side_effect = YAMLError()
+    with pytest.raises(EmailTemplateError):
+        instance._load_all_metadata("some-fp")
 
-        with patch(
-            "email_api.template_handler.TemplateHandler._load_all_metadata",
-            return_value=self.mock_template_metadata,
-        ):
-            self.instance = TemplateHandler()
-            self.instance._template_env = self.mock_template_env
 
-    @patch("email_api.template_handler.safe_load")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_load_all_metadata_valid(self, mock_file, mock_yaml_load):
-        """
-        Test that load_all_metadata method functions expectedly
-        Reads yaml file containing metadata info set in EMAIL_TEMPLATE_METADATA_FP
-        """
-        safe_load_out = NonCallableMock()
-        mock_yaml_load.return_value = safe_load_out
-
-        res = self.instance._load_all_metadata("some-fp")
-        mock_file.assert_called_once_with("some-fp", "r", encoding="utf-8")
-        mock_yaml_load.assert_called_once_with(mock_file.return_value)
-        self.assertEqual(res, safe_load_out)
-
-    @raises(EmailTemplateError)
-    @patch("email_api.template_handler.safe_load")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_load_all_metadata_invalid(self, _, mock_yaml_load):
-        """
-        Tests that load_all_metadata method functions expectedly
-        Raises error if yaml file cannot be read
-        """
-
-        mock_yaml_load.side_effect = YAMLError()
-        self.instance._load_all_metadata("some-fp")
-
-    @parameterized.expand(
-        [
-            (
-                "with emtpy given vals, use defaults",
-                {"attr1": "def1", "attr2": "def2", "attr3": "def3"},
-                {},
-                {"attr1": "def1", "attr2": "def2", "attr3": "def3"},
-            ),
-            (
-                "with given vals and defaults, use given vals",
-                {"attr1": "def1", "attr2": "def2", "attr3": "def3"},
-                {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
-                {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
-            ),
-            (
-                "with given vals and no defaults, use given vals",
-                {"attr1": None, "attr2": None, "attr3": None},
-                {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
-                {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
-            ),
-            (
-                "with given vals set as None, use defaults",
-                {"attr1": None, "attr2": None, "attr3": None},
-                {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
-                {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
-            ),
-            (
-                "mix of given vals and defaults, use given vals if available else defaults",
-                {"attr1": None, "attr2": "def2", "attr3": "def3"},
-                {"attr1": "val1", "attr2": None},
-                {"attr1": "val1", "attr2": "def2", "attr3": "def3"},
-            ),
-        ]
+@pytest.mark.parametrize(
+    "mock_schema, mock_given_vals, expected_out",
+    [
+        (
+            # "with emtpy given vals, use defaults",
+            {"attr1": "def1", "attr2": "def2", "attr3": "def3"},
+            {},
+            {"attr1": "def1", "attr2": "def2", "attr3": "def3"},
+        ),
+        (
+            # "with given vals and defaults, use given vals",
+            {"attr1": "def1", "attr2": "def2", "attr3": "def3"},
+            {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
+            {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
+        ),
+        (
+            # "with given vals and no defaults, use given vals",
+            {"attr1": None, "attr2": None, "attr3": None},
+            {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
+            {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
+        ),
+        (
+            # "with given vals set as None, use defaults",
+            {"attr1": None, "attr2": None, "attr3": None},
+            {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
+            {"attr1": "val1", "attr2": "val2", "attr3": "val3"},
+        ),
+        (
+            # "mix of given vals and defaults, use given vals if available else defaults",
+            {"attr1": None, "attr2": "def2", "attr3": "def3"},
+            {"attr1": "val1", "attr2": None},
+            {"attr1": "val1", "attr2": "def2", "attr3": "def3"},
+        ),
+    ],
+)
+def test_parse_template_attrs_valid(
+    instance, mock_schema, mock_given_vals, expected_out
+):
+    """
+    Tests that parse_template_attrs method functions expectedly - with valid params
+    should parse schema and given values and returns a list of attributes to map
+    """
+    res = instance._parse_template_attrs(
+        EmailTemplateDetails(
+            template_name="mock-template", template_params=mock_given_vals
+        ),
+        template_schema=mock_schema,
     )
-    def test_parse_template_attrs_valid(
-        self, _, mock_schema, mock_given_vals, expected_out
-    ):
-        """
-        Tests that parse_template_attrs method functions expectedly - with valid params
-        should parse schema and given values and returns a list of attributes to map
-        """
-        res = self.instance._parse_template_attrs(
+    assert res == expected_out
+
+
+@pytest.mark.parametrize(
+    "mock_schema, mock_given_vals",
+    [
+        # no default, no given value
+        ({"attr1": None}, {}),
+        # no default, given value is None
+        ({"attr1": None}, {"attr1": None}),
+    ],
+)
+def test_parse_template_attrs_invalid(mock_schema, mock_given_vals, instance):
+    """
+    Tests that parse_template_attrs method functions expectedly - with invalid params
+    should raise error if given_vals have missing required params
+    """
+    with pytest.raises(EmailTemplateError):
+        instance._parse_template_attrs(
             EmailTemplateDetails(
                 template_name="mock-template", template_params=mock_given_vals
             ),
             template_schema=mock_schema,
         )
-        self.assertEqual(res, expected_out)
 
-    @parameterized.expand(
-        [
-            ("no default, no given value", {"attr1": None}, {}),
-            ("no default, given value is None", {"attr1": None}, {"attr1": None}),
-        ]
+
+def test_get_template_file_valid(instance):
+    """
+    Tests that get_template_file method functions expectedly - with valid filepath
+    should open file at given filepath and return jinja template file
+    """
+    mock_template_env = MagicMock()
+    instance._template_env = mock_template_env
+
+    mock_template = NonCallableMock()
+    mock_fp = "/path/to/file"
+    mock_template_env.get_template.return_value = mock_template
+
+    res = instance._get_template_file(mock_fp)
+    mock_template_env.get_template.assert_called_once_with(mock_fp)
+    assert res == mock_template
+
+
+def test_get_template_file_invalid(instance):
+    """
+    Tests that get_template_file method functions expectedly - with invalid filepath
+    should raise error if given an invalid filepath
+    """
+    mock_template_env = MagicMock()
+    instance._template_env = mock_template_env
+
+    mock_template_env.get_template.side_effect = TemplateNotFound("template-error")
+    with pytest.raises(EmailTemplateError):
+        instance._get_template_file("invalid-path")
+
+
+def test_get_template_metadata_valid(instance, mock_template_metadata):
+    """
+    Tests that get_template_metadata method functions expectedly - with valid template name
+    should get metadata info for a valid template name
+    """
+    res = instance._get_template_metadata(template_name="mock-template")
+    assert res == mock_template_metadata["mock-template"]
+
+
+def test_get_template_metadata_invalid(instance):
+    """
+    Tests that get_template_metadata method functions expectedly - with invalid template name
+    should raise error if given invalid template name
+    """
+    with pytest.raises(EmailTemplateError):
+        instance._get_template_metadata(template_name="an-invalid-template-name")
+
+
+@pytest.mark.parametrize(
+    "mock_template_name, mock_file_path_key, mock_template_params",
+    [
+        # "html and schema",
+        (
+            "mock-template",
+            "html_filepath",
+            {"attr1": "123", "attr2": "abc", "attr3": "def"},
+        ),
+        # "html and no schema"
+        ("mock-template-no-schema", "html_filepath", {}),
+        # "plaintext and schema",
+        (
+            "mock-template",
+            "plaintext_filepath",
+            {"attr1": "123", "attr2": "abc", "attr3": "def"},
+        ),
+        # "plaintext and no schema",
+        (
+            "mock-template-no-schema",
+            "plaintext_filepath",
+            {},
+        ),
+    ],
+)
+@patch("email_api.template_handler.TemplateHandler._get_template_file")
+# pylint:disable=too-many-arguments
+def test_render_template(
+    mock_get_template_file,
+    mock_template_name,
+    mock_file_path_key,
+    mock_template_params,
+    instance,
+    mock_template_metadata,
+):
+    """
+    Tests that render_template method works expectedly
+    Should call functions to get template, parse given attributes against metadata schema and
+    render html version of template
+    """
+    mock_template_file = MagicMock()
+    mock_get_template_file.return_value = mock_template_file
+
+    mock_template_obj = MagicMock()
+    mock_template_file.render.return_value = mock_template_obj
+
+    res = instance._render_template(
+        template_details=EmailTemplateDetails(
+            template_name=mock_template_name, template_params=mock_template_params
+        ),
+        file_path_key=mock_file_path_key,
     )
-    @raises(EmailTemplateError)
-    def test_parse_template_attrs_invalid(self, _, mock_schema, mock_given_vals):
-        """
-        Tests that parse_template_attrs method functions expectedly - with invalid params
-        should raise error if given_vals have missing required params
-        """
-        self.instance._parse_template_attrs(
-            EmailTemplateDetails(
-                template_name="mock-template", template_params=mock_given_vals
-            ),
-            template_schema=mock_schema,
-        )
-
-    def test_get_template_file_valid(self):
-        """
-        Tests that get_template_file method functions expectedly - with valid filepath
-        should open file at given filepath and return jinja template file
-        """
-        mock_template = NonCallableMock()
-        mock_fp = "/path/to/file"
-        self.mock_template_env.get_template.return_value = mock_template
-
-        res = self.instance._get_template_file(mock_fp)
-        self.mock_template_env.get_template.assert_called_once_with(mock_fp)
-        self.assertEqual(res, mock_template)
-
-    @raises(EmailTemplateError)
-    def test_get_template_file_invalid(self):
-        """
-        Tests that get_template_file method functions expectedly - with invalid filepath
-        should raise error if given an invalid filepath
-        """
-        self.mock_template_env.get_template.side_effect = TemplateNotFound(
-            "template-error"
-        )
-        self.instance._get_template_file("invalid-path")
-
-    def test_get_template_metadata_valid(self):
-        """
-        Tests that get_template_metadata method functions expectedly - with valid template name
-        should get metadata info for a valid template name
-        """
-        res = self.instance._get_template_metadata(template_name="mock-template")
-        self.assertEqual(res, self.mock_template_metadata["mock-template"])
-
-    @raises(EmailTemplateError)
-    def test_get_template_metadata_invalid(self):
-        """
-        Tests that get_template_metadata method functions expectedly - with invalid template name
-        should raise error if given invalid template name
-        """
-        self.instance._get_template_metadata(template_name="an-invalid-template-name")
-
-    @parameterized.expand(
-        [
-            (
-                "html and schema",
-                "mock-template",
-                "html_filepath",
-                {"attr1": "123", "attr2": "abc", "attr3": "def"},
-            ),
-            ("html and no schema", "mock-template-no-schema", "html_filepath", {}),
-            (
-                "plaintext and schema",
-                "mock-template",
-                "plaintext_filepath",
-                {"attr1": "123", "attr2": "abc", "attr3": "def"},
-            ),
-            (
-                "plaintext and no schema",
-                "mock-template-no-schema",
-                "plaintext_filepath",
-                {},
-            ),
-        ]
+    mock_get_template_file.assert_called_once_with(
+        mock_template_metadata[mock_template_name][mock_file_path_key]
     )
-    @patch("email_api.template_handler.TemplateHandler._get_template_file")
-    def test_render_template(
-        self,
-        _,
-        mock_template_name,
-        mock_file_path_key,
-        mock_template_params,
-        mock_get_template_file,
-    ):
-        """
-        Tests that render_template method works expectedly
-        Should call functions to get template, parse given attributes against metadata schema and
-        render html version of template
-        """
-        mock_template_file = MagicMock()
-        mock_get_template_file.return_value = mock_template_file
+    mock_template_file.render.assert_called_once_with(**mock_template_params)
+    assert res == mock_template_obj
 
-        mock_template_obj = MagicMock()
-        mock_template_file.render.return_value = mock_template_obj
 
-        res = self.instance._render_template(
-            template_details=EmailTemplateDetails(
-                template_name=mock_template_name, template_params=mock_template_params
-            ),
-            file_path_key=mock_file_path_key,
-        )
-        mock_get_template_file.assert_called_once_with(
-            self.mock_template_metadata[mock_template_name][mock_file_path_key]
-        )
-        mock_template_file.render.assert_called_once_with(**mock_template_params)
-        self.assertEqual(res, mock_template_obj)
-
-    @parameterized.expand(
-        [
-            ("test missing html_filepath", "html_filepath"),
-            ("test missing plaintext_filepath", "plaintext_filepath"),
-        ]
-    )
-    @raises(EmailTemplateError)
-    def test_render_template_missing_fp(self, _, file_path_key):
-        """
-        Tests that render_template method works expectedly - if metadata is missing config
-        should raise error if necessary filepath config missing
-        """
-        self.instance._render_template(
+@pytest.mark.parametrize("file_path_key", ["html_filepath", "plaintext_filepath"])
+def test_render_template_missing_fp(file_path_key, instance):
+    """
+    Tests that render_template method works expectedly - if metadata is missing config
+    should raise error if necessary filepath config missing
+    """
+    with pytest.raises(EmailTemplateError):
+        instance._render_template(
             template_details=EmailTemplateDetails(
                 template_name="mock-template-misconfigured"
             ),
             file_path_key=file_path_key,
         )
 
-    @raises(EmailTemplateError)
-    def test_render_template_params_missing(self):
-        """
-        Tests that render_template method works expectedly - if template params missing when required
-        should raise error if given a template which requires template params but none given
-        """
-        self.instance._render_template(
+
+def test_render_template_params_missing(instance):
+    """
+    Tests that render_template method works expectedly - if template params missing when required
+    should raise error if given a template which requires template params but none given
+    """
+    with pytest.raises(EmailTemplateError):
+        instance._render_template(
             template_details=EmailTemplateDetails(
                 template_name="mock-template-misconfigured"
             ),
             file_path_key="html_filepath",
         )
 
-    @raises(EmailTemplateError)
-    @patch("email_api.template_handler.TemplateHandler._get_template_file")
-    def test_render_template_jinja_failure(self, mock_get_template_file):
-        """
-        Tests that render_template method works expectedly - if jinja render() fails
-        should raise EmailTemplate error
-        """
-        mock_get_template_file.return_value.render.side_effect = TemplateError()
-        self.instance._render_template(
+
+@patch("email_api.template_handler.TemplateHandler._get_template_file")
+def test_render_template_jinja_failure(mock_get_template_file, instance):
+    """
+    Tests that render_template method works expectedly - if jinja render() fails
+    should raise EmailTemplate error
+    """
+    mock_get_template_file.return_value.render.side_effect = TemplateError()
+    with pytest.raises(EmailTemplateError):
+        instance._render_template(
             template_details=EmailTemplateDetails(
                 template_name="mock-template-no-schema",
             ),
             file_path_key="html_filepath",
         )
 
-    @patch("email_api.template_handler.TemplateHandler._render_template")
-    def test_render_html_template(self, mock_render_template):
-        """
-        Tests that render_html_template method works expectedly
-        """
-        mock_template_details = EmailTemplateDetails(
-            template_name="mock-template",
-            template_params={"attr1": "123", "attr2": "abc", "attr3": "def"},
-        )
-        res = self.instance.render_html_template(mock_template_details)
-        mock_render_template.assert_called_once_with(
-            template_details=mock_template_details,
-            file_path_key="html_filepath",
-        )
-        mock_render_template.return_value.replace.assert_called_once_with("\n", "")
-        self.assertEqual(res, mock_render_template.return_value.replace.return_value)
 
-    @patch("email_api.template_handler.TemplateHandler._render_template")
-    def test_render_plaintext_template(self, mock_render_template):
-        """
-        Tests that render_plaintext_template method works expectedly
-        """
-        mock_template_details = EmailTemplateDetails(
-            template_name="mock-template",
-            template_params={"attr1": "123", "attr2": "abc", "attr3": "def"},
-        )
+@patch("email_api.template_handler.TemplateHandler._render_template")
+def test_render_html_template(mock_render_template, instance):
+    """
+    Tests that render_html_template method works expectedly
+    """
+    mock_template_details = EmailTemplateDetails(
+        template_name="mock-template",
+        template_params={"attr1": "123", "attr2": "abc", "attr3": "def"},
+    )
+    res = instance.render_html_template(mock_template_details)
+    mock_render_template.assert_called_once_with(
+        template_details=mock_template_details,
+        file_path_key="html_filepath",
+    )
+    mock_render_template.return_value.replace.assert_called_once_with("\n", "")
+    assert res == mock_render_template.return_value.replace.return_value
 
-        res = self.instance.render_plaintext_template(mock_template_details)
 
-        mock_render_template.assert_called_once_with(
-            template_details=mock_template_details,
-            file_path_key="plaintext_filepath",
-        )
-        self.assertEqual(res, mock_render_template.return_value)
+@patch("email_api.template_handler.TemplateHandler._render_template")
+def test_render_plaintext_template(mock_render_template, instance):
+    """
+    Tests that render_plaintext_template method works expectedly
+    """
+    mock_template_details = EmailTemplateDetails(
+        template_name="mock-template",
+        template_params={"attr1": "123", "attr2": "abc", "attr3": "def"},
+    )
+
+    res = instance.render_plaintext_template(mock_template_details)
+
+    mock_render_template.assert_called_once_with(
+        template_details=mock_template_details,
+        file_path_key="plaintext_filepath",
+    )
+    assert res == mock_render_template.return_value


### PR DESCRIPTION
### Description:
Switches the unit test framework for `lib/email_api` and associated tests. Also addresses comments from #112 

The diff is dominated by us having to un-indent the whole file whilst switching from unit test to pytest, so we can continue using parametrize 

