### PR TITLE
Prop enum and *Query refactor

### DIFF
--- a/lib/enums/query/props/prop_enum.py
+++ b/lib/enums/query/props/prop_enum.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from enum import Enum
-from typing import Callable, Any, Optional
+from typing import Callable, Any, Optional, Type
+
+from exceptions.parse_query_error import ParseQueryError
 
 PropFunc = Callable[[Any], Any]
 
@@ -9,6 +13,19 @@ class PropEnum(Enum):
     """
     An enum base class for all openstack resource properties - for type annotation purposes
     """
+
+    @staticmethod
+    def _from_string_impl(val: str, prop_cls: Type[PropEnum]):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return prop_cls[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find property {val}. "
+                f"Available properties are {','.join([prop.name for prop in prop_cls])}"
+            ) from err
 
     @staticmethod
     @abstractmethod

--- a/lib/enums/query/props/server_properties.py
+++ b/lib/enums/query/props/server_properties.py
@@ -1,6 +1,5 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
 
@@ -26,13 +25,7 @@ class ServerProperties(PropEnum):
         """
         Converts a given string in a case-insensitive way to the enum values
         """
-        try:
-            return ServerProperties[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find Server Property {val}. "
-                f"Available properties are {','.join([prop.name for prop in ServerProperties])}"
-            ) from err
+        return ServerProperties._from_string_impl(val, ServerProperties)
 
     @staticmethod
     def get_prop_mapping(prop):

--- a/lib/enums/query/props/user_properties.py
+++ b/lib/enums/query/props/user_properties.py
@@ -1,6 +1,5 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
 
@@ -20,13 +19,7 @@ class UserProperties(PropEnum):
         """
         Converts a given string in a case-insensitive way to the enum values
         """
-        try:
-            return UserProperties[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find User Property {val}. "
-                f"Available properties are {','.join([prop.name for prop in UserProperties])}"
-            ) from err
+        return UserProperties._from_string_impl(val, UserProperties)
 
     @staticmethod
     def get_prop_mapping(prop):

--- a/lib/openstack_query/queries/query_wrapper.py
+++ b/lib/openstack_query/queries/query_wrapper.py
@@ -1,9 +1,12 @@
+from enums.query.props.prop_enum import PropEnum
 from openstack_query.query_output import QueryOutput
 from openstack_query.query_builder import QueryBuilder
 from openstack_query.query_parser import QueryParser
 
 from openstack_query.query_methods import QueryMethods
 from openstack_query.query_base import QueryBase
+from openstack_query.runners.query_runner import QueryRunner
+
 
 # pylint:disable=too-few-public-methods
 
@@ -15,13 +18,20 @@ class QueryWrapper(QueryMethods, QueryBase):
     QueryWrapper is a base class for all Query<Resource> subclasses
     """
 
-    def __init__(self):
-        self._query_results = []
-        self.runner = self.runner_cls(self.prop_enum_cls)
-        self.output = QueryOutput(self.prop_enum_cls)
-        self.parser = QueryParser(self.prop_enum_cls)
+    def __init__(self, query_runner: QueryRunner, prop_enum_cls: PropEnum):
+        self.runner = query_runner
+        self.output = QueryOutput(prop_enum_cls)
+        self.parser = QueryParser(prop_enum_cls)
         self.builder = QueryBuilder(
-            self.prop_enum_cls,
+            prop_enum_cls,
             self._get_client_side_handlers().to_list(),
             self._get_server_side_handler(),
         )
+        super().__init__(
+            builder=self.builder,
+            runner=self.runner,
+            parser=self.parser,
+            output=self.output,
+        )
+
+        self._query_results = []

--- a/lib/openstack_query/queries/query_wrapper.py
+++ b/lib/openstack_query/queries/query_wrapper.py
@@ -1,11 +1,9 @@
-from enums.query.props.prop_enum import PropEnum
 from openstack_query.query_output import QueryOutput
 from openstack_query.query_builder import QueryBuilder
 from openstack_query.query_parser import QueryParser
 
 from openstack_query.query_methods import QueryMethods
 from openstack_query.query_base import QueryBase
-from openstack_query.runners.query_runner import QueryRunner
 
 
 # pylint:disable=too-few-public-methods
@@ -18,18 +16,17 @@ class QueryWrapper(QueryMethods, QueryBase):
     QueryWrapper is a base class for all Query<Resource> subclasses
     """
 
-    def __init__(self, query_runner: QueryRunner, prop_enum_cls: PropEnum):
-        self.runner = query_runner
-        self.output = QueryOutput(prop_enum_cls)
-        self.parser = QueryParser(prop_enum_cls)
+    def __init__(self):
+        self.output = QueryOutput(self.prop_mapping)
+        self.parser = QueryParser(self.prop_mapping)
         self.builder = QueryBuilder(
-            prop_enum_cls,
+            self.prop_mapping,
             self._get_client_side_handlers().to_list(),
             self._get_server_side_handler(),
         )
         super().__init__(
             builder=self.builder,
-            runner=self.runner,
+            runner=self.query_runner,
             parser=self.parser,
             output=self.output,
         )

--- a/lib/openstack_query/queries/server_query.py
+++ b/lib/openstack_query/queries/server_query.py
@@ -33,10 +33,16 @@ class ServerQuery(QueryWrapper):
 
     @property
     def prop_mapping(self) -> Type[ServerProperties]:
+        """
+        Returns the enum this query class uses to map property names to openstack server properties
+        """
         return ServerProperties
 
     @property
     def query_runner(self) -> ServerRunner:
+        """
+        Instantiates and returns a ServerRunner object with the correct property mapping pre-defined
+        """
         return ServerRunner(self.prop_mapping)
 
     def _get_server_side_handler(self) -> ServerSideHandler:

--- a/lib/openstack_query/queries/server_query.py
+++ b/lib/openstack_query/queries/server_query.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 from structs.query.query_client_side_handlers import QueryClientSideHandlers
 
 from enums.query.props.server_properties import ServerProperties
@@ -22,8 +24,6 @@ from openstack_query.runners.server_runner import ServerRunner
 
 from openstack_query.time_utils import TimeUtils
 
-# pylint:disable=too-few-public-methods
-
 
 class ServerQuery(QueryWrapper):
     """
@@ -31,8 +31,13 @@ class ServerQuery(QueryWrapper):
     Define property mappings, kwarg mappings and filter function mappings related to servers here
     """
 
-    prop_enum_cls = ServerProperties
-    runner_cls = ServerRunner
+    @property
+    def prop_mapping(self) -> Type[ServerProperties]:
+        return ServerProperties
+
+    @property
+    def query_runner(self) -> ServerRunner:
+        return ServerRunner(self.prop_mapping)
 
     def _get_server_side_handler(self) -> ServerSideHandler:
         """

--- a/lib/openstack_query/queries/user_query.py
+++ b/lib/openstack_query/queries/user_query.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 from structs.query.query_client_side_handlers import QueryClientSideHandlers
 
 from enums.query.props.user_properties import UserProperties
@@ -17,24 +19,25 @@ from openstack_query.queries.query_wrapper import QueryWrapper
 from openstack_query.runners.user_runner import UserRunner
 
 
-# pylint:disable=too-few-public-methods
-
-
 class UserQuery(QueryWrapper):
     """
     Query class for querying Openstack User objects.
     Define property mappings, kwarg mappings and filter function mappings related to users here
     """
 
-    def __init__(
-        self, prop_enum_cls: UserProperties = None, query_runner: UserRunner = None
-    ):
-        prop_enum_cls = UserProperties if prop_enum_cls is None else prop_enum_cls
-        query_runner = (
-            UserRunner(prop_enum_cls) if query_runner is None else query_runner
-        )
+    @property
+    def prop_mapping(self) -> Type[UserProperties]:
+        """
+        Property enum class for users
+        """
+        return UserProperties
 
-        super().__init__(query_runner=query_runner, prop_enum_cls=prop_enum_cls)
+    @property
+    def query_runner(self) -> UserRunner:
+        """
+        Constructs a QueryRunner class for users
+        """
+        return UserRunner(self.prop_mapping)
 
     def _get_server_side_handler(self) -> ServerSideHandler:
         """

--- a/lib/openstack_query/queries/user_query.py
+++ b/lib/openstack_query/queries/user_query.py
@@ -26,8 +26,15 @@ class UserQuery(QueryWrapper):
     Define property mappings, kwarg mappings and filter function mappings related to users here
     """
 
-    prop_enum_cls = UserProperties
-    runner_cls = UserRunner
+    def __init__(
+        self, prop_enum_cls: UserProperties = None, query_runner: UserRunner = None
+    ):
+        prop_enum_cls = UserProperties if prop_enum_cls is None else prop_enum_cls
+        query_runner = (
+            UserRunner(prop_enum_cls) if query_runner is None else query_runner
+        )
+
+        super().__init__(query_runner=query_runner, prop_enum_cls=prop_enum_cls)
 
     def _get_server_side_handler(self) -> ServerSideHandler:
         """

--- a/lib/openstack_query/query_base.py
+++ b/lib/openstack_query/query_base.py
@@ -1,9 +1,12 @@
 from abc import ABC, abstractmethod
-from structs.query.query_client_side_handlers import QueryClientSideHandlers
+from typing import Type
+from typing import TypeVar
 
 from openstack_query.handlers.server_side_handler import ServerSideHandler
+from openstack_query.runners.query_runner import QueryRunner
+from structs.query.query_client_side_handlers import QueryClientSideHandlers
 
-# pylint:disable=too-few-public-methods
+AnyPropEnum = TypeVar("AnyPropEnum", bound=Type["PropEnum"])
 
 
 class QueryBase(ABC):
@@ -11,6 +14,20 @@ class QueryBase(ABC):
     Abstract Base class. This class defines abstract getter methods to enforce Query classes implement
     server-side, client-side and property handlers correctly
     """
+
+    @property
+    @abstractmethod
+    def prop_mapping(self) -> Type[AnyPropEnum]:
+        """
+        Returns the correct mapping for a given query class
+        """
+
+    @property
+    @abstractmethod
+    def query_runner(self) -> QueryRunner:
+        """
+        Returns an instance for a given query class
+        """
 
     @abstractmethod
     def _get_server_side_handler(self) -> ServerSideHandler:

--- a/lib/openstack_query/query_base.py
+++ b/lib/openstack_query/query_base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Type
-from typing import TypeVar
+from typing import Type, TypeVar
 
 from openstack_query.handlers.server_side_handler import ServerSideHandler
 from openstack_query.runners.query_runner import QueryRunner

--- a/lib/openstack_query/runners/query_runner.py
+++ b/lib/openstack_query/runners/query_runner.py
@@ -1,18 +1,17 @@
-from abc import abstractmethod
-import time
 import logging
-from typing import Optional, List, Any, Dict, Callable
+import time
+from abc import abstractmethod
+from typing import Optional, List, Any, Dict, Callable, Type
 
-from enums.cloud_domains import CloudDomains
-
-from openstack_api.openstack_wrapper_base import OpenstackWrapperBase
-from openstack_api.openstack_connection import OpenstackConnection
 from custom_types.openstack_query.aliases import (
-    PropFunc,
     ServerSideFilters,
     ClientSideFilterFunc,
     OpenstackResourceObj,
 )
+from enums.cloud_domains import CloudDomains
+from enums.query.props.prop_enum import PropEnum
+from openstack_api.openstack_connection import OpenstackConnection
+from openstack_api.openstack_wrapper_base import OpenstackWrapperBase
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +28,9 @@ class QueryRunner(OpenstackWrapperBase):
     _LIMIT_FOR_PAGINATION = 1000
     _PAGINATION_CALL_LIMIT = 1000
 
-    def __init__(self, marker_prop_func: PropFunc, connection_cls=OpenstackConnection):
+    def __init__(self, prop_enum: Type[PropEnum], connection_cls=OpenstackConnection):
         OpenstackWrapperBase.__init__(self, connection_cls)
-        self._page_marker_prop_func = marker_prop_func
+        self._prop_enum = prop_enum
 
     def run(
         self,
@@ -155,7 +154,7 @@ class QueryRunner(OpenstackWrapperBase):
                 if i == self._LIMIT_FOR_PAGINATION - 1:
                     # restart the for loop with marker set
                     paginated_filters.update(
-                        {"marker": self._page_marker_prop_func(resource)}
+                        {"marker": self._prop_enum.get_prop_mapping(resource)}
                     )
                     logger.debug(
                         "page limit reached: %s - setting new marker: %s",

--- a/lib/openstack_query/runners/user_runner.py
+++ b/lib/openstack_query/runners/user_runner.py
@@ -9,7 +9,6 @@ from openstack_query.runners.query_runner import QueryRunner
 from exceptions.parse_query_error import ParseQueryError
 from exceptions.enum_mapping_error import EnumMappingError
 
-from enums.query.props.user_properties import UserProperties
 from enums.user_domains import UserDomains
 
 logger = logging.getLogger(__name__)
@@ -24,14 +23,6 @@ class UserRunner(QueryRunner):
     """
 
     DEFAULT_DOMAIN = UserDomains.STFC
-
-    @staticmethod
-    def _get_marker(obj: User) -> str:
-        """
-        This method returns the marker value for a User object, required for pagination
-        :param obj: An Server object to get the marker property for
-        """
-        return UserProperties.get_prop_mapping("id")(obj)
 
     def _parse_meta_params(
         self, conn: OpenstackConnection, from_domain: Optional[UserDomains] = None

--- a/tests/enums/props/test_server_properties.py
+++ b/tests/enums/props/test_server_properties.py
@@ -1,15 +1,14 @@
 from unittest.mock import patch
-from parameterized import parameterized
+
+import pytest
 
 from enums.query.props.server_properties import ServerProperties
-from nose.tools import raises
-
 from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
-@parameterized(list(ServerProperties))
+@pytest.mark.parametrize("prop", list(ServerProperties))
 def test_get_prop_mapping(prop):
     """
     Tests that all server properties have a property function mapping
@@ -17,12 +16,12 @@ def test_get_prop_mapping(prop):
     ServerProperties.get_prop_mapping(prop)
 
 
-@raises(QueryPropertyMappingError)
 def test_get_prop_mapping_invalid():
     """
     Tests that get_prop_mapping returns Error if property not supported
     """
-    ServerProperties.get_prop_mapping(MockProperties.PROP_1)
+    with pytest.raises(QueryPropertyMappingError):
+        ServerProperties.get_prop_mapping(MockProperties.PROP_1)
 
 
 @patch("enums.query.props.server_properties.ServerProperties.get_prop_mapping")
@@ -35,7 +34,7 @@ def test_get_marker_prop_func(mock_get_prop_func):
     assert val == mock_get_prop_func.return_value
 
 
-@parameterized(["flavor_id", "Flavor_ID", "FlAvOr_Id"])
+@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id"])
 def test_flavor_id_serialization(val):
     """
     Tests that variants of FLAVOR_ID can be serialized
@@ -43,7 +42,7 @@ def test_flavor_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.FLAVOR_ID
 
 
-@parameterized(["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID"])
+@pytest.mark.parametrize("val", ["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID"])
 def test_hypervisor_id_serialization(val):
     """
     Tests that variants of HYPERVISOR_ID can be serialized
@@ -51,7 +50,7 @@ def test_hypervisor_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.HYPERVISOR_ID
 
 
-@parameterized(["image_id", "Image_ID", "ImaGe_iD"])
+@pytest.mark.parametrize("val", ["image_id", "Image_ID", "ImaGe_iD"])
 def test_image_id_serialization(val):
     """
     Tests that variants of IMAGE_ID can be serialized
@@ -59,7 +58,7 @@ def test_image_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.IMAGE_ID
 
 
-@parameterized(["project_id", "Project_Id", "PrOjEcT_Id"])
+@pytest.mark.parametrize("val", ["project_id", "Project_Id", "PrOjEcT_Id"])
 def test_project_id_serialization(val):
     """
     Tests that variants of PROJECT_ID can be serialized
@@ -67,7 +66,9 @@ def test_project_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.PROJECT_ID
 
 
-@parameterized(["server_creation_date", "Server_Creation_Date", "SeRvEr_CrEaTiOn_DAte"])
+@pytest.mark.parametrize(
+    "val", ["server_creation_date", "Server_Creation_Date", "SeRvEr_CrEaTiOn_DAte"]
+)
 def test_server_creation_date_serialization(val):
     """
     Tests that variants of SERVER_CREATION_DATE can be serialized
@@ -75,7 +76,9 @@ def test_server_creation_date_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_CREATION_DATE
 
 
-@parameterized(["server_description", "Server_Description", "SeRvEr_DeScrIpTion"])
+@pytest.mark.parametrize(
+    "val", ["server_description", "Server_Description", "SeRvEr_DeScrIpTion"]
+)
 def test_server_description_serialization(val):
     """
     Tests that variants of SERVER_DESCRIPTION can be serialized
@@ -83,7 +86,7 @@ def test_server_description_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_DESCRIPTION
 
 
-@parameterized(["server_id", "Server_Id", "SeRvEr_iD"])
+@pytest.mark.parametrize("val", ["server_id", "Server_Id", "SeRvEr_iD"])
 def test_server_id_serialization(val):
     """
     Tests that variants of SERVER_ID can be serialized
@@ -91,8 +94,13 @@ def test_server_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_ID
 
 
-@parameterized(
-    ["server_last_updated_date", "Server_Last_Updated_Date", "SerVer_LasT_UpDatED_DaTe"]
+@pytest.mark.parametrize(
+    "val",
+    [
+        "server_last_updated_date",
+        "Server_Last_Updated_Date",
+        "SerVer_LasT_UpDatED_DaTe",
+    ],
 )
 def test_server_last_updated_date_serialization(val):
     """
@@ -103,7 +111,7 @@ def test_server_last_updated_date_serialization(val):
     )
 
 
-@parameterized(["server_name", "Server_NaMe", "Server_Name"])
+@pytest.mark.parametrize("val", ["server_name", "Server_NaMe", "Server_Name"])
 def test_server_name_serialization(val):
     """
     Tests that variants of SERVER_NAME can be serialized
@@ -111,7 +119,7 @@ def test_server_name_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_NAME
 
 
-@parameterized(["server_status", "Server_Status", "SerVer_StAtUs"])
+@pytest.mark.parametrize("val", ["server_status", "Server_Status", "SerVer_StAtUs"])
 def test_server_status_serialization(val):
     """
     Tests that variants of SERVER_STATUS can be serialized
@@ -119,7 +127,7 @@ def test_server_status_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_STATUS
 
 
-@parameterized(["user_id", "User_Id", "UsEr_iD"])
+@pytest.mark.parametrize("val", ["user_id", "User_Id", "UsEr_iD"])
 def test_user_id_serialization(val):
     """
     Tests that variants of USER_ID can be serialized
@@ -127,9 +135,9 @@ def test_user_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.USER_ID
 
 
-@raises(ParseQueryError)
 def test_invalid_serialization():
     """
     Tests that error is raised when passes invalid string to all preset classes
     """
-    ServerProperties.from_string("some-invalid-string")
+    with pytest.raises(ParseQueryError):
+        ServerProperties.from_string("some-invalid-string")

--- a/tests/lib/openstack_query/queries/test_server_query.py
+++ b/tests/lib/openstack_query/queries/test_server_query.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from enums.query.props.server_properties import ServerProperties
+from openstack_query.queries.server_query import ServerQuery
+
+
+def test_server_query_enum_type():
+    """
+    Checks that server query returns the correct PropEnum type
+    """
+    assert ServerQuery().prop_mapping == ServerProperties
+
+
+def test_server_query_runner_is_initialized():
+    """
+    Checks that server query runner is initialized
+    with the correct prop_mapping
+    """
+    with patch("openstack_query.queries.server_query.ServerRunner") as constructor:
+        runner = ServerQuery().query_runner
+
+    constructor.assert_called_with(ServerProperties)
+    assert runner == constructor.return_value

--- a/tests/lib/openstack_query/queries/test_user_query.py
+++ b/tests/lib/openstack_query/queries/test_user_query.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from enums.query.props.user_properties import UserProperties
+from openstack_query.queries.user_query import UserQuery
+
+
+def test_user_query_enum_type():
+    """
+    Checks that server query returns the correct PropEnum type
+    """
+    assert UserQuery().prop_mapping == UserProperties
+
+
+def test_user_query_runner_is_initialized():
+    """
+    Checks that server query runner is initialized
+    with the correct prop_mapping
+    """
+    with patch("openstack_query.queries.user_query.UserRunner") as constructor:
+        runner = UserQuery().query_runner
+
+    constructor.assert_called_with(UserProperties)
+    assert runner == constructor.return_value

--- a/tests/lib/openstack_query/runners/test_query_runner.py
+++ b/tests/lib/openstack_query/runners/test_query_runner.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, Mock
 from parameterized import parameterized
 
 from openstack_query.runners.query_runner import QueryRunner
@@ -15,15 +15,12 @@ class QueryRunnerTests(unittest.TestCase):
         """
         super().setUp()
         self.mocked_connection = MagicMock()
-        self.mock_page_func = self._mock_page_func
+        self.mock_prop_enum = Mock()
+        self.mock_prop_enum.get_prop_mapping = lambda mock_obj: mock_obj["id"]
         self.instance = QueryRunner(
-            marker_prop_func=self.mock_page_func, connection_cls=self.mocked_connection
+            prop_enum=self.mock_prop_enum, connection_cls=self.mocked_connection
         )
         self.conn = self.mocked_connection.return_value.__enter__.return_value
-
-    def _mock_page_func(self, mock_obj):
-        """simple mock func which returns "id" key from given dict"""
-        return mock_obj["id"]
 
     @patch("openstack_query.runners.query_runner.QueryRunner._apply_client_side_filter")
     @patch("openstack_query.runners.query_runner.QueryRunner._run_query")

--- a/tests/lib/openstack_query/runners/test_server_runner.py
+++ b/tests/lib/openstack_query/runners/test_server_runner.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch, Mock
 from nose.tools import raises
 from parameterized import parameterized
 
@@ -24,9 +24,9 @@ class ServerRunnerTests(unittest.TestCase):
         """
         super().setUp()
         self.mocked_connection = MagicMock()
-        self.marker_prop_func = MagicMock()
+        self.prop_enum = Mock()
         self.instance = ServerRunner(
-            marker_prop_func=self.marker_prop_func,
+            prop_enum=self.prop_enum,
             connection_cls=self.mocked_connection,
         )
         self.conn = self.mocked_connection.return_value.__enter__.return_value

--- a/tests/lib/openstack_query/runners/test_user_runner.py
+++ b/tests/lib/openstack_query/runners/test_user_runner.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, Mock
 from nose.tools import raises
 from parameterized import parameterized
 
@@ -25,9 +25,9 @@ class UserRunnerTests(unittest.TestCase):
         """
         super().setUp()
         self.mocked_connection = MagicMock()
-        self.marker_prop_func = MagicMock()
+        self.mock_props = Mock()
         self.instance = UserRunner(
-            marker_prop_func=self.marker_prop_func,
+            prop_enum=self.mock_props,
             connection_cls=self.mocked_connection,
         )
         self.conn = self.mocked_connection.return_value.__enter__.return_value


### PR DESCRIPTION
### Description:
- Unify `from_string` into a single place in prop_enum
- Simplify init and add tests to *Query Objects

Another PR will extract `QueryWrapper` out to a factory, but I want to keep these small

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
