### PR TITLE
BUG: add missing Jinja2 package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-openstackclient == 5.7.0
 tabulate
 requests
 python-dateutil
-dataclasses; python_version < '3.7'
+Jinja2
 
 # for tests
 nose


### PR DESCRIPTION
### Description:
Adds a missing Jinja2 package, and removes the dataclasses packages which is dead since our min is now 3.8+