### PR TITLE
ENH: Remove text for keys when building unique groups

### DIFF
--- a/lib/openstack_query/query_parser.py
+++ b/lib/openstack_query/query_parser.py
@@ -166,7 +166,7 @@ class QueryParser:
 
         # build groups
         for val in unique_vals.keys():
-            group_key = f"{self._group_by.name} with value {val}"
+            group_key = val
             group_mappings[group_key] = (
                 lambda obj, test_val=val: prop_func(obj) == test_val
             )

--- a/tests/lib/openstack_query/test_query_parser.py
+++ b/tests/lib/openstack_query/test_query_parser.py
@@ -350,20 +350,20 @@ class QueryParserTests(unittest.TestCase):
                 "group by prop_1",
                 MockProperties.PROP_1,
                 {
-                    "PROP_1 with value a": [
+                    "a": [
                         {"prop_1": "a", "prop_2": 1},
                         {"prop_1": "a", "prop_2": 3},
                     ],
-                    "PROP_1 with value b": [{"prop_1": "b", "prop_2": 2}],
+                    "b": [{"prop_1": "b", "prop_2": 2}],
                 },
             ),
             (
                 "group by prop_2",
                 MockProperties.PROP_2,
                 {
-                    "PROP_2 with value 1": [{"prop_1": "a", "prop_2": 1}],
-                    "PROP_2 with value 2": [{"prop_1": "b", "prop_2": 2}],
-                    "PROP_2 with value 3": [{"prop_1": "a", "prop_2": 3}],
+                    1: [{"prop_1": "a", "prop_2": 1}],
+                    2: [{"prop_1": "b", "prop_2": 2}],
+                    3: [{"prop_1": "a", "prop_2": 3}],
                 },
             ),
         ]


### PR DESCRIPTION
### Description:
Removing the text before the key value when we group query results so that we can then use the group keys in other operations


---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
