### PR TITLE
TST: Refactor Prop Enums to use pytest

### DIFF
--- a/tests/enums/props/test_server_properties.py
+++ b/tests/enums/props/test_server_properties.py
@@ -1,15 +1,14 @@
 from unittest.mock import patch
-from parameterized import parameterized
 
 from enums.query.props.server_properties import ServerProperties
-from nose.tools import raises
+import pytest
 
 from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
-@parameterized(list(ServerProperties))
+@pytest.mark.parametrize("prop", list(ServerProperties))
 def test_get_prop_mapping(prop):
     """
     Tests that all server properties have a property function mapping
@@ -17,25 +16,25 @@ def test_get_prop_mapping(prop):
     ServerProperties.get_prop_mapping(prop)
 
 
-@raises(QueryPropertyMappingError)
 def test_get_prop_mapping_invalid():
     """
     Tests that get_prop_mapping returns Error if property not supported
     """
-    ServerProperties.get_prop_mapping(MockProperties.PROP_1)
+    with pytest.raises(QueryPropertyMappingError):
+        ServerProperties.get_prop_mapping(MockProperties.PROP_1)
 
 
 @patch("enums.query.props.server_properties.ServerProperties.get_prop_mapping")
-def test_get_marker_prop_func(mock_get_prop_func):
+def test_get_marker_prop_func(mock_get_prop_mapping):
     """
     Tests that marker_prop_func returns get_prop_mapping called with SERVER_ID
     """
     val = ServerProperties.get_marker_prop_func()
-    mock_get_prop_func.assert_called_once_with(ServerProperties.SERVER_ID)
-    assert val == mock_get_prop_func.return_value
+    mock_get_prop_mapping.assert_called_once_with(ServerProperties.SERVER_ID)
+    assert val == mock_get_prop_mapping.return_value
 
 
-@parameterized(["flavor_id", "Flavor_ID", "FlAvOr_Id"])
+@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id"])
 def test_flavor_id_serialization(val):
     """
     Tests that variants of FLAVOR_ID can be serialized
@@ -43,7 +42,7 @@ def test_flavor_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.FLAVOR_ID
 
 
-@parameterized(["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID"])
+@pytest.mark.parametrize("val", ["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID"])
 def test_hypervisor_id_serialization(val):
     """
     Tests that variants of HYPERVISOR_ID can be serialized
@@ -51,7 +50,7 @@ def test_hypervisor_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.HYPERVISOR_ID
 
 
-@parameterized(["image_id", "Image_ID", "ImaGe_iD"])
+@pytest.mark.parametrize("val", ["image_id", "Image_ID", "ImaGe_iD"])
 def test_image_id_serialization(val):
     """
     Tests that variants of IMAGE_ID can be serialized
@@ -59,7 +58,7 @@ def test_image_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.IMAGE_ID
 
 
-@parameterized(["project_id", "Project_Id", "PrOjEcT_Id"])
+@pytest.mark.parametrize("val", ["project_id", "Project_Id", "PrOjEcT_Id"])
 def test_project_id_serialization(val):
     """
     Tests that variants of PROJECT_ID can be serialized
@@ -67,7 +66,9 @@ def test_project_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.PROJECT_ID
 
 
-@parameterized(["server_creation_date", "Server_Creation_Date", "SeRvEr_CrEaTiOn_DAte"])
+@pytest.mark.parametrize(
+    "val", ["server_creation_date", "Server_Creation_Date", "SeRvEr_CrEaTiOn_DAte"]
+)
 def test_server_creation_date_serialization(val):
     """
     Tests that variants of SERVER_CREATION_DATE can be serialized
@@ -75,7 +76,9 @@ def test_server_creation_date_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_CREATION_DATE
 
 
-@parameterized(["server_description", "Server_Description", "SeRvEr_DeScrIpTion"])
+@pytest.mark.parametrize(
+    "val", ["server_description", "Server_Description", "SeRvEr_DeScrIpTion"]
+)
 def test_server_description_serialization(val):
     """
     Tests that variants of SERVER_DESCRIPTION can be serialized
@@ -83,7 +86,7 @@ def test_server_description_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_DESCRIPTION
 
 
-@parameterized(["server_id", "Server_Id", "SeRvEr_iD"])
+@pytest.mark.parametrize("val", ["server_id", "Server_Id", "SeRvEr_iD"])
 def test_server_id_serialization(val):
     """
     Tests that variants of SERVER_ID can be serialized
@@ -91,8 +94,13 @@ def test_server_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_ID
 
 
-@parameterized(
-    ["server_last_updated_date", "Server_Last_Updated_Date", "SerVer_LasT_UpDatED_DaTe"]
+@pytest.mark.parametrize(
+    "val",
+    [
+        "server_last_updated_date",
+        "Server_Last_Updated_Date",
+        "SerVer_LasT_UpDatED_DaTe",
+    ],
 )
 def test_server_last_updated_date_serialization(val):
     """
@@ -103,7 +111,7 @@ def test_server_last_updated_date_serialization(val):
     )
 
 
-@parameterized(["server_name", "Server_NaMe", "Server_Name"])
+@pytest.mark.parametrize("val", ["server_name", "Server_NaMe", "Server_Name"])
 def test_server_name_serialization(val):
     """
     Tests that variants of SERVER_NAME can be serialized
@@ -111,7 +119,7 @@ def test_server_name_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_NAME
 
 
-@parameterized(["server_status", "Server_Status", "SerVer_StAtUs"])
+@pytest.mark.parametrize("val", ["server_status", "Server_Status", "SerVer_StAtUs"])
 def test_server_status_serialization(val):
     """
     Tests that variants of SERVER_STATUS can be serialized
@@ -119,7 +127,7 @@ def test_server_status_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_STATUS
 
 
-@parameterized(["user_id", "User_Id", "UsEr_iD"])
+@pytest.mark.parametrize("val", ["user_id", "User_Id", "UsEr_iD"])
 def test_user_id_serialization(val):
     """
     Tests that variants of USER_ID can be serialized
@@ -127,9 +135,9 @@ def test_user_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.USER_ID
 
 
-@raises(ParseQueryError)
 def test_invalid_serialization():
     """
     Tests that error is raised when passes invalid string to all preset classes
     """
-    ServerProperties.from_string("some-invalid-string")
+    with pytest.raises(ParseQueryError):
+        ServerProperties.from_string("some-invalid-string")

--- a/tests/enums/props/test_user_properties.py
+++ b/tests/enums/props/test_user_properties.py
@@ -1,14 +1,13 @@
 from unittest.mock import patch
-from parameterized import parameterized
 from enums.query.props.user_properties import UserProperties
-from nose.tools import raises
+import pytest
 
 from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
-@parameterized(list(UserProperties))
+@pytest.mark.parametrize("prop", list(UserProperties))
 def test_get_prop_mapping(prop):
     """
     Tests that all user properties have a property function mapping
@@ -16,25 +15,25 @@ def test_get_prop_mapping(prop):
     UserProperties.get_prop_mapping(prop)
 
 
-@raises(QueryPropertyMappingError)
 def test_get_prop_mapping_invalid():
     """
     Tests that get_prop_mapping returns Error if property not supported
     """
-    UserProperties.get_prop_mapping(MockProperties.PROP_1)
+    with pytest.raises(QueryPropertyMappingError):
+        UserProperties.get_prop_mapping(MockProperties.PROP_1)
 
 
 @patch("enums.query.props.user_properties.UserProperties.get_prop_mapping")
-def test_get_marker_prop_func(mock_get_prop_func):
+def test_get_marker_prop_func(mock_get_prop_mapping):
     """
     Tests that marker_prop_func returns get_prop_mapping called with USER_ID
     """
     val = UserProperties.get_marker_prop_func()
-    mock_get_prop_func.assert_called_once_with(UserProperties.USER_ID)
-    assert val == mock_get_prop_func.return_value
+    mock_get_prop_mapping.assert_called_once_with(UserProperties.USER_ID)
+    assert val == mock_get_prop_mapping.return_value
 
 
-@parameterized(["user_domain_id", "User_Domain_ID", "UsEr_DoMaIn_iD"])
+@pytest.mark.parametrize("val", ["user_domain_id", "User_Domain_ID", "UsEr_DoMaIn_iD"])
 def test_user_domain_id_serialization(val):
     """
     Tests that variants of USER_DOMAIN_ID can be serialized
@@ -42,7 +41,7 @@ def test_user_domain_id_serialization(val):
     assert UserProperties.from_string(val) is UserProperties.USER_DOMAIN_ID
 
 
-@parameterized(["USER_EMAIL", "User_Email", "UsEr_EmAiL"])
+@pytest.mark.parametrize("val", ["USER_EMAIL", "User_Email", "UsEr_EmAiL"])
 def test_user_email_serialization(val):
     """
     Tests that variants of USER_EMAIL can be serialized
@@ -50,7 +49,9 @@ def test_user_email_serialization(val):
     assert UserProperties.from_string(val) is UserProperties.USER_EMAIL
 
 
-@parameterized(["USER_DESCRIPTION", "User_Description", "UsEr_DeScRiPtIoN"])
+@pytest.mark.parametrize(
+    "val", ["USER_DESCRIPTION", "User_Description", "UsEr_DeScRiPtIoN"]
+)
 def test_user_description_serialization(val):
     """
     Tests that variants of USER_DESCRIPTION can be serialized
@@ -58,7 +59,7 @@ def test_user_description_serialization(val):
     assert UserProperties.from_string(val) is UserProperties.USER_DESCRIPTION
 
 
-@parameterized(["USER_NAME", "User_Name", "UsEr_NaMe"])
+@pytest.mark.parametrize("val", ["USER_NAME", "User_Name", "UsEr_NaMe"])
 def test_user_name_serialization(val):
     """
     Tests that variants of USER_NAME can be serialized
@@ -66,9 +67,9 @@ def test_user_name_serialization(val):
     assert UserProperties.from_string(val) is UserProperties.USER_NAME
 
 
-@raises(ParseQueryError)
 def test_invalid_serialization():
     """
     Tests that error is raised when passes invalid string to all preset classes
     """
-    UserProperties.from_string("some-invalid-string")
+    with pytest.raises(ParseQueryError):
+        UserProperties.from_string("some-invalid-string")


### PR DESCRIPTION
refactor to use pytest.mark.parametrize() and pytest.raises instead of nose tools