### PR TITLE
TST: Refactor query_runner tests to pytest

### DIFF
--- a/lib/openstack_query/runners/server_runner.py
+++ b/lib/openstack_query/runners/server_runner.py
@@ -102,7 +102,7 @@ class ServerRunner(RunnerWrapper):
                 ",".join(f"{key}={value}" for key, value in filter_kwargs.items()),
             )
             query_res.extend(
-                self._run_paginated_query(conn.compute.servers, filter_kwargs)
+                self._run_paginated_query(conn.compute.servers, dict(filter_kwargs))
             )
         return query_res
 

--- a/tests/lib/openstack_query/runners/conftest.py
+++ b/tests/lib/openstack_query/runners/conftest.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+import pytest
+
+
+@pytest.fixture(scope="function", name="mock_connection")
+def mock_connection_fixture():
+    """
+    Returns a mocked OpenstackConnection class
+    """
+    return MagicMock()
+
+
+@pytest.fixture(scope="function", name="mock_openstack_connection")
+def mock_openstack_connection_fixture(mock_connection):
+    """
+    Returns a mocked openstacksdk connection object
+    """
+    return mock_connection.return_value.__enter__.return_value

--- a/tests/lib/openstack_query/runners/test_runner_wrapper.py
+++ b/tests/lib/openstack_query/runners/test_runner_wrapper.py
@@ -1,208 +1,224 @@
-import unittest
 from unittest.mock import MagicMock, patch
-from parameterized import parameterized
-
+import pytest
 from openstack_query.runners.runner_wrapper import RunnerWrapper
 
 # pylint:disable=protected-access
 
 
-class RunnerWrapperTests(unittest.TestCase):
-    @patch.multiple(RunnerWrapper, __abstractmethods__=set())
-    def setUp(self):
-        """
-        Setup for tests
-        """
-        super().setUp()
-        self.mocked_connection = MagicMock()
-        self.mock_page_func = self._mock_page_func
-        self.instance = RunnerWrapper(
-            marker_prop_func=self.mock_page_func, connection_cls=self.mocked_connection
-        )
-        self.conn = self.mocked_connection.return_value.__enter__.return_value
+@pytest.fixture(name="mock_page_func")
+def mock_page_func_fixture():
+    """
+    Returns a stub function for mock_page_func
+    """
 
-    def _mock_page_func(self, mock_obj):
+    def _mock_page_func(mock_obj):
         """simple mock func which returns "id" key from given dict"""
         return mock_obj["id"]
 
-    @patch(
-        "openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter"
-    )
-    @patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
-    @patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
-    def test_run_with_only_client_side_filter(
-        self, mock_parse_meta_params, mock_run_query, mock_apply_client_side_filter
-    ):
-        """
-        Tests that run method functions expectedly - with only client_side_filter_func set
-        method should call run_query and run apply_client_side_filter and return results
-        also tests with no meta-params set
-        """
-        mock_run_query.return_value = ["openstack-resource-1", "openstack-resource-2"]
-        mock_apply_client_side_filter.return_value = ["openstack-resource-1"]
+    return _mock_page_func
 
-        mock_client_side_filter_func = MagicMock()
-        mock_cloud_domain = MagicMock()
 
-        res = self.instance.run(
-            cloud_account=mock_cloud_domain,
-            client_side_filter_func=mock_client_side_filter_func,
-        )
-        self.mocked_connection.assert_called_once_with(mock_cloud_domain)
+@pytest.fixture(name="instance")
+def instance_fixture(mock_connection, mock_page_func):
+    """
+    Returns an instance to run tests with
+    """
 
-        mock_parse_meta_params.assert_not_called()
-        mock_run_query.assert_called_once_with(self.conn, None)
-
-        mock_apply_client_side_filter.assert_called_once_with(
-            ["openstack-resource-1", "openstack-resource-2"],
-            mock_client_side_filter_func,
-        )
-        mock_client_side_filter_func.assert_not_called()
-        self.assertEqual(["openstack-resource-1"], res)
-
-    @patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
-    @patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
-    def test_run_with_server_side_filters(self, mock_parse_meta_params, mock_run_query):
-        """
-        Tests that run method functions expectedly - with server_side_filters set
-        method should call run_query and return results
-        """
-        mock_server_filters = {"server_filter1": "abc", "server_filter2": False}
-        mock_run_query.return_value = ["openstack-resource-1"]
-        self.instance._run_query = mock_run_query
-        mock_client_side_filter_func = MagicMock()
-        mock_user_domain = MagicMock()
-
-        mock_parse_meta_params.return_value = {
-            "parsed_arg1": "val1",
-            "parsed_arg2": "val2",
-        }
-
-        res = self.instance.run(
-            cloud_account=mock_user_domain,
-            client_side_filter_func=mock_client_side_filter_func,
-            server_side_filters=mock_server_filters,
-            **{"arg1": "val1", "arg2": "val2"}
-        )
-        self.mocked_connection.assert_called_once_with(mock_user_domain)
-
-        mock_parse_meta_params.assert_called_once_with(
-            self.conn, **{"arg1": "val1", "arg2": "val2"}
+    with patch.multiple(RunnerWrapper, __abstractmethods__=set()):
+        return RunnerWrapper(
+            marker_prop_func=mock_page_func, connection_cls=mock_connection
         )
 
-        mock_run_query.assert_called_once_with(
-            self.conn,
-            mock_server_filters,
-            **{"parsed_arg1": "val1", "parsed_arg2": "val2"}
-        )
 
-        # if we have server-side filters, don't use client_side_filters
-        mock_client_side_filter_func.assert_not_called()
-        self.assertEqual(["openstack-resource-1"], res)
+@pytest.fixture(name="run_paginated_query_test")
+def run_paginated_query_test_fixture(instance):
+    """
+    Fixture which runs a paginated query test case
+    """
 
-    @patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_subset")
-    @patch(
-        "openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter"
-    )
-    def test_run_with_subset(self, mock_apply_filter_func, mock_parse_subset):
+    def _run_paginated_query_test(number_iterations):
         """
-        Tests that run method functions expectedly - with meta param 'from_subset' set
-        method should run parse_subset on 'from_subset' values and then apply_client_side_filter and return results
-        """
-        mock_parse_subset.return_value = [
-            "parsed-openstack-resource-1",
-            "parsed-openstack-resource-2",
-        ]
-        mock_apply_filter_func.return_value = ["parsed-openstack-resource-1"]
-        mock_client_side_filter_func = MagicMock()
-        mock_cloud_domain = MagicMock()
-
-        res = self.instance.run(
-            cloud_account=mock_cloud_domain,
-            client_side_filter_func=mock_client_side_filter_func,
-            from_subset=["openstack-resource-1", "openstack-resource-2"],
-        )
-        self.mocked_connection.assert_called_once_with(mock_cloud_domain)
-
-        mock_parse_subset.assert_called_once_with(
-            self.conn, ["openstack-resource-1", "openstack-resource-2"]
-        )
-
-        mock_apply_filter_func.assert_called_once_with(
-            ["parsed-openstack-resource-1", "parsed-openstack-resource-2"],
-            mock_client_side_filter_func,
-        )
-
-        self.assertEqual(["parsed-openstack-resource-1"], res)
-
-    def test_apply_filter_func(self):
-        """
-        Tests that apply_filter_func method functions expectedly
-        method should iteratively run filter_func on each item and return only those that filter_function returned True
-        """
-        mock_client_side_filter_func = MagicMock()
-        mock_client_side_filter_func.side_effect = [False, True]
-
-        mock_items = ["openstack-resource-1", "openstack-resource-2"]
-
-        res = self.instance._apply_client_side_filter(
-            mock_items, mock_client_side_filter_func
-        )
-        self.assertEqual(["openstack-resource-2"], res)
-
-    @parameterized.expand(
-        [
-            ("call terminated with no rounds - (empty list)", [[]]),
-            (
-                "call terminates after one round",
-                [
-                    [
-                        {"id": "marker1"},
-                    ],
-                    [
-                        {"id": "out"},
-                    ],
-                    [],
-                ],
-            ),
-            (
-                "call terminates after two rounds",
-                [
-                    [
-                        {"id": "marker1"},
-                    ],
-                    [
-                        {"id": "marker2"},
-                    ],
-                    [
-                        {"id": "out"},
-                    ],
-                    [],
-                ],
-            ),
-        ]
-    )
-    def test_run_paginated_query(self, _, mock_out):
-        """
-        tests that run_paginated_query works expectedly - with no rounds, one round, and two rounds of pagination
+        tests that run_paginated_query works expectedly - with one round or more of pagination
         mocked paginated call simulates the effect of retrieving a list of values up to a limit and then calling the
         same call again with a "marker" set to the last seen item to continue reading
         """
+        pagination_order = []
+        expected_out = []
 
-        def _mock_prop_func(resource):
-            return resource["id"]
+        for i in range(0, number_iterations - 1):
+            # Generate markers, it's a list of results with an ID
+            marker = {"id": f"marker{i}"}
+            expected_out.append(marker)
+            pagination_order.append([marker])
+
+        pagination_order.append([])
 
         mock_paginated_call = MagicMock()
-        mock_paginated_call.side_effect = mock_out
-        expected_out = [item for sublist in mock_out for item in sublist]
-        self.instance._page_marker_prop_func = MagicMock(wraps=_mock_prop_func)
+        mock_paginated_call.side_effect = pagination_order
+        instance._page_marker_prop_func = MagicMock(
+            wraps=lambda resource: resource["id"]
+        )
 
         # set round to 1, so new calls begins after returning one value
-        self.instance._LIMIT_FOR_PAGINATION = 1
-        self.instance._PAGINATION_CALL_LIMIT = 10
+        instance._LIMIT_FOR_PAGINATION = 1
+        instance._PAGINATION_CALL_LIMIT = 10
 
         mock_server_side_filters = {"arg1": "val1", "arg2": "val2"}
-        res = self.instance._run_paginated_query(
+        res = instance._run_paginated_query(
             mock_paginated_call, mock_server_side_filters
         )
-        self.assertEqual(res, expected_out)
+        assert res == expected_out
+
+    return _run_paginated_query_test
+
+
+# pylint:disable=too-many-arguments
+
+
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter")
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
+def test_run_with_only_client_side_filter(
+    mock_parse_meta_params,
+    mock_run_query,
+    mock_apply_client_side_filter,
+    instance,
+    mock_connection,
+    mock_openstack_connection,
+):
+    """
+    Tests that run method functions expectedly - with only client_side_filter_func set
+    method should call run_query and run apply_client_side_filter and return results
+    also tests with no meta-params set
+    """
+
+    mock_run_query.return_value = ["openstack-resource-1", "openstack-resource-2"]
+    mock_apply_client_side_filter.return_value = ["openstack-resource-1"]
+
+    mock_client_side_filter_func = MagicMock()
+    mock_cloud_domain = MagicMock()
+
+    res = instance.run(
+        cloud_account=mock_cloud_domain,
+        client_side_filter_func=mock_client_side_filter_func,
+    )
+    mock_connection.assert_called_once_with(mock_cloud_domain)
+
+    mock_parse_meta_params.assert_not_called()
+    mock_run_query.assert_called_once_with(mock_openstack_connection, None)
+
+    mock_apply_client_side_filter.assert_called_once_with(
+        ["openstack-resource-1", "openstack-resource-2"],
+        mock_client_side_filter_func,
+    )
+    mock_client_side_filter_func.assert_not_called()
+    assert ["openstack-resource-1"] == res
+
+
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
+def test_run_with_server_side_filters(
+    mock_parse_meta_params,
+    mock_run_query,
+    instance,
+    mock_connection,
+    mock_openstack_connection,
+):
+    """
+    Tests that run method functions expectedly - with server_side_filters set
+    method should call run_query and return results
+    """
+    mock_server_filters = {"server_filter1": "abc", "server_filter2": False}
+    mock_run_query.return_value = ["openstack-resource-1"]
+    instance._run_query = mock_run_query
+    mock_client_side_filter_func = MagicMock()
+    mock_user_domain = MagicMock()
+
+    mock_parse_meta_params.return_value = {
+        "parsed_arg1": "val1",
+        "parsed_arg2": "val2",
+    }
+
+    res = instance.run(
+        cloud_account=mock_user_domain,
+        client_side_filter_func=mock_client_side_filter_func,
+        server_side_filters=mock_server_filters,
+        **{"arg1": "val1", "arg2": "val2"},
+    )
+    mock_connection.assert_called_once_with(mock_user_domain)
+
+    mock_parse_meta_params.assert_called_once_with(
+        mock_openstack_connection, **{"arg1": "val1", "arg2": "val2"}
+    )
+
+    mock_run_query.assert_called_once_with(
+        mock_openstack_connection,
+        mock_server_filters,
+        **{"parsed_arg1": "val1", "parsed_arg2": "val2"},
+    )
+
+    # if we have server-side filters, don't use client_side_filters
+    mock_client_side_filter_func.assert_not_called()
+    assert res == ["openstack-resource-1"]
+
+
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_subset")
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter")
+def test_run_with_subset(
+    mock_apply_filter_func,
+    mock_parse_subset,
+    instance,
+    mock_connection,
+    mock_openstack_connection,
+):
+    """
+    Tests that run method functions expectedly - with meta param 'from_subset' set
+    method should run parse_subset on 'from_subset' values and then apply_client_side_filter and return results
+    """
+    mock_parse_subset.return_value = [
+        "parsed-openstack-resource-1",
+        "parsed-openstack-resource-2",
+    ]
+    mock_apply_filter_func.return_value = ["parsed-openstack-resource-1"]
+    mock_client_side_filter_func = MagicMock()
+    mock_cloud_domain = MagicMock()
+
+    res = instance.run(
+        cloud_account=mock_cloud_domain,
+        client_side_filter_func=mock_client_side_filter_func,
+        from_subset=["openstack-resource-1", "openstack-resource-2"],
+    )
+    mock_connection.assert_any_call(mock_cloud_domain)
+
+    mock_parse_subset.assert_called_once_with(
+        mock_openstack_connection, ["openstack-resource-1", "openstack-resource-2"]
+    )
+
+    mock_apply_filter_func.assert_called_once_with(
+        ["parsed-openstack-resource-1", "parsed-openstack-resource-2"],
+        mock_client_side_filter_func,
+    )
+    assert res == ["parsed-openstack-resource-1"]
+
+
+def test_apply_filter_func(instance):
+    """
+    Tests that apply_filter_func method functions expectedly
+    method should iteratively run filter_func on each item and return only those that filter_function returned True
+    """
+    mock_client_side_filter_func = MagicMock()
+    mock_client_side_filter_func.side_effect = [False, True]
+
+    mock_items = ["openstack-resource-1", "openstack-resource-2"]
+
+    res = instance._apply_client_side_filter(mock_items, mock_client_side_filter_func)
+    assert ["openstack-resource-2"] == res
+
+
+def test_run_pagination_query_gt_0(run_paginated_query_test):
+    """
+    Calls the testing case with various numbers of iterations
+    to ensure pagination is working
+    """
+    for i in range(1, 3):
+        run_paginated_query_test(i)

--- a/tests/lib/openstack_query/runners/test_server_runner.py
+++ b/tests/lib/openstack_query/runners/test_server_runner.py
@@ -1,176 +1,209 @@
-import unittest
 from unittest.mock import MagicMock, call, patch
-from nose.tools import raises
-from parameterized import parameterized
+import pytest
 
 from openstack_query.runners.server_runner import ServerRunner
-
-from openstack.exceptions import ResourceNotFound
 from openstack.compute.v2.server import Server
 
+from openstack.exceptions import ResourceNotFound
 from exceptions.parse_query_error import ParseQueryError
 
 # pylint:disable=protected-access
 
 
-class ServerRunnerTests(unittest.TestCase):
+@pytest.fixture(name="instance")
+def instance_fixture(mock_connection):
     """
-    Runs various tests to ensure that ServerRunner functions expectedly.
+    Returns an instance to run tests with
+    """
+    mock_marker_prop_func = MagicMock()
+    return ServerRunner(
+        marker_prop_func=mock_marker_prop_func, connection_cls=mock_connection
+    )
+
+
+def test_parse_meta_params_with_from_projects(instance, mock_openstack_connection):
+    """
+    Tests _parse_meta_params method works expectedly - with valid from_project argument
+    method should iteratively call find_project() to find each project in list and return outputs
     """
 
-    def setUp(self):
-        """
-        Setup for tests
-        """
-        super().setUp()
-        self.mocked_connection = MagicMock()
-        self.marker_prop_func = MagicMock()
-        self.instance = ServerRunner(
-            marker_prop_func=self.marker_prop_func,
-            connection_cls=self.mocked_connection,
-        )
-        self.conn = self.mocked_connection.return_value.__enter__.return_value
+    mock_project_identifiers = ["project_id1", "project_id2"]
+    mock_openstack_connection.identity.find_project.side_effect = [
+        {"id": "id1"},
+        {"id": "id2"},
+    ]
 
-    def test_parse_meta_params_with_from_projects(self):
-        """
-        Tests _parse_meta_params method works expectedly - with valid from_project argument
-        method should iteratively call find_project() to find each project in list and return outputs
-        """
-
-        mock_project_identifiers = ["project_id1", "project_id2"]
-        self.conn.identity.find_project.side_effect = [
-            {"id": "id1"},
-            {"id": "id2"},
-        ]
-
-        res = self.instance._parse_meta_params(self.conn, mock_project_identifiers)
-        self.conn.identity.find_project.assert_has_calls(
-            [
-                call("project_id1", ignore_missing=False),
-                call("project_id2", ignore_missing=False),
-            ]
-        )
-        self.assertListEqual(list(res.keys()), ["projects"])
-        self.assertListEqual(res["projects"], ["id1", "id2"])
-
-    @raises(ParseQueryError)
-    def test_parse_meta_params_with_invalid_project_identifier(self):
-        """
-        Tests _parse_meta_parms method works expectedly - with invalid from_project argument
-        method should raise ParseQueryError when an invalid project identifier is given
-        (or when project cannot be found)
-        """
-        mock_project_identifiers = ["project_id3"]
-        self.conn.identity.find_project.side_effect = [ResourceNotFound()]
-        self.instance._parse_meta_params(self.conn, mock_project_identifiers)
-
-    @parameterized.expand(
+    res = instance._parse_meta_params(
+        mock_openstack_connection, mock_project_identifiers
+    )
+    mock_openstack_connection.identity.find_project.assert_has_calls(
         [
-            ("with server side filters", {"arg1": "val1"}),
-            ("with no server side filters", None),
+            call("project_id1", ignore_missing=False),
+            call("project_id2", ignore_missing=False),
         ]
     )
-    @patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
-    def test_run_query_with_meta_arg_projects(
-        self, _, mock_filter_kwargs, mock_run_paginated_query
-    ):
-        """
-        Tests _run_query method works expectedly - when meta arg projects given
-        method should for each project:
-            - update filter kwargs to include "project_id": <id of project>
-            - run _run_paginated_query with updated filter_kwargs
-        """
-        mock_run_paginated_query.side_effect = [
-            ["server1", "server2"],
-            ["server3", "server4"],
-        ]
+    assert not set(res.keys()).difference({"projects"})
+    assert not set(res["projects"]).difference({"id1", "id2"})
 
-        res = self.instance._run_query(
-            self.conn,
-            filter_kwargs=mock_filter_kwargs,
-            projects=["project-id1", "project-id2"],
-        )
 
-        if not mock_filter_kwargs:
-            mock_filter_kwargs = {}
+def test_parse_meta_params_with_invalid_project_identifier(
+    instance, mock_openstack_connection
+):
+    """
+    Tests _parse_meta_parms method works expectedly - with invalid from_project argument
+    method should raise ParseQueryError when an invalid project identifier is given
+    (or when project cannot be found)
+    """
+    mock_project_identifiers = ["project_id3"]
+    mock_openstack_connection.identity.find_project.side_effect = [ResourceNotFound()]
+    with pytest.raises(ParseQueryError):
+        instance._parse_meta_params(mock_openstack_connection, mock_project_identifiers)
 
-        mock_run_paginated_query.asset_has_calls(
-            [
-                call(
-                    self.conn.compute.servers,
-                    {
-                        **mock_filter_kwargs,
-                        **{"all_tenants": True, "project_id": "project-id1"},
-                    },
-                ),
-                call(
-                    self.conn.compute.servers,
-                    {
-                        **mock_filter_kwargs,
-                        **{"all_tenants": True, "project_id": "project-id2"},
-                    },
-                ),
-            ]
-        )
-        self.assertEqual(res, ["server1", "server2", "server3", "server4"])
 
-    @raises(ParseQueryError)
-    def test_run_query_project_meta_arg_preset_duplication(self):
-        """
-        Tests that an error is raised when run_query is called with filter kwargs which contains project_id and with
-        meta_params that also contain projects - i.e there's a mismatch in which projects to search
-        """
-        self.instance._run_query(
-            self.conn,
+def test_run_query_project_meta_arg_preset_duplication(
+    instance, mock_openstack_connection
+):
+    """
+    Tests that an error is raised when run_query is called with filter kwargs which contains project_id and with
+    meta_params that also contain projects - i.e there's a mismatch in which projects to search
+    """
+    with pytest.raises(ParseQueryError):
+        instance._run_query(
+            mock_openstack_connection,
             filter_kwargs={"project_id": "proj1"},
             projects=["proj2", "proj3"],
         )
 
-    @parameterized.expand(
-        [
-            ("with server side filters", {"arg1": "val1"}),
-            ("with no server side filters", None),
-        ]
+
+@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+def test_run_query_with_meta_arg_projects_with_server_side_queries(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests _run_query method works expectedly - when meta arg projects given
+    method should for each project:
+        - update filter kwargs to include "project_id": <id of project>
+        - run _run_paginated_query with updated filter_kwargs
+    """
+    mock_run_paginated_query.side_effect = [
+        ["server1", "server2"],
+        ["server3", "server4"],
+    ]
+    mock_filter_kwargs = {"arg1": "val1"}
+
+    projects = ["project-id1", "project-id2"]
+
+    res = instance._run_query(
+        mock_openstack_connection,
+        filter_kwargs=mock_filter_kwargs,
+        projects=projects,
     )
-    @patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
-    def test_run_query_with_no_meta_args(
-        self, _, mock_filter_kwargs, mock_run_paginated_query
-    ):
-        mock_run_paginated_query.side_effect = [["server1", "server2"]]
 
-        res = self.instance._run_query(self.conn, filter_kwargs=mock_filter_kwargs)
-
-        if not mock_filter_kwargs:
-            mock_filter_kwargs = {}
-
-        mock_run_paginated_query.asset_called_once_with(
-            self.conn.compute.servers, {**mock_filter_kwargs, **{"all_tenants": True}}
+    for project in projects:
+        mock_run_paginated_query.assert_any_call(
+            mock_openstack_connection.compute.servers,
+            {"all_tenants": True, "project_id": project, **mock_filter_kwargs},
         )
-        self.assertEqual(res, ["server1", "server2"])
 
-    def test_parse_subset(self):
-        """
-        Tests _parse_subset works expectedly
-        method simply checks each value in 'subset' param is of the Server type and returns it
-        """
+    assert res == ["server1", "server2", "server3", "server4"]
 
-        # with one item
-        mock_server_1 = MagicMock()
-        mock_server_1.__class__ = Server
-        res = self.instance._parse_subset(self.conn, [mock_server_1])
-        self.assertEqual(res, [mock_server_1])
 
-        # with two items
-        mock_server_2 = MagicMock()
-        mock_server_2.__class__ = Server
-        res = self.instance._parse_subset(self.conn, [mock_server_1, mock_server_2])
-        self.assertEqual(res, [mock_server_1, mock_server_2])
+@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+def test_run_query_with_meta_arg_projects_with_no_server_queries(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests _run_query method works expectedly - when meta arg projects given
+    method should for each project run without any filter kwargs
+    """
+    mock_run_paginated_query.side_effect = [
+        ["server1", "server2"],
+        ["server3", "server4"],
+    ]
+    projects = ["project-id1", "project-id2"]
+    res = instance._run_query(
+        mock_openstack_connection, filter_kwargs={}, projects=projects
+    )
 
-    @raises(ParseQueryError)
-    def test_parse_subset_invalid(self):
-        """
-        Tests _parse_subset works expectedly
-        method raises error when provided value which is not of Server type
-        """
-        invalid_server = "invalid-server-obj"
-        self.instance._parse_subset(self.conn, [invalid_server])
+    for project in projects:
+        mock_run_paginated_query.assert_any_call(
+            mock_openstack_connection.compute.servers,
+            {"all_tenants": True, "project_id": project},
+        )
+
+    assert res == ["server1", "server2", "server3", "server4"]
+
+
+@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+def test_run_query_with_no_meta_args_no_kwargs(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests _run_query method works expectedly - no meta arg projects, no filter kwargs
+    method should call run_paginated_query with all_tenants=True and no other filters
+    """
+
+    mock_run_paginated_query.side_effect = [["server1", "server2"]]
+    mock_filter_kwargs = {}
+
+    res = instance._run_query(
+        mock_openstack_connection, filter_kwargs=mock_filter_kwargs
+    )
+
+    mock_run_paginated_query.asset_called_once_with(
+        mock_openstack_connection.compute.servers, {"all_tenants": True}
+    )
+    assert res == ["server1", "server2"]
+
+
+@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+def test_run_query_with_no_meta_args_with_kwargs(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests _run_query method works expectedly - no meta arg projects, and with filter kwargs
+    method should call run_paginated_query with all_tenants=True and pass through other filters
+    """
+
+    mock_run_paginated_query.side_effect = [["server1", "server2"]]
+    mock_filter_kwargs = {"arg1": "val1"}
+
+    res = instance._run_query(
+        mock_openstack_connection, filter_kwargs=mock_filter_kwargs
+    )
+
+    mock_run_paginated_query.asset_called_once_with(
+        mock_openstack_connection.compute.servers, {"all_tenants": True, "arg1": "val1"}
+    )
+    assert res == ["server1", "server2"]
+
+
+def test_parse_subset(instance, mock_openstack_connection):
+    """
+    Tests _parse_subset works expectedly
+    method simply checks each value in 'subset' param is of the Server type and returns it
+    """
+
+    # with one item
+    mock_server_1 = MagicMock()
+    mock_server_1.__class__ = Server
+    res = instance._parse_subset(mock_openstack_connection, [mock_server_1])
+    assert res == [mock_server_1]
+
+    # with two items
+    mock_server_2 = MagicMock()
+    mock_server_2.__class__ = Server
+    res = instance._parse_subset(
+        mock_openstack_connection, [mock_server_1, mock_server_2]
+    )
+    assert res == [mock_server_1, mock_server_2]
+
+
+def test_parse_subset_invalid(instance, mock_openstack_connection):
+    """
+    Tests _parse_subset works expectedly
+    method raises error when provided value which is not of Server type
+    """
+    invalid_server = "invalid-server-obj"
+    with pytest.raises(ParseQueryError):
+        instance._parse_subset(mock_openstack_connection, [invalid_server])

--- a/tests/lib/openstack_query/runners/test_user_runner.py
+++ b/tests/lib/openstack_query/runners/test_user_runner.py
@@ -1,191 +1,207 @@
-import unittest
-from unittest.mock import MagicMock, patch
-from nose.tools import raises
-from parameterized import parameterized
+from unittest.mock import MagicMock, NonCallableMock, patch
+import pytest
 
 from openstack_query.runners.user_runner import UserRunner
 from openstack.identity.v3.user import User
 
 from exceptions.parse_query_error import ParseQueryError
 from exceptions.enum_mapping_error import EnumMappingError
-
 from enums.user_domains import UserDomains
 
 # pylint:disable=protected-access
 
 
-class UserRunnerTests(unittest.TestCase):
+@pytest.fixture(name="instance")
+def instance_fixture(mock_connection):
     """
-    Runs various tests to ensure that UserRunner functions expectedly.
+    Returns an instance to run tests with
     """
-
-    def setUp(self):
-        """
-        Setup for tests
-        """
-        super().setUp()
-        self.mocked_connection = MagicMock()
-        self.marker_prop_func = MagicMock()
-        self.instance = UserRunner(
-            marker_prop_func=self.marker_prop_func,
-            connection_cls=self.mocked_connection,
-        )
-        self.conn = self.mocked_connection.return_value.__enter__.return_value
-
-    @patch("openstack_query.runners.user_runner.UserRunner._get_user_domain")
-    def test_parse_meta_params_with_from_domain(self, mock_get_user_domain):
-        """
-        Tests _parse_meta_params method works expectedly - with valid from_domain argument
-        method should get domain id from a UserDomain enum by calling get_user_domain
-        """
-
-        mock_domain_enum = UserDomains.DEFAULT
-        mock_get_user_domain.return_value = "default-domain-id"
-
-        res = self.instance._parse_meta_params(self.conn, from_domain=mock_domain_enum)
-        mock_get_user_domain.assert_called_once_with(self.conn, mock_domain_enum)
-
-        self.assertEqual(res, {"domain_id": "default-domain-id"})
-
-    @parameterized.expand(
-        [
-            ("with server side filters", {"arg1": "val1", "arg2": "val2"}),
-            ("with no server side filters", None),
-        ]
+    mock_marker_prop_func = MagicMock()
+    return UserRunner(
+        marker_prop_func=mock_marker_prop_func, connection_cls=mock_connection
     )
-    @patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
-    def test_run_query_with_meta_arg_domain_id(
-        self, _, mock_filter_kwargs, mock_run_paginated_query
-    ):
-        """
-        Tests the _run_query method works expectedly - when meta arg domain id given
-        method should:
-            - update filter kwargs to include "domain_id": <domain id given>
-            - run _run_paginated_query with updated filter_kwargs
-        """
 
-        mock_user_list = mock_run_paginated_query.return_value = [
-            "user1",
-            "user2",
-            "user3",
-        ]
-        mock_domain_id = "domain-id1"
-        res = self.instance._run_query(
-            self.conn, filter_kwargs=mock_filter_kwargs, domain_id=mock_domain_id
-        )
 
-        self.assertEqual(res, mock_user_list)
+@patch("openstack_query.runners.user_runner.UserRunner._get_user_domain")
+def test_parse_meta_params_with_from_domain(
+    mock_get_user_domain, instance, mock_openstack_connection
+):
+    """
+    Tests _parse_meta_params method works expectedly - with valid from_domain argument
+    method should get domain id from a UserDomain enum by calling get_user_domain
+    """
 
-        if mock_filter_kwargs:
-            mock_run_paginated_query.assert_called_once_with(
-                self.conn.identity.users,
-                {**{"domain_id": mock_domain_id}, **mock_filter_kwargs},
-            )
-        else:
-            mock_run_paginated_query.assert_called_once_with(
-                self.conn.identity.users, {"domain_id": mock_domain_id}
-            )
-        self.assertEqual(res, mock_user_list)
+    mock_domain_enum = UserDomains.DEFAULT
+    mock_get_user_domain.return_value = "default-domain-id"
 
-    @raises(ParseQueryError)
-    def test_run_query_domain_id_meta_arg_preset_duplication(self):
-        """
-        Tests that an error is raised when run_query is called with filter kwargs which contians domain_id and with meta
-        params that also contains a domain id - i.e. there's a mismatch in which domain to search
-        """
-        self.instance._run_query(
-            self.conn,
+    res = instance._parse_meta_params(
+        mock_openstack_connection, from_domain=mock_domain_enum
+    )
+    mock_get_user_domain.assert_called_once_with(
+        mock_openstack_connection, mock_domain_enum
+    )
+
+    assert res == {"domain_id": "default-domain-id"}
+
+
+@patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
+def test_run_query_with_meta_arg_domain_id_with_server_side_filters(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests the _run_query method works expectedly - when meta arg domain id given
+    method should:
+        - update filter kwargs to include "domain_id": <domain id given>
+        - run _run_paginated_query with updated filter_kwargs
+    """
+
+    mock_user_list = mock_run_paginated_query.return_value = [
+        "user1",
+        "user2",
+        "user3",
+    ]
+    mock_filter_kwargs = {"arg1": "val1", "arg2": "val2"}
+    mock_domain_id = "domain-id1"
+
+    res = instance._run_query(
+        mock_openstack_connection,
+        filter_kwargs=mock_filter_kwargs,
+        domain_id=mock_domain_id,
+    )
+
+    mock_run_paginated_query.assert_called_once_with(
+        mock_openstack_connection.identity.users,
+        {**{"domain_id": mock_domain_id}, **mock_filter_kwargs},
+    )
+    assert res == mock_user_list
+
+
+@patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
+def test_run_query_with_meta_arg_domain_id_with_no_server_filters(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests the _run_query method works expectedly with no server side filters
+    """
+
+    mock_user_list = mock_run_paginated_query.return_value = [
+        "user1",
+        "user2",
+        "user3",
+    ]
+    mock_filter_kwargs = None
+    mock_domain_id = "domain-id1"
+    res = instance._run_query(
+        mock_openstack_connection,
+        filter_kwargs=mock_filter_kwargs,
+        domain_id=mock_domain_id,
+    )
+
+    mock_run_paginated_query.assert_called_once_with(
+        mock_openstack_connection.identity.users, {"domain_id": mock_domain_id}
+    )
+    assert res == mock_user_list
+
+
+def test_run_query_domain_id_meta_arg_preset_duplication(
+    instance, mock_openstack_connection
+):
+    """
+    Tests that an error is raised when run_query is called with filter kwargs which contians domain_id and with meta
+    params that also contains a domain id - i.e. there's a mismatch in which domain to search
+    """
+    with pytest.raises(ParseQueryError):
+        instance._run_query(
+            mock_openstack_connection,
             filter_kwargs={"domain_id": "some-domain"},
             domain_id=["some-other-domain"],
         )
 
-    @parameterized.expand(
-        [
-            ("with server side filters", {"arg1": "val1", "arg2": "val2"}),
-            ("with no server side filters", None),
-        ]
+
+@patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
+@patch("openstack_query.runners.user_runner.UserRunner._get_user_domain")
+def test_run_query_no_meta_args(
+    mock_get_user_domain, mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests that run_query functions expectedly - when no meta args given
+    method should use the default-domain-id
+    """
+    mock_run_paginated_query.side_effect = [["user1", "user2"]]
+    mock_get_user_domain.return_value = "default-domain-id"
+    mock_filter_kwargs = {"test_arg": NonCallableMock()}
+
+    res = instance._run_query(
+        mock_openstack_connection, filter_kwargs=mock_filter_kwargs, domain_id=None
     )
-    @patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
-    @patch("openstack_query.runners.user_runner.UserRunner._get_user_domain")
-    def test_run_query_no_meta_args(
-        self, _, mock_filter_kwargs, mock_get_user_domain, mock_run_paginated_query
-    ):
-        """
-        Tests that run_query functions expectedly - when no meta args given
-        method should use the default-domain-id
-        """
-        mock_run_paginated_query.side_effect = [["user1", "user2"]]
-        mock_get_user_domain.return_value = "default-domain-id"
 
-        res = self.instance._run_query(
-            self.conn, filter_kwargs=mock_filter_kwargs, domain_id=None
-        )
-
-        if not mock_filter_kwargs:
-            mock_filter_kwargs = {}
-
-        mock_get_user_domain.assert_called_once_with(
-            self.conn, self.instance.DEFAULT_DOMAIN
-        )
-        mock_run_paginated_query.asset_called_once_with(
-            self.conn.identity.users,
-            {
-                **mock_filter_kwargs,
-                **{"all_tenants": True, "domain_id": "default-domain-id"},
-            },
-        )
-
-        self.assertEqual(res, ["user1", "user2"])
-
-    @raises(ParseQueryError)
-    def test_run_query_with_from_domain_and_id_given(self):
-        """
-        Test error is raised when the domain name and domain id is provided at
-        the same time
-        """
-        self.instance._run_query(
-            self.conn, filter_kwargs={"domain_id": 1}, domain_id="domain-id2"
-        )
-
-    @parameterized.expand(
-        [(f"test {domain.name.lower()}", domain) for domain in UserDomains]
+    mock_get_user_domain.assert_called_once_with(
+        mock_openstack_connection, instance.DEFAULT_DOMAIN
     )
-    def test_get_user_domain(self, _, domain):
-        """
-        Test that user domains have a mapping and no errors are raised
-        """
-        self.instance._get_user_domain(self.conn, domain)
+    mock_run_paginated_query.asset_called_once_with(
+        mock_openstack_connection.identity.users,
+        {
+            **mock_filter_kwargs,
+            "all_tenants": True,
+            "domain_id": "default-domain-id",
+        },
+    )
+    assert res == ["user1", "user2"]
 
-    @raises(EnumMappingError)
-    def test_get_user_domain_error_raised(self):
-        """
-        Test that an error is raised if a domain mapping is not found
-        """
-        self.instance._get_user_domain(self.conn, MagicMock())
 
-    def test_parse_subset(self):
-        """
-        Tests _parse_subset works expectedly
-        method simply checks each value in 'subset' param is of the User type and returns it
-        """
+def test_run_query_with_from_domain_and_id_given(instance, mock_openstack_connection):
+    """
+    Test error is raised when the domain name and domain id is provided at
+    the same time
+    """
+    with pytest.raises(ParseQueryError):
+        instance._run_query(
+            mock_openstack_connection,
+            filter_kwargs={"domain_id": 1},
+            domain_id="domain-id2",
+        )
 
-        # with one item
-        mock_user_1 = MagicMock()
-        mock_user_1.__class__ = User
-        res = self.instance._parse_subset(self.conn, [mock_user_1])
-        self.assertEqual(res, [mock_user_1])
 
-        # with two items
-        mock_user_2 = MagicMock()
-        mock_user_2.__class__ = User
-        res = self.instance._parse_subset(self.conn, [mock_user_1, mock_user_2])
-        self.assertEqual(res, [mock_user_1, mock_user_2])
+def test_get_user_domain(instance, mock_openstack_connection):
+    """
+    Test that user domains have a mapping and no errors are raised
+    """
+    for domain in UserDomains:
+        instance._get_user_domain(mock_openstack_connection, domain)
 
-    @raises(ParseQueryError)
-    def test_parse_subset_invalid(self):
-        """
-        Tests _parse_subset works expectedly
-        method raises error when provided value which is not of User type
-        """
-        invalid_user = "invalid-user-obj"
-        self.instance._parse_subset(self.conn, [invalid_user])
+
+def test_get_user_domain_error_raised(instance, mock_openstack_connection):
+    """
+    Test that an error is raised if a domain mapping is not found
+    """
+    with pytest.raises(EnumMappingError):
+        instance._get_user_domain(mock_openstack_connection, MagicMock())
+
+
+def test_parse_subset(instance, mock_openstack_connection):
+    """
+    Tests _parse_subset works expectedly
+    method simply checks each value in 'subset' param is of the User type and returns it
+    """
+
+    # with one item
+    mock_user_1 = MagicMock()
+    mock_user_1.__class__ = User
+    res = instance._parse_subset(mock_openstack_connection, [mock_user_1])
+    assert res == [mock_user_1]
+
+    # with two items
+    mock_user_2 = MagicMock()
+    mock_user_2.__class__ = User
+    res = instance._parse_subset(mock_openstack_connection, [mock_user_1, mock_user_2])
+    assert res == [mock_user_1, mock_user_2]
+
+
+def test_parse_subset_invalid(instance, mock_openstack_connection):
+    """
+    Tests _parse_subset works expectedly
+    method raises error when provided value which is not of User type
+    """
+    invalid_user = "invalid-user-obj"
+    with pytest.raises(ParseQueryError):
+        instance._parse_subset(mock_openstack_connection, [invalid_user])


### PR DESCRIPTION
changed QueryRunner tests so that they are in line with pytest conventions
Included shared fixtures in conftest.py