### PR TITLE
BUG: fix DateTime type issue

### DIFF
--- a/lib/openstack_query/managers/query_manager.py
+++ b/lib/openstack_query/managers/query_manager.py
@@ -342,7 +342,7 @@ class QueryManager:
             "days": days,
             "hours": hours,
             "minutes": minutes,
-            "seconds": float(seconds),
+            "seconds": seconds,
         }
         logging.info(
             "This query will run a relative datetime query %s %s with args %s",


### PR DESCRIPTION
Really simple fix for a type issue with DateTime Actions - previously using float for `seconds` - will default to `int` I don't think anyone will want to write a query using fractions of a second :)

This fix is required #125 to be merged first

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
