### PR TITLE
TST: Refactor TimeUtils tests to use pytest

### DIFF
--- a/lib/openstack_query/time_utils.py
+++ b/lib/openstack_query/time_utils.py
@@ -4,10 +4,6 @@ from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
 
 class TimeUtils:
     @staticmethod
-    def get_current_time() -> datetime:
-        return datetime.now()
-
-    @staticmethod
     def get_timestamp_in_seconds(
         days: int = 0, hours: int = 0, minutes: int = 0, seconds: int = 0
     ) -> float:
@@ -23,7 +19,7 @@ class TimeUtils:
                 "requires at least 1 argument for function to be non-zero"
             )
 
-        current_time = TimeUtils.get_current_time().timestamp()
+        current_time = datetime.now().timestamp()
         prop_time_in_seconds = timedelta(
             days=days, hours=hours, minutes=minutes, seconds=float(seconds)
         ).total_seconds()
@@ -46,8 +42,9 @@ class TimeUtils:
         """
 
         time_in_seconds = timedelta(
-            days=days, hours=hours, minutes=minutes, seconds=seconds
+            days=days, hours=hours, minutes=minutes, seconds=float(seconds)
         ).total_seconds()
-        return datetime.fromtimestamp(
-            TimeUtils.get_current_time().timestamp() - time_in_seconds
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        current_time = datetime.now().timestamp()
+        return datetime.fromtimestamp(current_time - time_in_seconds).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )

--- a/tests/lib/openstack_query/test_time_utils.py
+++ b/tests/lib/openstack_query/test_time_utils.py
@@ -1,92 +1,71 @@
-import unittest
-from datetime import datetime
-
 from unittest.mock import patch
-from parameterized import parameterized
-from nose.tools import raises
-
+import pytest
 from openstack_query.time_utils import TimeUtils
 from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
 
 # pylint:disable=too-many-arguments
 
 
-class TimeUtilsTests(unittest.TestCase):
+def test_get_timestamp_in_seconds():
     """
-    Runs various tests to ensure that utils module functions expectedly
+    Tests that get_timestamp_in_seconds method works expectedly
+    method takes a set of integer params "days, hours, minutes, seconds" and calculates total seconds
     """
+    days, hours, minutes, seconds = 1, 2, 3, 4
 
-    @parameterized.expand(
-        [
-            ("1 day = 86400 seconds", 1, 0, 0, 0, 86400),
-            ("12 hours = 43200 seconds", 0, 12, 0, 0, 43200),
-            ("2 days, 30 minutes = 174600 seconds", 2, 0, 30, 0, 174600),
-            ("20 seconds", 0, 0, 0, 20, 20),
-        ]
+    with patch("openstack_query.time_utils.datetime") as mock_datetime:
+        with patch("openstack_query.time_utils.timedelta") as mock_timedelta:
+            mock_datetime.now.return_value.timestamp.return_value = 6
+            mock_timedelta.return_value.total_seconds.return_value = 2
+            out = TimeUtils.get_timestamp_in_seconds(days, hours, minutes, seconds)
+
+    # Now - amount of time in the past = expected out
+    assert out == 4
+
+    mock_datetime.now.assert_called_once()
+    mock_datetime.now.return_value.timestamp.assert_called_once()
+
+    mock_timedelta.assert_called_once_with(
+        days=days, hours=hours, minutes=minutes, seconds=float(seconds)
     )
-    @patch("openstack_query.time_utils.TimeUtils.get_current_time")
-    def test_get_timestamp_in_seconds(
-        self, _, days, hours, minutes, seconds, total_seconds, mock_current_datetime
-    ):
-        """
-        Tests that get_timestamp_in_seconds method works expectedly
-        method takes a set of integer params "days, hours, minutes, seconds" and calculates total seconds
-        """
-        mock_current_datetime.return_value = datetime(2023, 6, 4, 10, 30, 0)
-        out = TimeUtils.get_timestamp_in_seconds(days, hours, minutes, seconds)
+    mock_timedelta.return_value.total_seconds.assert_called()
 
-        mock_current_datetime.assert_called_once()
 
-        expected_timestamp = (
-            mock_current_datetime.return_value.timestamp() - total_seconds
-        )
-        assert out == expected_timestamp
+def test_get_timestamp_in_seconds_invalid():
+    """
+    Tests that get_timestamp_in_seconds method works expectedly - with invalid inputs - all 0
+    method should raise an error - we should expect at least one non-zero param
+    """
+    with pytest.raises(MissingMandatoryParamError):
+        TimeUtils.get_timestamp_in_seconds(0, 0, 0, 0)
 
-    @raises(MissingMandatoryParamError)
-    def test_get_timestamp_in_seconds_invalid(self):
-        """
-        Tests that get_timestamp_in_seconds method works expectedly - with invalid inputs - all 0
-        method should raise an error - we should expect at least one non-zero param
-        """
-        TimeUtils.get_timestamp_in_seconds(days=0, hours=0, minutes=0, seconds=0)
 
-    @parameterized.expand(
-        [
-            (
-                "no inputs",
-                0,
-                0,
-                0,
-                0,
-                datetime(2023, 6, 4, 10, 30, 0).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            ),
-            (
-                "with inputs",
-                1,
-                2,
-                30,
-                45,
-                datetime(2023, 6, 3, 7, 59, 15).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            ),
-        ]
+def test_convert_to_timestamp():
+    """
+    Tests that convert_to_timestamp method works expectedly
+    method takes a set of integer params "days, hours, minutes, seconds" and calculates a relative timestamp
+    of that many seconds in the past from current time
+    """
+    days, hours, minutes, seconds = 1, 2, 3, 4
+
+    with patch("openstack_query.time_utils.datetime") as mock_datetime:
+        with patch("openstack_query.time_utils.timedelta") as mock_timedelta:
+            mock_datetime.now.return_value.timestamp.return_value = 6
+            mock_timedelta.return_value.total_seconds.return_value = 2
+            mock_datetime.fromtimestamp.return_value.strftime.return_value = (
+                "timestamp-out"
+            )
+            out = TimeUtils.convert_to_timestamp(days, hours, minutes, seconds)
+
+    mock_datetime.now.assert_called_once()
+    mock_datetime.now.return_value.timestamp.assert_called_once()
+    mock_timedelta.assert_called_once_with(
+        days=days, hours=hours, minutes=minutes, seconds=float(seconds)
     )
-    @patch("openstack_query.time_utils.TimeUtils.get_current_time")
-    def test_convert_to_timestamp(
-        self,
-        _,
-        days,
-        hours,
-        minutes,
-        seconds,
-        expected_timestamp,
-        mock_current_datetime,
-    ):
-        """
-        Tests that convert_to_timestamp method works expectedly
-        method takes a set of integer params "days, hours, minutes, seconds" and calculates a relative timestamp
-        of that many seconds in the past from current time
-        """
-        mock_current_datetime.return_value = datetime(2023, 6, 4, 10, 30, 0)
-        out = TimeUtils.convert_to_timestamp(days, hours, minutes, seconds)
-        mock_current_datetime.assert_called_once()
-        self.assertEqual(out, expected_timestamp)
+    mock_timedelta.return_value.total_seconds.assert_called()
+    mock_datetime.fromtimestamp.assert_called_once_with(6 - 2)
+    mock_datetime.fromtimestamp.return_value.strftime.assert_called_once_with(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    assert out == "timestamp-out"


### PR DESCRIPTION
Rewrite tests to use pytest fixtures and conventions

Patching Datetime no longer requires using a wrapper method - hence removed get_current_time method
