### PR TITLE
BUG: Not using CloudDomain to check validity of cloud_account in run() method

### DIFF
--- a/lib/openstack_query/managers/query_manager.py
+++ b/lib/openstack_query/managers/query_manager.py
@@ -90,7 +90,7 @@ class QueryManager:
                 **preset_details.args,
             )
 
-        self._query.run(self._cloud_account, **runner_params)
+        self._query.run(self._cloud_account.name, **runner_params)
 
         return self._get_query_output(
             output_details.output_type,

--- a/lib/openstack_query/query_methods.py
+++ b/lib/openstack_query/query_methods.py
@@ -5,6 +5,7 @@ from typing import Union, List, Any, Optional, Dict, Tuple
 from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
 from enums.query.props.prop_enum import PropEnum
 from enums.query.query_presets import QueryPresets
+from enums.cloud_domains import CloudDomains
 from exceptions.parse_query_error import ParseQueryError
 from openstack_query.query_builder import QueryBuilder
 from openstack_query.query_output import QueryOutput
@@ -140,6 +141,9 @@ class QueryMethods:
             - valid kwargs specific to resource
         """
 
+        # get cloud_account enum
+        cloud_account_enum = CloudDomains.from_string(cloud_account)
+
         local_filters = self.builder.client_side_filter
         server_filters = self.builder.server_side_filters
 
@@ -164,7 +168,11 @@ class QueryMethods:
         logger.debug("run started")
         start = time.time()
         results = self.runner.run(
-            cloud_account, local_filters, server_filters, from_subset, **kwargs
+            cloud_account_enum.name.lower(),
+            local_filters,
+            server_filters,
+            from_subset,
+            **kwargs,
         )
         logger.debug("run completed - time elapsed: %s seconds", time.time() - start)
 

--- a/tests/lib/openstack_query/managers/test_query_manager.py
+++ b/tests/lib/openstack_query/managers/test_query_manager.py
@@ -41,8 +41,11 @@ class QueryManagerTests(unittest.TestCase):
 
         self.query = MagicMock()
         self.prop_cls = MagicMock()
+        self.cloud_account = MagicMock()
+        self.cloud_account.name = "test_account"
+
         self.instance = QueryManager(
-            cloud_account="test_account", query=self.query, prop_cls=self.prop_cls
+            cloud_account=self.cloud_account, query=self.query, prop_cls=self.prop_cls
         )
 
     def _run_build_and_run_query_case(

--- a/tests/lib/openstack_query/test_query_methods.py
+++ b/tests/lib/openstack_query/test_query_methods.py
@@ -121,14 +121,17 @@ class QueryMethodsTests(unittest.TestCase):
         mock_client_filter_func = self.mock_builder.client_side_filter
         mock_server_filters = self.mock_builder.server_side_filters
         mock_parser_results = ["obj1", "obj2"]
+
         self.mock_parser.run_parser.return_value = mock_parser_results
 
         if not mock_kwargs:
             mock_kwargs = {}
 
-        res = self.instance.run("test-account", mock_from_subset, **mock_kwargs)
+        # should implicitly convert it to a valid enum in the function
+        res = self.instance.run("PROD", mock_from_subset, **mock_kwargs)
+
         self.mock_runner.run.assert_called_once_with(
-            "test-account",
+            "prod",
             mock_client_filter_func,
             mock_server_filters,
             mock_from_subset,
@@ -145,12 +148,25 @@ class QueryMethodsTests(unittest.TestCase):
         Tests that run method works expectedly - with parsing - i.e. grouping into dict
         Should call run_parser to get items - either dict of lists or list and handle them properly
         """
+        mock_client_filter_func = self.mock_builder.client_side_filter
+        mock_server_filters = self.mock_builder.server_side_filters
         self.mock_parser.run_parser.return_value = ["obj1", "obj2"]
         self.mock_parser.run_parser.return_value = {
             "group1": ["obj1", "obj2"],
             "group2": ["obj3", "obj4"],
         }
-        self.instance.run("cloud_account")
+
+        # should implicitly convert it to a valid enum in the function
+        self.instance.run("DEV")
+
+        self.mock_runner.run.assert_called_once_with(
+            "dev", mock_client_filter_func, mock_server_filters, None
+        )
+
+        self.mock_parser.run_parser.assert_called_once_with(
+            self.mock_runner.run.return_value
+        )
+
         self.mock_output.generate_output.assert_has_calls(
             [call(["obj1", "obj2"]), call(["obj3", "obj4"])]
         )


### PR DESCRIPTION
### Description:

Recent changes made to run() method signiture - where `cloud_account` was changed from `CloudDomain` enum to a string removed use of `CloudDomain` entirely - this was necessary to check the validity of the `cloud_account` being passed in - and convert it to a value that would be accepted by Openstacksdk

This fix adds that back in 

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
