### PR TITLE
MAINT: Port tests in lib/query/managers to pytest

### DIFF
--- a/tests/lib/openstack_query/managers/test_query_manager.py
+++ b/tests/lib/openstack_query/managers/test_query_manager.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch, NonCallableMock
+
+import pytest
 from parameterized import parameterized
-from nose.tools import raises
 
 from openstack_query.managers.query_manager import QueryManager
 from enums.query.query_output_types import QueryOutputTypes
@@ -119,12 +120,12 @@ class QueryManagerTests(unittest.TestCase):
         """
         self.assertIsNotNone(self.instance._get_query_output(outtype))
 
-    @raises(EnumMappingError)
     def test_get_query_output_raises_error(self):
         """
         Tests that query output type raises error when given an enum which does not have a mapping
         """
-        self.instance._get_query_output(MagicMock())
+        with pytest.raises(EnumMappingError):
+            self.instance._get_query_output(MagicMock())
 
     def _run_populate_output_params_check(self, mock_output_details):
         self.instance._populate_output_params(output_details=mock_output_details)

--- a/tests/lib/openstack_query/managers/test_user_manager.py
+++ b/tests/lib/openstack_query/managers/test_user_manager.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
 
-from nose.tools import raises
 
 from exceptions.parse_query_error import ParseQueryError
 from openstack_query.managers.user_manager import UserManager
@@ -25,7 +24,6 @@ class QueryManagerTests(unittest.TestCase):
         self.prop_cls = MagicMock()
         self.instance = UserManager(cloud_account="test_account")
 
-    @raises(ParseQueryError)
     def test_search_datetime_raise_error(self):
         """
         Test that ParseQueryError is raised when someone tries to query
@@ -36,4 +34,5 @@ class QueryManagerTests(unittest.TestCase):
             "property_to_search_by": "mock_prop",
             "date 1": "2023-08-01",
         }
-        self.instance.search_by_datetime(**mock_kwargs)
+        with self.assertRaises(ParseQueryError):
+            self.instance.search_by_datetime(**mock_kwargs)


### PR DESCRIPTION
### Description:
Ports the tests found in lib/query/manages to pytest as part of the ongoing migration

