### PR TITLE
ENH: clean workflow action outputs

### DIFF
--- a/actions/workflows/project.create.external.yaml
+++ b/actions/workflows/project.create.external.yaml
@@ -26,11 +26,16 @@ vars:
   - project_uuid: null
   - router_uuid: null
   - subnet_uuid: null
-  - stdout: null
+  - network_uuid: null
   - stderr: null
 
 output:
-  - stdout: <% ctx().stdout %>
+  - project_id: <% ctx().project_uuid %>
+  - project_name: <% ctx().project_name %>
+  - project_description: <% ctx().project_description %>
+  - router_id: <% ctx().router_uuid %>
+  - subnet_id: <% ctx().subnet_uuid %>
+  - network_id: <% ctx().network_uuid %>
   - stderr: <% ctx().stderr %>
 
 tasks:
@@ -48,7 +53,6 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - project_uuid: <% task(create_internal_project).result.output.project_id %>
-          - stdout: <% task(create_internal_project).result.output.project %>
         do:
           - allocate_floating_ips
           - create_network
@@ -73,6 +77,8 @@ tasks:
       has_external_router=False
     next:
       - when: <% succeeded() %>
+        publish:
+          - network_uuid: <% result().result.id %>
         do:
           - create_rbac_policy
           - create_subnet

--- a/actions/workflows/project.create.internal.yaml
+++ b/actions/workflows/project.create.internal.yaml
@@ -14,7 +14,6 @@ input:
 
 vars:
   - project_uuid: null
-  - stdout: null
   - stderr: null
 
 tasks:
@@ -29,7 +28,6 @@ tasks:
       - when: <% succeeded() %>
         publish:
           - project_uuid: <% result().result.id %>
-          - project: <% result().result %>
         do:
           - wait_for_default_security_group
           - create_security_group_http
@@ -167,7 +165,7 @@ tasks:
       user_domain="stfc"
 
 output:
-  - stdout: <% ctx().stdout %>
   - stderr: <% ctx().stderr %>
   - project_id: <% ctx().project_uuid %>
-  - project: <% ctx().project %>
+  - project_name: <% ctx().project_name %>
+  - project_description: <% ctx().project_description %>


### PR DESCRIPTION
### Description:

We noticed that `create_project_internal` and `create_project_external` were both providing too much information that would lead to confusion - especially that it would output the admin `project_id` which could be confused with the actual `project_id`. 
(Almost deleted the admin project because of this :grimacing: ) - hence we removed this 

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
