### PR TITLE
MAINT: Port tests for lib/openstack_query/handlers

### DIFF
--- a/tests/lib/openstack_query/handlers/test_client_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler.py
@@ -14,9 +14,16 @@ from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 @pytest.fixture(name="mock_filter_func")
 def filter_func_fixture():
-    # Required to mock the filter_func
+    """
+    Stubs out something callable for the method
+    under test. We don't want any side effects from
+    this function, so we just pass.
+    """
+
     # pylint:disable=unused-argument
     def _mock_filter_func(prop, *args, **kwargs):
+        # We're not testing filter functions in this test, so
+        # pass instead of returning a value
         pass
 
     return _mock_filter_func
@@ -24,6 +31,11 @@ def filter_func_fixture():
 
 @pytest.fixture(name="instance")
 def instance_fixture(mock_filter_func):
+    """
+    Returns an instance with a mocked filter function
+    injects, and various properties to query presets
+    pre-defined
+    """
     _filter_function_mappings = {
         MockQueryPresets.ITEM_1: ["*"],
         MockQueryPresets.ITEM_2: [MockProperties.PROP_1, MockProperties.PROP_2],
@@ -235,6 +247,9 @@ def test_check_filter_func_valid_filters(input_val, instance):
 
     # pylint:disable=unused-argument
     def _mock_filter_func(prop, arg1: int, arg2: str = "some-default", **kwargs):
+        # Fake the filter function not finding anything,
+        # so we can test that it handles when args not matched extra args available
+        # based on the arguments in this function, e.g. arg2
         return None
 
     res = instance._check_filter_func(_mock_filter_func, func_kwargs=input_val)

--- a/tests/lib/openstack_query/handlers/test_client_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler.py
@@ -1,7 +1,7 @@
-import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch, NonCallableMock
-from parameterized import parameterized
+
+import pytest
 
 from openstack_query.handlers.client_side_handler import ClientSideHandler
 from exceptions.query_preset_mapping_error import QueryPresetMappingError
@@ -12,293 +12,309 @@ from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 # pylint:disable=protected-access
 
 
-class ClientSideHandlerBaseTests(unittest.TestCase):
-    """
-    Runs various tests to ensure that ClientSideHandlerBase class methods function expectedly
-    """
-
-    @staticmethod
+@pytest.fixture(name="mock_filter_func")
+def filter_func_fixture():
+    # Required to mock the filter_func
+    # pylint:disable=unused-argument
     def _mock_filter_func(prop, *args, **kwargs):
         pass
 
-    def setUp(self):
-        """
-        Setup for tests
-        """
-        super().setUp()
+    return _mock_filter_func
 
-        _filter_function_mappings = {
-            MockQueryPresets.ITEM_1: ["*"],
-            MockQueryPresets.ITEM_2: [MockProperties.PROP_1, MockProperties.PROP_2],
-            MockQueryPresets.ITEM_3: [MockProperties.PROP_3, MockProperties.PROP_4],
-        }
-        self.instance = ClientSideHandler(_filter_function_mappings)
-        self.instance._filter_functions = {
-            MockQueryPresets.ITEM_1: self._mock_filter_func,
-        }
 
-    def test_check_supported_true(self):
-        """
-        Tests that check_supported method works expectedly
-        returns True if Prop Enum and Preset Enum have client-side mapping
-        """
-        # when preset has '*' mapping - accepts all props
-        self.assertTrue(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_1, MockProperties.PROP_1
-            )
-        )
+@pytest.fixture(name="instance")
+def instance_fixture(mock_filter_func):
+    _filter_function_mappings = {
+        MockQueryPresets.ITEM_1: ["*"],
+        MockQueryPresets.ITEM_2: [MockProperties.PROP_1, MockProperties.PROP_2],
+        MockQueryPresets.ITEM_3: [MockProperties.PROP_3, MockProperties.PROP_4],
+    }
+    instance = ClientSideHandler(_filter_function_mappings)
 
-        # when preset has explicit prop mapping
-        self.assertTrue(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_2, MockProperties.PROP_2
-            )
-        )
+    instance._filter_functions = {
+        MockQueryPresets.ITEM_1: mock_filter_func,
+    }
+    return instance
 
-    def test_check_preset_supported_false(self):
-        """
-        Tests that check_supported method works expectedly
-        returns False if either Preset is not supported or Preset-Prop does not have a mapping
-        """
 
-        # when preset is not supported
-        self.assertFalse(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_4, MockProperties.PROP_1
-            )
-        )
+def test_check_supported_true(instance):
+    """
+    Tests that check_supported method works expectedly
+    returns True if Prop Enum and Preset Enum have client-side mapping
+    """
+    # when preset has '*' mapping - accepts all props
+    assert instance.check_supported(MockQueryPresets.ITEM_1, MockProperties.PROP_1)
 
-        # when preset found, but prop is not supported
-        self.assertFalse(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_2, MockProperties.PROP_3
-            )
-        )
+    # when preset has explicit prop mapping
+    assert instance.check_supported(MockQueryPresets.ITEM_2, MockProperties.PROP_2)
 
-    @patch(
-        "openstack_query.handlers.client_side_handler.ClientSideHandler._check_filter_func"
+
+def test_check_preset_supported_false(instance):
+    """
+    Tests that check_supported method works expectedly
+    returns False if either Preset is not supported or Preset-Prop does not have a mapping
+    """
+
+    # when preset is not supported
+    assert not instance.check_supported(MockQueryPresets.ITEM_4, MockProperties.PROP_1)
+
+    # when preset found, but prop is not supported
+    assert not instance.check_supported(MockQueryPresets.ITEM_2, MockProperties.PROP_3)
+
+
+@patch(
+    "openstack_query.handlers.client_side_handler.ClientSideHandler._check_filter_func"
+)
+@patch(
+    "openstack_query.handlers.client_side_handler.ClientSideHandler._filter_func_wrapper"
+)
+def test_get_filter_func_valid(
+    mock_filter_func_wrapper, mock_check_filter_func, instance, mock_filter_func
+):
+    """
+    Tests that get_filter_func method works expectedly - with valid inputs
+    sets up and returns a function that when given an openstack object will return a boolean value on
+    whether it passes the filter
+    """
+    # define inputs
+    mock_prop_func = MagicMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    # mock function return values
+    mock_check_filter_func.return_value = True, ""
+    mock_filter_func_wrapper.return_value = "a-boolean-value"
+
+    res = instance.get_filter_func(
+        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_prop_func, mock_kwargs
     )
-    @patch(
-        "openstack_query.handlers.client_side_handler.ClientSideHandler._filter_func_wrapper"
+    val = res("test-openstack-res")
+
+    # MockQueryPresets.ITEM_1 and MockProperties.PROP_1 are valid and should return 'item1_func'
+    # - which represents a function mapping
+    mock_check_filter_func.assert_called_once_with(mock_filter_func, mock_kwargs)
+    mock_filter_func_wrapper.assert_called_once_with(
+        "test-openstack-res", mock_filter_func, mock_prop_func, mock_kwargs
     )
-    def test_get_filter_func_valid(
-        self, mock_filter_func_wrapper, mock_check_filter_func
-    ):
-        """
-        Tests that get_filter_func method works expectedly - with valid inputs
-        sets up and returns a function that when given an openstack object will return a boolean value on
-        whether it passes the filter
-        """
-        # define inputs
+
+    assert val == "a-boolean-value"
+
+
+def test_get_filter_func_preset_invalid(instance):
+    """
+    Tests that get_filter_func method works expectedly - with invalid inputs
+    raises QueryPresetMappingError if preset invalid
+    """
+    mock_prop_func = MagicMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    # when preset is invalid
+    with pytest.raises(QueryPresetMappingError):
+        instance.get_filter_func(
+            MockQueryPresets.ITEM_4,
+            MockProperties.PROP_1,
+            mock_prop_func,
+            mock_kwargs,
+        )
+
+
+def test_get_filter_func_prop_invalid(instance):
+    """
+    Tests that get_filter_func method works expectedly - with invalid inputs
+    raises QueryPresetMappingError if prop invalid
+    """
+
+    # when the preset is valid, but property is invalid
+    with pytest.raises(QueryPresetMappingError):
         mock_prop_func = MagicMock()
         mock_kwargs = {"arg1": "val1", "arg2": "val2"}
-
-        # mock function return values
-        mock_check_filter_func.return_value = True, ""
-        mock_filter_func_wrapper.return_value = "a-boolean-value"
-
-        res = self.instance.get_filter_func(
-            MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_prop_func, mock_kwargs
-        )
-        val = res("test-openstack-res")
-
-        # MockQueryPresets.ITEM_1 and MockProperties.PROP_1 are valid and should return 'item1_func'
-        # - which represents a function mapping
-        mock_check_filter_func.assert_called_once_with(
-            self._mock_filter_func, mock_kwargs
-        )
-        mock_filter_func_wrapper.assert_called_once_with(
-            "test-openstack-res", self._mock_filter_func, mock_prop_func, mock_kwargs
+        instance.get_filter_func(
+            MockQueryPresets.ITEM_2,
+            MockProperties.PROP_3,
+            mock_prop_func,
+            mock_kwargs,
         )
 
-        self.assertEqual(val, "a-boolean-value")
 
-    def test_get_filter_func_preset_invalid(self):
-        """
-        Tests that get_filter_func method works expectedly - with invalid inputs
-        raises QueryPresetMappingError if preset invalid
-        """
-        mock_prop_func = MagicMock()
-        mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+@patch(
+    "openstack_query.handlers.client_side_handler.ClientSideHandler._check_filter_func"
+)
+def test_get_filter_func_arguments_invalid(mock_check_filter_func, instance):
+    """
+    Tests that get_filter_func method works expectedly - with invalid inputs
+    raises QueryPresetMappingError if filter_func_kwargs are invalid
+    """
+    mock_prop_func = MagicMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    # when check_filter_func is false
+    mock_check_filter_func.return_value = False, "some-error"
+    with pytest.raises(QueryPresetMappingError):
+        instance.get_filter_func(
+            MockQueryPresets.ITEM_1,
+            MockProperties.PROP_1,
+            mock_prop_func,
+            mock_kwargs,
+        )
 
-        # when preset is invalid
-        with self.assertRaises(QueryPresetMappingError):
-            self.instance.get_filter_func(
-                MockQueryPresets.ITEM_4,
-                MockProperties.PROP_1,
-                mock_prop_func,
-                mock_kwargs,
-            )
 
-    def test_get_filter_func_prop_invalid(self):
-        """
-        Tests that get_filter_func method works expectedly - with invalid inputs
-        raises QueryPresetMappingError if prop invalid
-        """
+def test_filter_func_wrapper_prop_func_error(instance):
+    """
+    Tests that get_filter_func method works expectedly - with invalid inputs
+    raises QueryPresetMappingError if filter_func_kwargs are invalid
+    """
+    mock_item = NonCallableMock()
 
-        # when the preset is valid, but property is invalid
-        with self.assertRaises(QueryPresetMappingError):
-            mock_prop_func = MagicMock()
-            mock_kwargs = {"arg1": "val1", "arg2": "val2"}
-            self.instance.get_filter_func(
-                MockQueryPresets.ITEM_2,
-                MockProperties.PROP_3,
-                mock_prop_func,
-                mock_kwargs,
-            )
+    mock_filter_func = MagicMock()
+    mock_filter_func.return_value = "a-boolean-value"
 
-    @patch(
-        "openstack_query.handlers.client_side_handler.ClientSideHandler._check_filter_func"
+    mock_prop_func = MagicMock()
+    mock_filter_func_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    # when prop_func raises exception - i.e. property not found
+    mock_prop_func.side_effect = AttributeError()
+    res = instance._filter_func_wrapper(
+        mock_item, mock_filter_func, mock_prop_func, mock_filter_func_kwargs
     )
-    def test_get_filter_func_arguments_invalid(self, mock_check_filter_func):
-        """
-        Tests that get_filter_func method works expectedly - with invalid inputs
-        raises QueryPresetMappingError if filter_func_kwargs are invalid
-        """
-        mock_prop_func = MagicMock()
-        mock_kwargs = {"arg1": "val1", "arg2": "val2"}
-        # when check_filter_func is false
-        mock_check_filter_func.return_value = False, "some-error"
-        with self.assertRaises(QueryPresetMappingError):
-            self.instance.get_filter_func(
-                MockQueryPresets.ITEM_1,
-                MockProperties.PROP_1,
-                mock_prop_func,
-                mock_kwargs,
-            )
+    assert not res
 
-    def test_filter_func_wrapper_prop_func_error(self):
-        """
-        Tests that get_filter_func method works expectedly - with invalid inputs
-        raises QueryPresetMappingError if filter_func_kwargs are invalid
-        """
-        mock_item = NonCallableMock()
 
-        mock_filter_func = MagicMock()
-        mock_filter_func.return_value = "a-boolean-value"
+def test_filter_func_wrapper_valid(instance):
+    """
+    Tests that filter_func_wrapper method works expectedly - with valid inputs
+    returns a function that takes an openstack item as input and returns either True or False
+    on whether that item passes the set filter condition.
+        - Prop Enum and Preset Enum are supported
+        - and filter_func_kwargs are valid
+    """
+    mock_item = NonCallableMock()
 
-        mock_prop_func = MagicMock()
-        mock_filter_func_kwargs = {"arg1": "val1", "arg2": "val2"}
+    mock_filter_func = MagicMock()
+    mock_filter_func.return_value = "a-boolean-value"
 
-        # when prop_func raises exception - i.e. property not found
-        mock_prop_func.side_effect = AttributeError()
-        res = self.instance._filter_func_wrapper(
-            mock_item, mock_filter_func, mock_prop_func, mock_filter_func_kwargs
-        )
-        self.assertFalse(res)
+    mock_prop_func = MagicMock()
+    mock_filter_func_kwargs = {"arg1": "val1", "arg2": "val2"}
 
-    def test_filter_func_wrapper_valid(self):
-        """
-        Tests that filter_func_wrapper method works expectedly - with valid inputs
-        returns a function that takes an openstack item as input and returns either True or False
-        on whether that item passes the set filter condition.
-            - Prop Enum and Preset Enum are supported
-            - and filter_func_kwargs are valid
-        """
-        mock_item = NonCallableMock()
-
-        mock_filter_func = MagicMock()
-        mock_filter_func.return_value = "a-boolean-value"
-
-        mock_prop_func = MagicMock()
-        mock_filter_func_kwargs = {"arg1": "val1", "arg2": "val2"}
-
-        # when prop_func is valid and filter_kwargs given
-        mock_prop_func.return_value = "some-prop-val"
-        mock_prop_func.side_effect = None
-        res = self.instance._filter_func_wrapper(
-            mock_item, mock_filter_func, mock_prop_func, mock_filter_func_kwargs
-        )
-        self.assertEqual(res, "a-boolean-value")
-        mock_filter_func.assert_called_once_with(
-            "some-prop-val", **mock_filter_func_kwargs
-        )
-
-        # when prop_func is valid and filter_kwargs not given
-        mock_prop_func.reset_mock()
-        mock_filter_func.reset_mock()
-        mock_prop_func.return_value = "some-prop-val"
-        mock_prop_func.side_effect = None
-        res = self.instance._filter_func_wrapper(
-            mock_item, mock_filter_func, mock_prop_func
-        )
-        self.assertEqual(res, "a-boolean-value")
-        mock_filter_func.assert_called_once_with("some-prop-val")
-
-    @parameterized.expand(
-        [
-            ("required args only", {"arg1": 12}, True),
-            ("required and default", {"arg1": 12, "arg2": "non-default"}, True),
-            ("required and kwarg", {"arg1": 12, "some_kwarg": "some-val"}, True),
-            (
-                "all possible",
-                {"arg1": 12, "arg2": "non-default", "some_kwarg": "some-val"},
-                True,
-            ),
-            (
-                "different order",
-                {"arg2": "non-default", "some_kwarg": "some-val", "arg1": 12},
-                True,
-            ),
-            ("no required", {}, False),
-            ("required wrong type", {"arg1": "non-default"}, False),
-            ("optional wrong type", {"arg1": 12, "arg2": 12}, False),
-        ]
+    # when prop_func is valid and filter_kwargs given
+    mock_prop_func.return_value = "some-prop-val"
+    mock_prop_func.side_effect = None
+    res = instance._filter_func_wrapper(
+        mock_item, mock_filter_func, mock_prop_func, mock_filter_func_kwargs
     )
-    def test_check_filter_func(self, _, kwargs_to_test, expected_value):
-        """
-        Tests that check_filter_func method works expectedly - for filter_func which takes extra params
-        returns True only if args match expected args required by client-side filter function
-        """
+    assert res == "a-boolean-value"
+    mock_filter_func.assert_called_once_with("some-prop-val", **mock_filter_func_kwargs)
 
-        # pylint:disable=unused-argument
-        def mock_filter_func(prop, arg1: int, arg2: str = "some-default", **kwargs):
-            return None
+    # when prop_func is valid and filter_kwargs not given
+    mock_prop_func.reset_mock()
+    mock_filter_func.reset_mock()
+    mock_prop_func.return_value = "some-prop-val"
+    mock_prop_func.side_effect = None
+    res = instance._filter_func_wrapper(mock_item, mock_filter_func, mock_prop_func)
+    assert res == "a-boolean-value"
+    mock_filter_func.assert_called_once_with("some-prop-val")
 
-        res = self.instance._check_filter_func(
-            mock_filter_func, func_kwargs=kwargs_to_test
-        )
-        self.assertEqual(expected_value, res[0])
 
-    @parameterized.expand(
-        [
-            ("empty", {}, True),
-            ("provided invalid arg", {"arg1": "non-default"}, False),
-        ]
+@pytest.mark.parametrize(
+    "input_val",
+    [
+        # required args only
+        {"arg1": 12},
+        # required and default
+        {"arg1": 12, "arg2": "non-default"},
+        # required and kwarg
+        {"arg1": 12, "some_kwarg": "some-val"},
+        # all possible
+        {"arg1": 12, "arg2": "non-default", "some_kwarg": "some-val"},
+        # different order
+        {"arg2": "non-default", "some_kwarg": "some-val", "arg1": 12},
+    ],
+)
+def test_check_filter_func_valid_filters(input_val, instance):
+    """
+    Tests that check_filter_func method works expectedly - for filter_func which takes extra params
+    returns True only if args match expected args required by client-side filter function
+    """
+
+    # pylint:disable=unused-argument
+    def _mock_filter_func(prop, arg1: int, arg2: str = "some-default", **kwargs):
+        return None
+
+    res = instance._check_filter_func(_mock_filter_func, func_kwargs=input_val)
+    assert res[0]
+    assert res[1] == ""
+
+
+@pytest.mark.parametrize(
+    "input_val",
+    [
+        # no but required"
+        {},
+        # required wrong type
+        {"arg1": "non-default"},
+        # optional wrong type
+        {"arg1": 12, "arg2": 12},
+    ],
+)
+def test_check_filter_func_invalid_entry(input_val, instance):
+    """
+    Tests that check_filter_func method works expectedly - for filter_func which takes extra params
+    when args don't match expected args required by client-side filter function
+    """
+
+    # pylint:disable=unused-argument
+    def _mock_filter_func(prop, arg1: int, arg2: str = "some-default", **kwargs):
+        return None
+
+    res = instance._check_filter_func(_mock_filter_func, func_kwargs=input_val)
+    assert not res[0]
+    assert isinstance(res[1], str) and len(res[1]) > 0
+
+
+def test_check_filter_func_with_no_args(instance):
+    """
+    Tests that check_filter_func method works expectedly - for filter_func which takes no extra params
+    returns True if args match expected args required by client-side filter function
+    """
+
+    # pylint:disable=unused-argument
+    def _mock_filter_func(prop):
+        return None
+
+    res = instance._check_filter_func(_mock_filter_func, func_kwargs={})
+    assert res[0]
+
+
+def test_check_filter_func_with_extra_arg(instance):
+    """
+    Tests that check_filter_func method works expectedly - for filter_func which takes no extra params
+    if the user tries to pass one that doesn't exist
+    """
+
+    # pylint:disable=unused-argument
+    def _mock_filter_func(prop):
+        return None
+
+    res = instance._check_filter_func(
+        _mock_filter_func, func_kwargs={"arg1": "not-there"}
     )
-    def test_check_filter_func_with_no_args(self, _, kwargs_to_test, expected_value):
-        """
-        Tests that check_filter_func method works expectedly - for filter_func which takes no extra params
-        returns True if args match expected args required by client-side filter function
-        """
+    assert not res[0]
 
-        # pylint:disable=unused-argument
-        def mock_filter_func(prop):
-            return None
 
-        res = self.instance._check_filter_func(
-            mock_filter_func, func_kwargs=kwargs_to_test
-        )
-        self.assertEqual(expected_value, res[0])
+def test_check_filter_func_with_any_typing(instance):
+    """
+    Tests that check_filter_func method works expectedly - for filter_func which takes a param with Any
+    returns True for any args which match.
+    Also tests that variables with no type definition are also accepted (and type checking is ignored)
+    """
 
-    def test_check_filter_func_with_any_typing(self):
-        """
-        Tests that check_filter_func method works expectedly - for filter_func which takes a param with Any
-        returns True for any args which match.
-        Also tests that variables with no type definition are also accepted (and type checking is ignored)
-        """
+    # pylint:disable=unused-argument
+    def _mock_filter_func(prop, arg1, arg2, arg3: Any):
+        return None
 
-        # pylint:disable=unused-argument
-        def mock_filter_func(prop, arg1, arg2, arg3: Any):
-            return None
+    res = instance._check_filter_func(
+        _mock_filter_func, func_kwargs={"arg1": 1, "arg2": bool, "arg3": "string"}
+    )
+    assert res[0]
 
-        res = self.instance._check_filter_func(
-            mock_filter_func, func_kwargs={"arg1": 1, "arg2": bool, "arg3": "string"}
-        )
-        self.assertEqual(True, res[0])
-
-        res = self.instance._check_filter_func(
-            mock_filter_func, func_kwargs={"arg1": 1, "arg2": bool, "arg3": "string"}
-        )
-        self.assertEqual(True, res[0])
+    res = instance._check_filter_func(
+        _mock_filter_func, func_kwargs={"arg1": 1, "arg2": bool, "arg3": "string"}
+    )
+    assert res[0]

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_generic.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_generic.py
@@ -1,5 +1,5 @@
 import unittest
-from parameterized import parameterized
+
 
 from openstack_query.handlers.client_side_handler_generic import (
     ClientSideHandlerGeneric,
@@ -9,6 +9,9 @@ from enums.query.query_presets import QueryPresetsGeneric
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 # pylint:disable=protected-access
+
+
+TEST_CORPUS = [1, "foo", None, {"a": "b"}]
 
 
 class ClientSideHandlerGenericTests(unittest.TestCase):
@@ -27,44 +30,39 @@ class ClientSideHandlerGenericTests(unittest.TestCase):
         }
         self.instance = ClientSideHandlerGeneric(_filter_function_mappings)
 
-    @parameterized.expand(
-        [(f"test {preset.name}", preset) for preset in QueryPresetsGeneric]
-    )
-    def test_check_supported_all_presets(self, _, preset):
+    def test_check_supported_all_presets(self):
         """
         Tests that client_side_handler_generic supports all generic QueryPresets
         """
-        self.assertTrue(self.instance.check_supported(preset, MockProperties.PROP_1))
+        self.assertTrue(
+            self.instance.check_supported(preset, MockProperties.PROP_1)
+            for preset in QueryPresetsGeneric
+        )
 
-    @parameterized.expand(
-        [
-            ("test integer equal", 10, 10, True),
-            ("test string equal", "some-string", "some-string", True),
-            ("test integer not equal", 10, 8, False),
-            ("test string not equal", "some-string", "some-other-string", False),
-            ("test dict equal", {"a": 10}, {"a": 10}, True),
-            ("test dict val not equal", {"a": 12}, {"a": 10}, False),
-            ("test dict keys not equal", {"a": 12, "b": 12}, {"a": 12}, False),
-        ]
-    )
-    def test_prop_equal_to(self, _, prop, value, expected_out):
+    def test_prop_equal_to_valid(self):
         """
         Tests that method prop_equal_to functions expectedly
-        Returns True if prop and value are equal
         """
-        assert self.instance._prop_equal_to(prop, value) == expected_out
+        for i in TEST_CORPUS:
+            assert self.instance._prop_equal_to(i, i)
 
-    @parameterized.expand(
-        [
-            ("test integer equal", 10, 10, False),
-            ("test string equal", "some-string", "some-string", False),
-            ("test integer not equal", 10, 8, True),
-            ("test string not equal", "some-string", "some-other-string", True),
-        ]
-    )
-    def test_prop_not_equal_to(self, _, prop, value, expected_out):
+    def test_prop_equal_to_invalid(self):
+        """
+        Tests that method prop_equal_to functions expectedly
+        """
+        for i in TEST_CORPUS:
+            assert not self.instance._prop_equal_to(i, "not equal")
+
+    def test_prop_not_equal_to_valid(self):
         """
         Tests that method not_prop_equal_to functions expectedly
-        Returns True if prop and value are not equal
         """
-        assert self.instance._prop_not_equal_to(prop, value) == expected_out
+        for i in TEST_CORPUS:
+            assert self.instance._prop_not_equal_to(i, "FOO")
+
+    def test_prop_not_equal_to_invalid(self):
+        """
+        Tests that method not_prop_equal_to functions expectedly
+        """
+        for i in TEST_CORPUS:
+            assert not self.instance._prop_not_equal_to(i, i)

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_integer.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_integer.py
@@ -1,5 +1,5 @@
 import unittest
-from parameterized import parameterized
+
 
 from enums.query.query_presets import QueryPresetsInteger
 
@@ -26,67 +26,43 @@ class ClientSideHandlerIntegerTests(unittest.TestCase):
         }
         self.instance = ClientSideHandlerInteger(_filter_function_mappings)
 
-    @parameterized.expand(
-        [(f"test {preset.name}", preset) for preset in QueryPresetsInteger]
-    )
-    def test_check_supported_all_presets(self, _, preset):
+    def test_check_supported_all_presets(self):
         """
         Tests that client_side_handler_integer supports all integer QueryPresets
         """
-        self.assertTrue(self.instance.check_supported(preset, MockProperties.PROP_1))
+        self.assertTrue(
+            self.instance.check_supported(preset, MockProperties.PROP_1)
+            for preset in QueryPresetsInteger
+        )
 
-    @parameterized.expand(
-        [
-            ("test less than", 8, 10, True),
-            ("test equal", 10, 10, False),
-            ("test greater than", 10, 8, False),
-        ]
-    )
-    def test_prop_less_than(self, _, val1, val2, expected_out):
+    def test_prop_less_than(self):
         """
         Tests that method prop_less_than functions expectedly
         Returns True if val1 is less than val2
         """
-        assert self.instance._prop_less_than(val1, val2) == expected_out
+        for i, expected in (1, True), (2, False):
+            assert self.instance._prop_less_than(i, 2) == expected
 
-    @parameterized.expand(
-        [
-            ("test less than", 8, 10, False),
-            ("test equal", 10, 10, False),
-            ("test greater than", 10, 8, True),
-        ]
-    )
-    def test_prop_greater_than(self, _, val1, val2, expected_out):
+    def test_prop_greater_than(self):
         """
         Tests that method prop_greater_than functions expectedly
         Returns True if val1 is greater than val2
         """
-        assert self.instance._prop_greater_than(val1, val2) == expected_out
+        for i, expected in (1, False), (2, False), (3, True):
+            assert self.instance._prop_greater_than(i, 2) == expected
 
-    @parameterized.expand(
-        [
-            ("test less than", 8, 10, True),
-            ("test equal", 10, 10, True),
-            ("test greater than", 10, 8, False),
-        ]
-    )
-    def test_prop_less_than_or_equal_to(self, _, val1, val2, expected_out):
+    def test_prop_less_than_or_equal_to(self):
         """
         Tests that method prop_less_than_or_equal_to functions expectedly
         Returns True if val1 is less than or equal to val2
         """
-        assert self.instance._prop_less_than_or_equal_to(val1, val2) == expected_out
+        for i, expected in (1, True), (2, True), (3, False):
+            assert self.instance._prop_less_than_or_equal_to(i, 2) == expected
 
-    @parameterized.expand(
-        [
-            ("test less than", 8, 10, False),
-            ("test equal", 10, 10, True),
-            ("test greater than", 10, 8, True),
-        ]
-    )
-    def test_prop_greater_than_or_equal_to(self, _, val1, val2, expected_out):
+    def test_prop_greater_than_or_equal_to(self):
         """
         Tests that method prop_greater_than_or_equal_to functions expectedly
         Returns True if val1 is greater than or equal to val2
         """
-        assert self.instance._prop_greater_than_or_equal_to(val1, val2) == expected_out
+        for i, expected in (1, False), (2, True), (3, True):
+            assert self.instance._prop_greater_than_or_equal_to(i, 2) == expected

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_string.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_string.py
@@ -1,99 +1,112 @@
-import unittest
 from unittest.mock import patch, NonCallableMock
-from parameterized import parameterized
 
-from nose.tools import raises
-
-from openstack_query.handlers.client_side_handler_string import ClientSideHandlerString
+import pytest
 
 from enums.query.query_presets import QueryPresetsString
 from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
-
+from openstack_query.handlers.client_side_handler_string import ClientSideHandlerString
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
 
 # pylint:disable=protected-access
 
 
-class ClientSideHandlerStringTests(unittest.TestCase):
+@pytest.fixture(name="instance")
+def instance_fixture():
     """
-    Run various tests to ensure that ClientSideHandlerString class methods function expectedly
+    Prepares an instance to be used in tests
     """
+    _filter_function_mappings = {
+        preset: [MockProperties.PROP_1] for preset in QueryPresetsString
+    }
+    return ClientSideHandlerString(_filter_function_mappings)
 
-    def setUp(self):
-        """
-        Setup for tests
-        """
-        super().setUp()
-        _filter_function_mappings = {
-            preset: [MockProperties.PROP_1] for preset in QueryPresetsString
-        }
-        self.instance = ClientSideHandlerString(_filter_function_mappings)
 
-    @parameterized.expand(
-        [(f"test {preset.name}", preset) for preset in QueryPresetsString]
+def test_check_supported_all_presets(instance):
+    """
+    Tests that client_side_handler_string supports all string QueryPresets
+    """
+    assert (
+        instance.check_supported(preset, MockProperties.PROP_1)
+        for preset in QueryPresetsString
     )
-    def test_check_supported_all_presets(self, _, preset):
-        """
-        Tests that client_side_handler_string supports all string QueryPresets
-        """
-        self.assertTrue(self.instance.check_supported(preset, MockProperties.PROP_1))
 
-    @parameterized.expand(
-        [
-            ("Numeric digits only", "[0-9]+", "123"),
-            ("Alphabetic characters only", "[A-Za-z]+", "abc"),
-            ("No alphabetic characters", "[A-Za-z]+", "123"),
-            ("Alphabetic and numeric characters", "[A-Za-z0-9]+", "abc123"),
-            ("Empty string, no match", "[A-Za-z]+", ""),
-        ]
-    )
-    @patch("re.match")
-    @patch("re.compile")
-    def test_prop_matches_regex_valid(
-        self, _, regex_string, test_prop, mock_regex_compile, mock_regex_match
-    ):
-        """
-        Tests that method prop_matches_regex functions expectedly - with valid regex patterns
-        Returns True if test_prop matches given regex pattern regex_string
-        """
-        mock_compile = NonCallableMock()
-        mock_regex_match.return_value = test_prop
-        mock_regex_compile.return_value = mock_compile
-        self.instance._prop_matches_regex(test_prop, regex_string)
-        mock_regex_match.assert_called_once_with(mock_compile, test_prop)
-        mock_regex_compile.assert_called_once_with(regex_string)
 
-    @parameterized.expand(
-        [
-            ("item is in", ["val1", "val2", "val3"], "val1", True),
-            ("item is not in", ["val1", "val2"], "val3", False),
-        ]
-    )
-    def test_prop_any_in(self, _, val_list, test_prop, expected_out):
-        """
-        Tests that method prop_any_in functions expectedly
-        Returns True if test_prop matches any values in a given list val_list
-        """
-        out = self.instance._prop_any_in(test_prop, val_list)
-        assert out == expected_out
+@pytest.mark.parametrize(
+    "regex_string, test_prop",
+    [
+        # "Numeric digits only",
+        ("[0-9]+", "123"),
+        # "Alphabetic characters only",
+        ("[A-Za-z]+", "abc"),
+        # "No alphabetic characters",
+        ("[A-Za-z]+", "123"),
+        # "Alphabetic and numeric characters",
+        ("[A-Za-z0-9]+", "abc123"),
+        # "Empty string, no match",
+        ("[A-Za-z]+", ""),
+    ],
+)
+@patch("re.match")
+@patch("re.compile")
+def test_prop_matches_regex_valid(
+    mock_regex_compile, mock_regex_match, regex_string, test_prop, instance
+):
+    """
+    Tests that method prop_matches_regex functions expectedly - with valid regex patterns
+    Returns True if test_prop matches given regex pattern regex_string
+    """
+    mock_compile = NonCallableMock()
+    mock_regex_match.return_value = test_prop
+    mock_regex_compile.return_value = mock_compile
+    instance._prop_matches_regex(test_prop, regex_string)
+    mock_regex_match.assert_called_once_with(mock_compile, test_prop)
+    mock_regex_compile.assert_called_once_with(regex_string)
 
-    @raises(MissingMandatoryParamError)
-    def test_prop_any_in_empty_list(self):
-        """
-        Tests that method prop_any_in functions expectedly - when given empty list raise error
-        """
-        self.instance._prop_any_in("some-prop-val", [])
 
-    @parameterized.expand(
-        [
-            ("item is in", ["val1", "val2", "val3"], "val1", False),
-            ("item is not in", ["val1", "val2"], "val3", True),
-        ]
-    )
-    def test_prop_not_any_in(self, _, val_list, test_prop, expected_out):
-        """
-        Tests that method prop_any_not_in functions expectedly
-        Returns True if test_prop does not match any values in a given list val_list
-        """
-        out = self.instance._prop_not_any_in(test_prop, val_list)
-        assert out == expected_out
+def test_prop_any_in_when_there(instance):
+    """
+    Tests that method prop_any_in functions expectedly
+    Returns True if test_prop matches any values in a given list val_list
+    """
+    test_prop = "val3"
+    val_list = ["val1", "val2", "val3"]
+    assert instance._prop_any_in(test_prop, val_list)
+
+
+def test_prop_any_in_when_not_there(instance):
+    """
+    Tests that method prop_any_in functions expectedly
+    Returns True if test_prop matches any values in a given list val_list
+    """
+    test_prop = "val3"
+    val_list = ["val1", "val2"]
+    assert not instance._prop_any_in(test_prop, val_list)
+
+
+def test_prop_any_in_empty_list(instance):
+    """
+    Tests that method prop_any_in functions expectedly - when given empty list raise error
+    """
+    with pytest.raises(MissingMandatoryParamError):
+        instance._prop_any_in("some-prop-val", [])
+
+
+def test_prop_not_any_in_when_there(instance):
+    """
+    Tests that method prop_any_not_in functions expectedly
+    Returns True if test_prop does not match any values in a given list val_list
+    """
+    val_list = ["val1", "val2", "val3"]
+    test_prop = "val3"
+    assert not instance._prop_not_any_in(test_prop, val_list)
+
+
+def test_prop_not_any_in_when_not_there(instance):
+    """
+    Tests that method prop_any_not_in functions expectedly
+    Returns True if test_prop does not match any values in a given list val_list
+    """
+    val_list = ["val1", "val2"]
+    test_prop = "val3"
+    assert instance._prop_not_any_in(test_prop, val_list)

--- a/tests/lib/openstack_query/handlers/test_server_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_server_side_handler.py
@@ -1,199 +1,182 @@
-import unittest
 from unittest.mock import MagicMock, patch, NonCallableMock
-from parameterized import parameterized
 
-from openstack_query.handlers.server_side_handler import ServerSideHandler
+import pytest
+
 from exceptions.query_preset_mapping_error import QueryPresetMappingError
-
-from tests.lib.openstack_query.mocks.mocked_query_presets import MockQueryPresets
+from openstack_query.handlers.server_side_handler import ServerSideHandler
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+from tests.lib.openstack_query.mocks.mocked_query_presets import MockQueryPresets
+
 
 # pylint:disable=protected-access, unnecessary-lambda-assignment
 
 
-class ServerSideHandlerTests(unittest.TestCase):
+@pytest.fixture(name="instance")
+def instance_fixture():
     """
-    Runs various tests to ensure that ServerSideHandler class methods function expectedly
+    Prepares an instance to be used in tests
+    """
+    server_side_function_mappings = {
+        MockQueryPresets.ITEM_1: {
+            MockProperties.PROP_1: "item1-prop1-kwarg",
+            MockProperties.PROP_2: "item2-prop2-kwarg",
+        },
+        MockQueryPresets.ITEM_2: {
+            MockProperties.PROP_3: "item2-prop3-kwarg",
+            MockProperties.PROP_4: "item2-prop4-kwarg",
+        },
+    }
+    return ServerSideHandler(server_side_function_mappings)
+
+
+def test_check_supported_true(instance):
+    """
+    Tests that check_supported method works expectedly
+    returns True if Prop Enum and Preset Enum have server-side mapping
+    """
+    assert instance.check_supported(MockQueryPresets.ITEM_1, MockProperties.PROP_1)
+
+
+def test_check_supported_false(instance):
+    """
+    Tests that check_supported method works expectedly
+    returns False if either Preset is not supported or Preset-Prop does not have a mapping
     """
 
-    def setUp(self):
-        """
-        Setup for tests
-        """
-        super().setUp()
+    # when preset is not supported
+    assert not instance.check_supported(MockQueryPresets.ITEM_3, MockProperties.PROP_1)
 
-        server_side_function_mappings = {
-            MockQueryPresets.ITEM_1: {
-                MockProperties.PROP_1: "item1-prop1-kwarg",
-                MockProperties.PROP_2: "item2-prop2-kwarg",
-            },
-            MockQueryPresets.ITEM_2: {
-                MockProperties.PROP_3: "item2-prop3-kwarg",
-                MockProperties.PROP_4: "item2-prop4-kwarg",
-            },
-        }
-        self.instance = ServerSideHandler(server_side_function_mappings)
+    # when preset found, but prop is not supported
+    assert not instance.check_supported(MockQueryPresets.ITEM_1, MockProperties.PROP_3)
 
-    def test_check_supported_true(self):
-        """
-        Tests that check_supported method works expectedly
-        returns True if Prop Enum and Preset Enum have server-side mapping
-        """
-        self.assertTrue(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_1, MockProperties.PROP_1
-            )
-        )
 
-    def test_check_supported_false(self):
-        """
-        Tests that check_supported method works expectedly
-        returns False if either Preset is not supported or Preset-Prop does not have a mapping
-        """
-
-        # when preset is not supported
-        self.assertFalse(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_3, MockProperties.PROP_1
-            )
-        )
-
-        # when preset found, but prop is not supported
-        self.assertFalse(
-            self.instance.check_supported(
-                MockQueryPresets.ITEM_1, MockProperties.PROP_3
-            )
-        )
-
-    def test_get_mapping_valid(self):
-        """
-        Tests that get_mapping method works expectedly
-        returns server-side filter func if Prop Enum and Preset Enum are supported
-        """
-        self.assertEqual(
-            self.instance._get_mapping(MockQueryPresets.ITEM_1, MockProperties.PROP_1),
-            "item1-prop1-kwarg",
-        )
-
-    def test_get_mapping_invalid(self):
-        """
-        Tests that get_mapping method works expectedly
-        returns None if Prop Enum and Preset Enum are not supported or don't have a mapping
-        """
-        # when preset is not supported
-        self.assertIsNone(
-            self.instance._get_mapping(MockQueryPresets.ITEM_3, MockProperties.PROP_1)
-        )
-
-        # when preset found, but prop is not supported
-        self.assertIsNone(
-            self.instance._get_mapping(MockQueryPresets.ITEM_1, MockProperties.PROP_3)
-        )
-
-    @patch(
-        "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
+def test_get_mapping_valid(instance):
+    """
+    Tests that get_mapping method works expectedly
+    returns server-side filter func if Prop Enum and Preset Enum are supported
+    """
+    assert (
+        instance._get_mapping(MockQueryPresets.ITEM_1, MockProperties.PROP_1)
+        == "item1-prop1-kwarg"
     )
-    @patch(
-        "openstack_query.handlers.server_side_handler.ServerSideHandler._get_mapping"
+
+
+def test_get_mapping_invalid(instance):
+    """
+    Tests that get_mapping method works expectedly
+    returns None if Prop Enum and Preset Enum are not supported or don't have a mapping
+    """
+    # when preset is not supported
+    assert instance._get_mapping(MockQueryPresets.ITEM_3, MockProperties.PROP_1) is None
+
+    # when preset found, but prop is not supported
+    assert instance._get_mapping(MockQueryPresets.ITEM_1, MockProperties.PROP_3) is None
+
+
+@patch(
+    "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
+)
+@patch("openstack_query.handlers.server_side_handler.ServerSideHandler._get_mapping")
+def test_get_filters_valid(mock_get_mapping, mock_check_filter_mapping, instance):
+    """
+    Tests that get_filters method works expectedly
+    returns server-side filters as a set of kwargs
+        - Prop Enum and Preset Enum are supported
+        - and filter_params are valid
+    """
+    mock_params = {"arg1": "val1", "arg2": "val2"}
+    mock_filter_func = MagicMock()
+
+    mock_filters = NonCallableMock()
+    mock_filter_func.return_value = mock_filters
+
+    mock_check_filter_mapping.return_value = True, ""
+    mock_get_mapping.return_value = mock_filter_func
+
+    res = instance.get_filters(
+        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
     )
-    def test_get_filters_valid(self, mock_get_mapping, mock_check_filter_mapping):
-        """
-        Tests that get_filters method works expectedly
-        returns server-side filters as a set of kwargs
-            - Prop Enum and Preset Enum are supported
-            - and filter_params are valid
-        """
-        mock_params = {"arg1": "val1", "arg2": "val2"}
-        mock_filter_func = MagicMock()
 
-        mock_filters = NonCallableMock()
-        mock_filter_func.return_value = mock_filters
+    mock_check_filter_mapping.assert_called_once_with(mock_filter_func, mock_params)
+    mock_filter_func.assert_called_once_with(**mock_params)
+    assert res == mock_filters
 
-        mock_check_filter_mapping.return_value = True, ""
-        mock_get_mapping.return_value = mock_filter_func
 
-        res = self.instance.get_filters(
+@patch(
+    "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
+)
+def test_get_filters_invalid(mock_check_filter_mapping, instance):
+    """
+    Tests that get_filters method works expectedly
+    raises QueryPresetMappingError if:
+        - Prop Enum and Preset Enum are not supported
+        - or filter_params is not valid
+    """
+    mock_params = {"arg1": "val1", "arg2": "val2"}
+
+    # when preset/prop not supported
+    res = instance.get_filters(
+        MockQueryPresets.ITEM_3, MockProperties.PROP_1, mock_params
+    )
+    assert res is None
+
+    # when preset/prop are supported, but wrong filter_params
+    mock_check_filter_mapping.return_value = False, "some-reason"
+    with pytest.raises(QueryPresetMappingError):
+        instance.get_filters(
             MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
         )
 
-        mock_check_filter_mapping.assert_called_once_with(mock_filter_func, mock_params)
-        mock_filter_func.assert_called_once_with(**mock_params)
-        self.assertEqual(res, mock_filters)
 
-    @patch(
-        "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
+@pytest.mark.parametrize(
+    "valid_params_to_test",
+    [
+        # "required args only",
+        {"arg1": 12},
+        # "required and default"
+        {"arg1": 12, "arg2": "non-default"},
+        # "required and kwarg"
+        {"arg1": 12, "some_kwarg": "some-val"},
+        # "all possible"
+        {"arg1": 12, "arg2": "non-default", "some_kwarg": "some-val"},
+        # "different order"
+        {"arg2": "non-default", "some_kwarg": "some-val", "arg1": 12},
+    ],
+)
+def test_check_filter_mapping_valid(valid_params_to_test, instance):
+    """
+    Tests that check_filter_mapping method works expectedly - valid
+    returns True only if args match expected args required by filter function lambda
+    """
+    mock_server_side_mapping = lambda arg1, arg2="some-default", **kwargs: {
+        "kwarg1": "val1"
+    }
+    assert instance._check_filter_mapping(
+        mock_server_side_mapping, filter_params=valid_params_to_test
+    )[0]
+
+
+def test_check_filter_mapping_invalid_positional(instance):
+    """
+    Tests that check_filter_mapping method works expectedly - invalid positional args
+    returns False if args don't match expected positional args required by filter function lambda
+    """
+    mock_server_side_mapping = lambda arg1: {"kwarg1": "val1"}
+    assert not (
+        instance._check_filter_mapping(
+            mock_server_side_mapping, filter_params={"arg2": "val2"}
+        )[0]
     )
-    def test_get_filters_invalid(self, mock_check_filter_mapping):
-        """
-        Tests that get_filters method works expectedly
-        raises QueryPresetMappingError if:
-            - Prop Enum and Preset Enum are not supported
-            - or filter_params is not valid
-        """
-        mock_params = {"arg1": "val1", "arg2": "val2"}
 
-        # when preset/prop not supported
-        res = self.instance.get_filters(
-            MockQueryPresets.ITEM_3, MockProperties.PROP_1, mock_params
-        )
-        self.assertIsNone(res)
 
-        # when preset/prop are supported, but wrong filter_params
-        mock_check_filter_mapping.return_value = False, "some-reason"
-        with self.assertRaises(QueryPresetMappingError):
-            self.instance.get_filters(
-                MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
-            )
-
-    @parameterized.expand(
-        [
-            ("required args only", {"arg1": 12}),
-            ("required and default", {"arg1": 12, "arg2": "non-default"}),
-            ("required and kwarg", {"arg1": 12, "some_kwarg": "some-val"}),
-            (
-                "all possible",
-                {"arg1": 12, "arg2": "non-default", "some_kwarg": "some-val"},
-            ),
-            (
-                "different order",
-                {"arg2": "non-default", "some_kwarg": "some-val", "arg1": 12},
-            ),
-        ]
+def test_check_filter_mapping_invalid_kwargs(instance):
+    """
+    Tests that check_filter_mapping method works expectedly - invalid key-word args
+    returns False if kwargs is passed and is used that is required
+    """
+    mock_server_side_mapping = lambda **kwargs: {"arg": kwargs["val1"]}
+    assert not (
+        instance._check_filter_mapping(
+            mock_server_side_mapping, filter_params={"arg2": "val2"}
+        )[0]
     )
-    def test_check_filter_mapping_valid(self, _, valid_params_to_test):
-        """
-        Tests that check_filter_mapping method works expectedly - valid
-        returns True only if args match expected args required by filter function lambda
-        """
-        mock_server_side_mapping = lambda arg1, arg2="some-default", **kwargs: {
-            "kwarg1": "val1"
-        }
-        self.assertTrue(
-            self.instance._check_filter_mapping(
-                mock_server_side_mapping, filter_params=valid_params_to_test
-            )[0]
-        )
-
-    def test_check_filter_mapping_invalid_positional(self):
-        """
-        Tests that check_filter_mapping method works expectedly - invalid positional args
-        returns False if args don't match expected positional args required by filter function lambda
-        """
-        mock_server_side_mapping = lambda arg1: {"kwarg1": "val1"}
-        self.assertFalse(
-            self.instance._check_filter_mapping(
-                mock_server_side_mapping, filter_params={"arg2": "val2"}
-            )[0]
-        )
-
-    def test_check_filter_mapping_invalid_kwargs(self):
-        """
-        Tests that check_filter_mapping method works expectedly - invalid key-word args
-        returns False if kwargs is passed and is used that is required
-        """
-        mock_server_side_mapping = lambda **kwargs: {"arg": kwargs["val1"]}
-        self.assertFalse(
-            self.instance._check_filter_mapping(
-                mock_server_side_mapping, filter_params={"arg2": "val2"}
-            )[0]
-        )


### PR DESCRIPTION
### Description:

As part of the ongoing pytest migration, port
lib/openstack_query/handlers to use pytest

The test for `handler_base` has been removed, as there was nothing to test following an earlier PR which changed it to effectively an interface