### PR TITLE
ENH:  Allow multiple queries on same resource

### DIFF
--- a/lib/custom_types/openstack_query/aliases.py
+++ b/lib/custom_types/openstack_query/aliases.py
@@ -30,7 +30,7 @@ ServerSideFilter = Dict[str, PropValue]
 
 # A type alias for representing a list of server-side-filters which will be used to run multiple openstacksdk commands
 # - one command per server-side filter
-ServerSideFilters = Union[ServerSideFilter, List[ServerSideFilter]]
+ServerSideFilters = List[ServerSideFilter]
 
 # A type alias for a function that takes a number of filter params and returns a set of server-side filters
 ServerSideFilterFunc = Callable[[FilterParams], ServerSideFilters]

--- a/lib/custom_types/openstack_query/aliases.py
+++ b/lib/custom_types/openstack_query/aliases.py
@@ -16,7 +16,7 @@ PropFunc = Callable[[OpenstackResourceObj], Any]
 PropertyMappings = Dict[PropEnum, PropFunc]
 
 # A type alias for a dictionary of params to pass to either client_side or server_side filters
-FilterParams = Dict[str, PropValue]
+FilterParams = Dict[str, Union[PropValue, List[PropValue]]]
 FilterFunc = Callable[[PropFunc, FilterParams], bool]
 
 # A type alias for a client-side filter func

--- a/lib/custom_types/openstack_query/aliases.py
+++ b/lib/custom_types/openstack_query/aliases.py
@@ -22,8 +22,15 @@ FilterFunc = Callable[[PropFunc, FilterParams], bool]
 # A type alias for a client-side filter func
 ClientSideFilterFunc = Callable[[OpenstackResourceObj], bool]
 
+# A type alias for a list of client-side filters to pass to run_query
+ClientSideFilters = List[ClientSideFilterFunc]
+
 # A type alias for a dictionary of filters to pass to openstacksdk commands as filter params
-ServerSideFilters = Dict[str, PropValue]
+ServerSideFilter = Dict[str, PropValue]
+
+# A type alias for representing a list of server-side-filters which will be used to run multiple openstacksdk commands
+# - one command per server-side filter
+ServerSideFilters = Union[ServerSideFilter, List[ServerSideFilter]]
 
 # A type alias for a function that takes a number of filter params and returns a set of server-side filters
 ServerSideFilterFunc = Callable[[FilterParams], ServerSideFilters]

--- a/lib/enums/query/query_presets.py
+++ b/lib/enums/query/query_presets.py
@@ -13,6 +13,8 @@ class QueryPresetsGeneric(QueryPresets):
 
     EQUAL_TO = auto()
     NOT_EQUAL_TO = auto()
+    ANY_IN = auto()
+    NOT_ANY_IN = auto()
 
     @staticmethod
     def from_string(val: str):
@@ -81,9 +83,7 @@ class QueryPresetsString(QueryPresets):
     Enum class which holds string comparison operators
     """
 
-    ANY_IN = auto()
     MATCHES_REGEX = auto()
-    NOT_ANY_IN = auto()
 
     @staticmethod
     def from_string(val: str):

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -129,7 +129,7 @@ class QueryAPI:
             - valid kwargs specific to resource
         """
 
-        self.executer.client_side_filter_func = self.builder.client_side_filter
+        self.executer.client_side_filters = self.builder.client_side_filters
         self.executer.server_side_filters = self.builder.server_side_filters
 
         self.executer.parse_func = self.parser.run_parser

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -129,8 +129,17 @@ class QueryAPI:
             - valid kwargs specific to resource
         """
 
-        self.executer.client_side_filters = self.builder.client_side_filters
-        self.executer.server_side_filters = self.builder.server_side_filters
+        if from_subset:
+            logger.debug(
+                "'from_subset' optional param given - will run client-side filters only"
+            )
+            self.executer.client_side_filters = (
+                self.builder.client_side_filters + self.builder.server_filter_fallback
+            )
+            self.executer.server_side_filters = None
+        else:
+            self.executer.client_side_filters = self.builder.client_side_filters
+            self.executer.server_side_filters = self.builder.server_side_filters
 
         self.executer.parse_func = self.parser.run_parser
         self.executer.output_func = self.output.generate_output

--- a/lib/openstack_query/handlers/client_side_handler.py
+++ b/lib/openstack_query/handlers/client_side_handler.py
@@ -168,8 +168,8 @@ class ClientSideHandler(HandlerBase):
 
         # a hack to get EAFP working - set a default value for prop just to see if filter function works
         prop_val = {
-            typing.Any: "",
-            typing.Union[int, float]: 0,
+            Any: "",
+            Union[int, float]: 0,
         }.get(prop_param.annotation, prop_param.annotation())
 
         if not func_kwargs:

--- a/lib/openstack_query/handlers/client_side_handler.py
+++ b/lib/openstack_query/handlers/client_side_handler.py
@@ -1,6 +1,7 @@
 import logging
 import inspect
-from typing import Optional, Tuple, Any, List, Union
+import typing
+from typing import Optional, Tuple, List, Union
 
 from openstack_query.handlers.handler_base import HandlerBase
 from custom_types.openstack_query.aliases import (
@@ -167,10 +168,12 @@ class ClientSideHandler(HandlerBase):
         prop_param = list(signature.parameters.values())[0]
 
         # a hack to get EAFP working - set a default value for prop just to see if filter function works
-        prop_val = {
-            Any: "",
-            Union[int, float]: 0,
-        }.get(prop_param.annotation, prop_param.annotation())
+        if prop_param.annotation == typing.Any:
+            prop_val = ""
+        elif prop_param.annotation == typing.Union[int, float]:
+            prop_val = 0
+        else:
+            prop_val = prop_param.annotation()
 
         if not func_kwargs:
             func_kwargs = {}

--- a/lib/openstack_query/handlers/client_side_handler.py
+++ b/lib/openstack_query/handlers/client_side_handler.py
@@ -3,6 +3,10 @@ import inspect
 import typing
 from typing import Optional, Tuple, List, Union
 
+from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
+from exceptions.parse_query_error import ParseQueryError
+from exceptions.query_preset_mapping_error import QueryPresetMappingError
+
 from openstack_query.handlers.handler_base import HandlerBase
 from custom_types.openstack_query.aliases import (
     FilterFunc,
@@ -15,7 +19,6 @@ from custom_types.openstack_query.aliases import (
 
 from enums.query.query_presets import QueryPresets
 from enums.query.props.prop_enum import PropEnum
-from exceptions.query_preset_mapping_error import QueryPresetMappingError
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +184,10 @@ class ClientSideHandler(HandlerBase):
             func(prop=prop_val, **func_kwargs)
             return True, ""
 
-        # we're catching all possible exceptions - and fail noisily
-        # pylint:disable=broad-exception-caught
-        except Exception as exp:
+        except (
+            TypeError,
+            NameError,
+            ParseQueryError,
+            MissingMandatoryParamError,
+        ) as exp:
             return False, str(exp)

--- a/lib/openstack_query/handlers/client_side_handler_generic.py
+++ b/lib/openstack_query/handlers/client_side_handler_generic.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, List
 from custom_types.openstack_query.aliases import PresetPropMappings
 
 from enums.query.query_presets import QueryPresetsGeneric
 from openstack_query.handlers.client_side_handler import ClientSideHandler
+from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
 
 # pylint: disable=too-few-public-methods
 
@@ -18,9 +19,31 @@ class ClientSideHandlerGeneric(ClientSideHandler):
         super().__init__(filter_function_mappings)
 
         self._filter_functions = {
+            QueryPresetsGeneric.ANY_IN: self._prop_any_in,
             QueryPresetsGeneric.EQUAL_TO: self._prop_equal_to,
+            QueryPresetsGeneric.NOT_ANY_IN: self._prop_not_any_in,
             QueryPresetsGeneric.NOT_EQUAL_TO: self._prop_not_equal_to,
         }
+
+    def _prop_not_any_in(self, prop: Any, values: List[str]) -> bool:
+        """
+        Filter function which returns true if a prop does not match any in a given list
+        :param prop: prop value to check against
+        :param values: a list of values to check against
+        """
+        return not self._prop_any_in(prop, values)
+
+    def _prop_any_in(self, prop: Any, values: List[str]) -> bool:
+        """
+        Filter function which returns true if a prop matches any in a given list
+        :param prop: prop value to check against
+        :param values: a list of values to check against
+        """
+        if len(values) == 0:
+            raise MissingMandatoryParamError(
+                "values list must contain at least one item to match against"
+            )
+        return any(prop == val for val in values)
 
     def _prop_not_equal_to(self, prop: Any, value: Any) -> bool:
         """

--- a/lib/openstack_query/handlers/client_side_handler_generic.py
+++ b/lib/openstack_query/handlers/client_side_handler_generic.py
@@ -1,5 +1,5 @@
 from typing import Any, List
-from custom_types.openstack_query.aliases import PresetPropMappings
+from custom_types.openstack_query.aliases import PresetPropMappings, PropValue
 
 from enums.query.query_presets import QueryPresetsGeneric
 from openstack_query.handlers.client_side_handler import ClientSideHandler
@@ -25,7 +25,7 @@ class ClientSideHandlerGeneric(ClientSideHandler):
             QueryPresetsGeneric.NOT_EQUAL_TO: self._prop_not_equal_to,
         }
 
-    def _prop_not_any_in(self, prop: Any, values: List[str]) -> bool:
+    def _prop_not_any_in(self, prop: Any, values: List[PropValue]) -> bool:
         """
         Filter function which returns true if a prop does not match any in a given list
         :param prop: prop value to check against
@@ -33,7 +33,7 @@ class ClientSideHandlerGeneric(ClientSideHandler):
         """
         return not self._prop_any_in(prop, values)
 
-    def _prop_any_in(self, prop: Any, values: List[str]) -> bool:
+    def _prop_any_in(self, prop: Any, values: List[PropValue]) -> bool:
         """
         Filter function which returns true if a prop matches any in a given list
         :param prop: prop value to check against
@@ -45,7 +45,7 @@ class ClientSideHandlerGeneric(ClientSideHandler):
             )
         return any(prop == val for val in values)
 
-    def _prop_not_equal_to(self, prop: Any, value: Any) -> bool:
+    def _prop_not_equal_to(self, prop: Any, value: PropValue) -> bool:
         """
         Filter function which returns true if a prop is not equal to a given value
         :param prop: prop value to check against
@@ -53,7 +53,7 @@ class ClientSideHandlerGeneric(ClientSideHandler):
         """
         return not self._prop_equal_to(prop, value)
 
-    def _prop_equal_to(self, prop: Any, value: Any) -> bool:
+    def _prop_equal_to(self, prop: Any, value: PropValue) -> bool:
         """
         Filter function which returns true if a prop is equal to a given value
         :param prop: prop value to check against

--- a/lib/openstack_query/handlers/client_side_handler_string.py
+++ b/lib/openstack_query/handlers/client_side_handler_string.py
@@ -1,11 +1,10 @@
 import re
 
-from typing import List, Any
+from typing import Any
 from custom_types.openstack_query.aliases import PresetPropMappings
 
 from enums.query.query_presets import QueryPresetsString
 from openstack_query.handlers.client_side_handler import ClientSideHandler
-from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
 
 # pylint: disable=too-few-public-methods
 
@@ -21,9 +20,7 @@ class ClientSideHandlerString(ClientSideHandler):
         super().__init__(filter_function_mappings)
 
         self._filter_functions = {
-            QueryPresetsString.ANY_IN: self._prop_any_in,
             QueryPresetsString.MATCHES_REGEX: self._prop_matches_regex,
-            QueryPresetsString.NOT_ANY_IN: self._prop_not_any_in,
         }
 
     def _prop_matches_regex(self, prop: Any, regex_string: str) -> bool:
@@ -33,23 +30,3 @@ class ClientSideHandlerString(ClientSideHandler):
         :param regex_string: a string which can be converted into a valid regex pattern to run
         """
         return bool(re.match(re.compile(regex_string), prop))
-
-    def _prop_any_in(self, prop: Any, values: List[str]) -> bool:
-        """
-        Filter function which returns true if a prop matches any in a given list
-        :param prop: prop value to check against
-        :param values: a list of values to check against
-        """
-        if len(values) == 0:
-            raise MissingMandatoryParamError(
-                "values list must contain at least one item to match against"
-            )
-        return any(prop == val for val in values)
-
-    def _prop_not_any_in(self, prop: Any, values: List[str]) -> bool:
-        """
-        Filter function which returns true if a prop does not match any in a given list
-        :param prop: prop value to check against
-        :param values: a list of values to check against
-        """
-        return not self._prop_any_in(prop, values)

--- a/lib/openstack_query/handlers/server_side_handler.py
+++ b/lib/openstack_query/handlers/server_side_handler.py
@@ -89,7 +89,11 @@ class ServerSideHandler(HandlerBase):
                 f"'{preset.name}':'{prop.name}' "
                 f"reason: {reason}"
             )
-        return filter_func(**params)
+        filters = filter_func(**params)
+
+        if not isinstance(filters, list):
+            return [filters]
+        return filters
 
     @staticmethod
     def _check_filter_mapping(

--- a/lib/openstack_query/managers/manager_wrapper.py
+++ b/lib/openstack_query/managers/manager_wrapper.py
@@ -204,7 +204,9 @@ class ManagerWrapper:
         logging.info("Running search by property query")
         logging.debug("converting user-defined property string into enum")
         preset = (
-            QueryPresetsString.ANY_IN if search_mode else QueryPresetsString.NOT_ANY_IN
+            QueryPresetsGeneric.ANY_IN
+            if search_mode
+            else QueryPresetsGeneric.NOT_ANY_IN
         )
         prop = self._prop_cls.from_string(property_to_search_by)
         args = {"values": values}
@@ -221,8 +223,8 @@ class ManagerWrapper:
                 "query only contains one value - EQUAL_TO preset will be used to speed up query"
             )
             equal_to_preset = {
-                QueryPresetsString.ANY_IN: QueryPresetsGeneric.EQUAL_TO,
-                QueryPresetsString.NOT_ANY_IN: QueryPresetsGeneric.NOT_EQUAL_TO,
+                QueryPresetsGeneric.ANY_IN: QueryPresetsGeneric.EQUAL_TO,
+                QueryPresetsGeneric.NOT_ANY_IN: QueryPresetsGeneric.NOT_EQUAL_TO,
             }.get(preset, None)
             if equal_to_preset:
                 preset = equal_to_preset

--- a/lib/openstack_query/mappings/server_mapping.py
+++ b/lib/openstack_query/mappings/server_mapping.py
@@ -23,8 +23,6 @@ from openstack_query.runners.server_runner import ServerRunner
 
 from openstack_query.time_utils import TimeUtils
 
-# pylint:disable=too-few-public-methods
-
 
 class ServerMapping(MappingInterface):
     """
@@ -73,6 +71,35 @@ class ServerMapping(MappingInterface):
                     ServerProperties.IMAGE_ID: lambda value: {"image": value},
                     ServerProperties.PROJECT_ID: lambda value: {"project_id": value},
                 },
+                QueryPresetsGeneric.ANY_IN: {
+                    ServerProperties.USER_ID: lambda values: [
+                        {"user_id": value} for value in values
+                    ],
+                    ServerProperties.SERVER_ID: lambda values: [
+                        {"uuid": value} for value in values
+                    ],
+                    ServerProperties.SERVER_NAME: lambda values: [
+                        {"hostname": value} for value in values
+                    ],
+                    ServerProperties.SERVER_DESCRIPTION: lambda values: [
+                        {"description": value} for value in values
+                    ],
+                    ServerProperties.SERVER_STATUS: lambda values: [
+                        {"vm_state": value} for value in values
+                    ],
+                    ServerProperties.SERVER_CREATION_DATE: lambda values: [
+                        {"created_at": value} for value in values
+                    ],
+                    ServerProperties.FLAVOR_ID: lambda values: [
+                        {"flavor": value} for value in values
+                    ],
+                    ServerProperties.IMAGE_ID: lambda values: [
+                        {"image": value} for value in values
+                    ],
+                    ServerProperties.PROJECT_ID: lambda values: [
+                        {"project_id": value} for value in values
+                    ],
+                },
                 QueryPresetsDateTime.OLDER_THAN_OR_EQUAL_TO: {
                     ServerProperties.SERVER_LAST_UPDATED_DATE: lambda func=TimeUtils.convert_to_timestamp, **kwargs: {
                         "changes-before": func(**kwargs)
@@ -99,6 +126,8 @@ class ServerMapping(MappingInterface):
                 {
                     QueryPresetsGeneric.EQUAL_TO: ["*"],
                     QueryPresetsGeneric.NOT_EQUAL_TO: ["*"],
+                    QueryPresetsGeneric.ANY_IN: ["*"],
+                    QueryPresetsGeneric.NOT_ANY_IN: ["*"],
                 }
             ),
             # set string query preset mappings

--- a/lib/openstack_query/mappings/user_mapping.py
+++ b/lib/openstack_query/mappings/user_mapping.py
@@ -18,9 +18,6 @@ from openstack_query.mappings.mapping_interface import MappingInterface
 from openstack_query.runners.user_runner import UserRunner
 
 
-# pylint:disable=too-few-public-methods
-
-
 class UserMapping(MappingInterface):
     """
     Mapping class for querying Openstack User objects.
@@ -58,7 +55,18 @@ class UserMapping(MappingInterface):
                     UserProperties.USER_DOMAIN_ID: lambda value: {"domain_id": value},
                     UserProperties.USER_NAME: lambda value: {"name": value},
                     UserProperties.USER_ID: lambda value: {"id": value},
-                }
+                },
+                QueryPresetsGeneric.ANY_IN: {
+                    UserProperties.USER_DOMAIN_ID: lambda values: [
+                        {"domain_id": value} for value in values
+                    ],
+                    UserProperties.USER_NAME: lambda values: [
+                        {"name": value} for value in values
+                    ],
+                    UserProperties.USER_ID: lambda values: [
+                        {"id": value} for value in values
+                    ],
+                },
             }
         )
 
@@ -75,6 +83,8 @@ class UserMapping(MappingInterface):
                 {
                     QueryPresetsGeneric.EQUAL_TO: ["*"],
                     QueryPresetsGeneric.NOT_EQUAL_TO: ["*"],
+                    QueryPresetsGeneric.ANY_IN: ["*"],
+                    QueryPresetsGeneric.NOT_ANY_IN: ["*"],
                 }
             ),
             # set string query preset mappings

--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -7,11 +7,14 @@ from openstack_query.handlers.server_side_handler import ServerSideHandler
 from enums.query.query_presets import QueryPresets
 from enums.query.props.prop_enum import PropEnum
 
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_preset_mapping_error import QueryPresetMappingError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
-from custom_types.openstack_query.aliases import ClientSideFilterFunc, ServerSideFilters
+from custom_types.openstack_query.aliases import (
+    ClientSideFilterFunc,
+    ClientSideFilters,
+    ServerSideFilters,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,24 +35,24 @@ class QueryBuilder:
         self._prop_enum_cls = prop_enum_cls
         self._server_side_handler = server_side_handler
 
-        self._client_side_filter = None
-        self._server_side_filters = None
+        self._client_side_filters = []
+        self._server_side_filters = []
 
     @property
-    def client_side_filter(self) -> Optional[ClientSideFilterFunc]:
+    def client_side_filters(self) -> Optional[ClientSideFilters]:
         """
         a getter method to return the client-side filter function
         """
-        return self._client_side_filter
+        return self._client_side_filters
 
-    @client_side_filter.setter
-    def client_side_filter(self, client_filter: ClientSideFilterFunc):
+    @client_side_filters.setter
+    def client_side_filters(self, client_filters: ClientSideFilters):
         """
         a setter method to set client side filter function
-        :param client_filter: a function that takes an openstack resource object and returns
+        :param client_filters: a list of filter functions that each take an openstack resource object and return
         True if it matches filter, False if not
         """
-        self._client_side_filter = client_filter
+        self._client_side_filters = client_filters
 
     @property
     def server_side_filters(self) -> Optional[ServerSideFilters]:
@@ -80,12 +83,6 @@ class QueryBuilder:
         :param preset_kwargs: A set of arguments to pass to configure filter function and filter kwargs
         """
 
-        if self.client_side_filter:
-            logging.error(
-                "Error: Chaining multiple where() functions currently not supported"
-            )
-            raise ParseQueryError("Error: Already set a query preset")
-
         prop_func = self._prop_enum_cls.get_prop_mapping(prop)
 
         if not prop_func:
@@ -104,17 +101,17 @@ class QueryBuilder:
             )
 
         preset_handler = self._get_preset_handler(preset, prop)
-        self.client_side_filter = preset_handler.get_filter_func(
+        client_side_filter = preset_handler.get_filter_func(
             preset=preset,
             prop=prop,
             prop_func=prop_func,
             filter_func_kwargs=preset_kwargs,
         )
 
-        self.server_side_filters = self._server_side_handler.get_filters(
+        server_side_filters = self._server_side_handler.get_filters(
             preset=preset, prop=prop, params=preset_kwargs
         )
-        if not self.server_side_filters:
+        if not server_side_filters:
             logger.info(
                 "No server-side filters for preset '%s': prop '%s' pair "
                 "- using client-side filter - this may take longer",
@@ -127,9 +124,54 @@ class QueryBuilder:
                 preset.name,
                 prop.name,
                 ", ".join(
-                    [f"{key}: '{val}'" for key, val in self.server_side_filters.items()]
+                    [f"{key}: '{val}'" for key, val in server_side_filters.items()]
                 ),
             )
+        self._add_filter(
+            client_side_filter=client_side_filter,
+            server_side_filters=server_side_filters,
+        )
+
+    def _add_filter(
+        self,
+        client_side_filter: ClientSideFilterFunc,
+        server_side_filters: Optional[ServerSideFilters] = None,
+    ) -> None:
+        """
+        method which parses client-side and server-side filters for a given preset and adds it to the
+        list of query operations to perform
+        :param client_side_filter: A client side filter function for the query preset
+        :param server_side_filters: An optional set of server side filters for the query preset
+        """
+
+        # add as client_side_filter if no server_side_filter
+        if not server_side_filters:
+            self.client_side_filters.append(client_side_filter)
+            return
+
+        # we convert to singleton list for aggregating into server_side_filter
+        if not isinstance(server_side_filters, list):
+            server_side_filters = [server_side_filters]
+
+        # check each any new server filter being added has overlapping keys with any server filters currently added
+        # if so add as client_side_filter
+        for current_server_filter in self.server_side_filters:
+            for new_server_filter in server_side_filters:
+                if set(new_server_filter).intersection(set(current_server_filter)):
+                    self.client_side_filters.append(client_side_filter)
+                    return
+
+        # if server side filter not set - set it
+        if not self.server_side_filters:
+            self.server_side_filters = server_side_filters
+            return
+
+        # we update server_side_filters
+        self.server_side_filters = [
+            {**new_server_filter, **current_server_filter}
+            for current_server_filter in self.server_side_filters
+            for new_server_filter in server_side_filters
+        ]
 
     def _get_preset_handler(
         self, preset: QueryPresets, prop: PropEnum

--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -37,6 +37,7 @@ class QueryBuilder:
 
         self._client_side_filters = []
         self._server_side_filters = []
+        self._server_filter_fallback = []
 
     @property
     def client_side_filters(self) -> Optional[ClientSideFilters]:
@@ -68,6 +69,23 @@ class QueryBuilder:
         :param server_filters: a dictionary that holds filter options to pass to openstacksdk
         """
         self._server_side_filters = server_filters
+
+    @property
+    def server_filter_fallback(self):
+        """
+        a getter method to return equivalent client-side filters for each server-side filter if
+        server-side filters are not to be used
+        """
+        return self._server_filter_fallback
+
+    @server_filter_fallback.setter
+    def server_filter_fallback(self, fallback_filters: ClientSideFilters):
+        """
+        a setter method to set client-side filters to fallback on for each server-side filter if
+        server-side filters are not to be used
+        :param fallback_filters: a set of client-side filters
+        """
+        self._server_filter_fallback = fallback_filters
 
     def parse_where(
         self,
@@ -159,6 +177,8 @@ class QueryBuilder:
         if not server_side_filters:
             self.client_side_filters.append(client_side_filter)
             return
+
+        self.server_filter_fallback.append(client_side_filter)
 
         # we convert to singleton list for aggregating into server_side_filter
         if not isinstance(server_side_filters, list):

--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -129,7 +129,7 @@ class QueryBuilder:
         server_side_filters = self._server_side_handler.get_filters(
             preset=preset, prop=prop, params=preset_kwargs
         )
-        if not isinstance(server_side_filters, list):
+        if server_side_filters and not isinstance(server_side_filters, list):
             server_side_filters = [server_side_filters]
 
         if not server_side_filters:
@@ -178,8 +178,6 @@ class QueryBuilder:
             self.client_side_filters.append(client_side_filter)
             return
 
-        self.server_filter_fallback.append(client_side_filter)
-
         # we convert to singleton list for aggregating into server_side_filter
         if not isinstance(server_side_filters, list):
             server_side_filters = [server_side_filters]
@@ -188,9 +186,12 @@ class QueryBuilder:
         # if so add as client_side_filter
         for current_server_filter in self.server_side_filters:
             for new_server_filter in server_side_filters:
-                if set(new_server_filter).intersection(set(current_server_filter)):
+                if set(new_server_filter.keys()) & set(current_server_filter.keys()):
                     self.client_side_filters.append(client_side_filter)
                     return
+
+        # before adding server-side filter - set fallback
+        self.server_filter_fallback.append(client_side_filter)
 
         # if server side filter not set - set it
         if not self.server_side_filters:

--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -111,6 +111,9 @@ class QueryBuilder:
         server_side_filters = self._server_side_handler.get_filters(
             preset=preset, prop=prop, params=preset_kwargs
         )
+        if not isinstance(server_side_filters, list):
+            server_side_filters = [server_side_filters]
+
         if not server_side_filters:
             logger.info(
                 "No server-side filters for preset '%s': prop '%s' pair "
@@ -120,13 +123,21 @@ class QueryBuilder:
             )
         else:
             logger.info(
-                "Found server-side filters for preset '%s': prop '%s' pair: {%s}",
+                "Found %s set of server-side filters for preset '%s': prop '%s' pair",
+                len(server_side_filters),
                 preset.name,
                 prop.name,
-                ", ".join(
-                    [f"{key}: '{val}'" for key, val in server_side_filters.items()]
-                ),
             )
+
+        logger.debug(
+            "server-side-filters found: %s",
+            {f"{server_side_filters}" if server_side_filters else "None"},
+        )
+        logger.debug(
+            "client-side-filter found: %s",
+            {client_side_filter if client_side_filter else "None"},
+        )
+
         self._add_filter(
             client_side_filter=client_side_filter,
             server_side_filters=server_side_filters,

--- a/lib/openstack_query/query_blocks/query_executer.py
+++ b/lib/openstack_query/query_blocks/query_executer.py
@@ -106,9 +106,9 @@ class QueryExecuter:
             return []
 
         if not isinstance(results, dict):
-            return self.output_func(results)
+            return self._output_func(results)
 
-        return {name: self.output_func(group) for name, group in results.items()}
+        return {name: self._output_func(group) for name, group in results.items()}
 
     def run_query(
         self,
@@ -141,5 +141,5 @@ class QueryExecuter:
         logger.debug("run completed - time elapsed: %s seconds", time.time() - start)
 
         if self.parse_func:
-            results = self.parse_func(results)
+            results = self._parse_func(results)
         return results, self.get_output(results)

--- a/lib/openstack_query/runners/runner_wrapper.py
+++ b/lib/openstack_query/runners/runner_wrapper.py
@@ -6,6 +6,7 @@ from typing import Optional, List, Any, Dict, Callable
 from custom_types.openstack_query.aliases import (
     PropFunc,
     ServerSideFilters,
+    ClientSideFilters,
     ClientSideFilterFunc,
     OpenstackResourceObj,
 )
@@ -34,7 +35,7 @@ class RunnerWrapper(OpenstackWrapperBase):
     def run(
         self,
         cloud_account: str,
-        client_side_filter_func: Optional[ClientSideFilterFunc] = None,
+        client_side_filters: Optional[ClientSideFilters] = None,
         server_side_filters: Optional[ServerSideFilters] = None,
         from_subset: Optional[List[Any]] = None,
         **kwargs,
@@ -42,72 +43,94 @@ class RunnerWrapper(OpenstackWrapperBase):
         """
         Public method that runs the query by querying openstacksdk and then applying a filter function.
         :param cloud_account: An string for the account from the clouds configuration to use
-        :param client_side_filter_func: An Optional function that we can use to limit the results after querying
-        openstacksdk
-        :param server_side_filters: An Optional set of filter kwargs to limit the results by when querying openstacksdk
+        :param client_side_filters: An Optional list of filter functions to run locally that we can use to limit the
+        results after querying openstacksdk
+        :param server_side_filters: An Optional list of filter kwargs to limit the results by when querying openstacksdk
         :param from_subset: A subset of openstack resources to run query on instead of querying openstacksdk
         :param kwargs: An extra set of kwargs to pass to internal _run_query method that changes what/how the
         openstacksdk query is run
             - valid kwargs to _run_query is specific to the runner object - see docstrings for _run_query() on the
             runner of interest.
         """
+
         logger.debug("making connection to openstack")
+        start = time.time()
         with self._connection_cls(cloud_account) as conn:
             logger.debug(
                 "openstack connection established - using cloud account '%s'",
                 cloud_account,
             )
-
             if from_subset:
-                logger.info("'from_subset' meta param given - parsing subset")
-                logger.debug("parsing subset of %s items", len(from_subset))
-                start = time.time()
-                resource_objects = self._parse_subset(conn, from_subset)
+                logger.info("'from_subset' meta param given - running query on subset")
+                resource_objects = self._parse_subset(
+                    conn=conn,
+                    subset=from_subset,
+                )
                 logger.debug(
-                    "parsing complete - time elapsed: %s seconds", time.time() - start
+                    "subset parsed. (time elapsed: %0.4f seconds)", time.time() - start
                 )
             else:
                 logger.info("running query using openstacksdk and server-side filters")
-                server_side_filters_log_str = "none (getting all)"
-                kwarg_log_str = "none"
-                if server_side_filters:
-                    server_side_filters_log_str = "\n\t\t".join(
-                        [f"{key}: '{val}'" for key, val in server_side_filters.items()]
-                    )
-                if kwargs:
-                    kwarg_log_str = "\n\t\t".join(
-                        [f"{key}: '{val}'" for key, val in kwargs.items()]
-                    )
-
+                resource_objects = self._run_with_openstacksdk(
+                    conn=conn, server_filters=server_side_filters, **kwargs
+                )
                 logger.debug(
-                    "calling run_query with parameters "
-                    "\n\tserver_side_filters: "
-                    "\n\t\t%s "
-                    "\n\trun_meta_kwargs: "
-                    "\n\t\t%s",
-                    server_side_filters_log_str,
-                    kwarg_log_str,
-                )
-                start = time.time()
-                query_meta_params = {}
-                if kwargs:
-                    query_meta_params = self._parse_meta_params(conn, **kwargs)
-                resource_objects = self._run_query(
-                    conn, server_side_filters, **query_meta_params
-                )
-                logger.info(
-                    "server-side query complete - time elapsed: %s seconds",
+                    "server-side quer(y/ies) completed - found %s items. (time elapsed: %0.4f seconds)",
+                    len(resource_objects),
                     time.time() - start,
                 )
-                logger.debug("server-side query found %s items", len(resource_objects))
 
-        if client_side_filter_func and not server_side_filters:
+        if client_side_filters:
             logger.info("applying client side filters")
-            resource_objects = self._apply_client_side_filter(
-                resource_objects, client_side_filter_func
+            resource_objects = self._apply_client_side_filters(
+                items=resource_objects, filters=client_side_filters
             )
 
-        logger.info("found %s items in total", len(resource_objects))
+        logger.info(
+            "Query Complete! Found %s items. Time elapsed: %0.4f seconds",
+            len(resource_objects),
+            time.time() - start,
+        )
+        return resource_objects
+
+    def _run_with_openstacksdk(
+        self,
+        conn: OpenstackConnection,
+        server_filters: Optional[ServerSideFilters] = None,
+        **kwargs,
+    ):
+        if not server_filters:
+            server_filters = [None]
+
+        if kwargs:
+            kwargs = self._parse_meta_params(conn, **kwargs)
+
+        meta_param_log_str = "\n\t\t".join(
+            [f"{key}: '{val}'" for key, val in kwargs.items()]
+        )
+        logger.info("found %s set(s) of server-side filters", len(server_filters))
+        resource_objects = []
+        for i, query_filters in enumerate(server_filters, 1):
+            logger.debug("running query %s / %s", i, len(server_filters))
+
+            filters_log_str = "None (getting all)"
+            if query_filters:
+                filters_log_str = "\n\t".join(
+                    [f"{key}: '{val}'" for key, val in query_filters.items()]
+                )
+
+            logger.debug(
+                "Running OpenstackSDK Query with: "
+                "\n\tserver side filters: "
+                "\n%s "
+                "\n\n meta kwargs: "
+                "\n\t%s",
+                filters_log_str,
+                "None" if not meta_param_log_str else meta_param_log_str,
+            )
+
+            resource_objects.extend(self._run_query(conn, query_filters, **kwargs))
+
         return resource_objects
 
     def _run_paginated_query(
@@ -173,17 +196,21 @@ class RunnerWrapper(OpenstackWrapperBase):
         return query_res
 
     @staticmethod
-    def _apply_client_side_filter(
-        items: List[OpenstackResourceObj], filter_func: ClientSideFilterFunc
+    def _apply_client_side_filters(
+        items: List[OpenstackResourceObj], filters: ClientSideFilters
     ) -> List[OpenstackResourceObj]:
         """
-        Removes items from a list by running a given filter function
+        Removes items from a list by running a given filter functions
         :param items: List of items to query e.g. list of servers
-        :param filter_func: An Optional function that we can use to limit the results after querying openstacksdk,
-            - function takes an openstack resource object and returns True if it passes the filter, false if not
+        :param filters: filter functions that we can use to limit the results after querying openstacksdk,
+            - each function takes an openstack resource object and returns True if it passes the filter, false if not
         :return: List of items that match the1 given query
         """
-        return [item for item in items if filter_func(item)]
+        filtered_items = []
+        for item in items:
+            if all(filter_func(item) for filter_func in filters):
+                filtered_items.append(item)
+        return filtered_items
 
     @abstractmethod
     def _run_query(

--- a/lib/openstack_query/runners/runner_wrapper.py
+++ b/lib/openstack_query/runners/runner_wrapper.py
@@ -52,6 +52,16 @@ class RunnerWrapper(OpenstackWrapperBase):
             runner of interest.
         """
 
+        if from_subset and server_side_filters:
+            logger.error(
+                "Error: Received server-side filters - suggesting that the query requires getting results via "
+                "openstacksdk, but also openstack objects directly - suggesting that we want to filter a set already "
+                "given. Not sure what to do - aborting."
+            )
+            raise RuntimeError(
+                "Ambiguous Query: received both server-side filters and values passed directly"
+            )
+
         logger.debug("making connection to openstack")
         start = time.time()
         with self._connection_cls(cloud_account) as conn:

--- a/lib/openstack_query/runners/runner_wrapper.py
+++ b/lib/openstack_query/runners/runner_wrapper.py
@@ -7,7 +7,6 @@ from custom_types.openstack_query.aliases import (
     PropFunc,
     ServerSideFilters,
     ClientSideFilters,
-    ClientSideFilterFunc,
     OpenstackResourceObj,
 )
 from openstack_api.openstack_connection import OpenstackConnection

--- a/lib/openstack_query/runners/server_runner.py
+++ b/lib/openstack_query/runners/server_runner.py
@@ -63,10 +63,9 @@ class ServerRunner(RunnerWrapper):
         For ServerQuery, this command gets all projects available and iteratively finds servers that belong to that
         project
         :param conn: An OpenstackConnection object - used to connect to openstacksdk
-        :param filter_kwargs: An Optional set of filter kwargs to pass to conn.compute.servers()
+        :param filter_kwargs: An Optional list of filter kwargs to pass to conn.compute.servers()
             to limit the servers being returned. - see https://docs.openstack.org/api-ref/compute/#list-servers
         :param meta_params: a set of meta parameters that dictates how the query is run
-
         """
         if not filter_kwargs:
             filter_kwargs = {}

--- a/lib/openstack_query/runners/user_runner.py
+++ b/lib/openstack_query/runners/user_runner.py
@@ -85,7 +85,7 @@ class UserRunner(RunnerWrapper):
 
         For UserQuery, this command gets all users by domain ID
         :param conn: An OpenstackConnection object - used to connect to openstacksdk
-        :param filter_kwargs: An Optional set of filter kwargs to pass to conn.identity.users()
+        :param filter_kwargs: An Optional list of filter kwargs to pass to conn.identity.users()
         """
 
         if not filter_kwargs:

--- a/tests/enums/test_query_presets.py
+++ b/tests/enums/test_query_presets.py
@@ -148,7 +148,7 @@ def test_any_in_serialization(preset_string):
     """
     Tests that variants of ANY_IN can be serialized
     """
-    assert QueryPresetsString.from_string(preset_string) is QueryPresetsString.ANY_IN
+    assert QueryPresetsGeneric.from_string(preset_string) is QueryPresetsGeneric.ANY_IN
 
 
 @pytest.mark.parametrize("preset_string", ["not_any_in", "Not_Any_In", "NoT_AnY_In"])
@@ -157,7 +157,7 @@ def test_not_any_in_serialization(preset_string):
     Tests that variants of NOT_ANY_IN can be serialized
     """
     assert (
-        QueryPresetsString.from_string(preset_string) is QueryPresetsString.NOT_ANY_IN
+        QueryPresetsGeneric.from_string(preset_string) is QueryPresetsGeneric.NOT_ANY_IN
     )
 
 

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -41,8 +41,8 @@ def run_with_test_case_fixture(instance):
 
         # test that data is marshalled correctly to executer
         assert (
-            instance.executer.client_side_filter_func
-            == instance.builder.client_side_filter
+            instance.executer.client_side_filters
+            == instance.builder.client_side_filters
         )
         assert (
             instance.executer.server_side_filters

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -30,6 +30,9 @@ def run_with_test_case_fixture(instance):
         """
         mock_query_results = ("object-list", "property-list")
         instance.executer.run_query.return_value = mock_query_results
+        instance.builder.client_side_filters = ["client-filters"]
+        instance.builder.server_filter_fallback = ["fallback-client-filters"]
+        instance.builder.server_side_filters = ["server-filters"]
 
         if not mock_kwargs:
             mock_kwargs = {}
@@ -40,14 +43,19 @@ def run_with_test_case_fixture(instance):
         )
 
         # test that data is marshalled correctly to executer
-        assert (
-            instance.executer.client_side_filters
-            == instance.builder.client_side_filters
-        )
-        assert (
-            instance.executer.server_side_filters
-            == instance.builder.server_side_filters
-        )
+        # - this differs based on if from_subset is given
+        if data_subset:
+            client_filters = (
+                instance.builder.client_side_filters
+                + instance.builder.server_filter_fallback
+            )
+            server_filters = None
+        else:
+            client_filters = instance.builder.client_side_filters
+            server_filters = instance.builder.server_side_filters
+
+        assert instance.executer.client_side_filters == client_filters
+        assert instance.executer.server_side_filters == server_filters
         assert instance.executer.parse_func == instance.parser.run_parser
         assert instance.executer.output_func == instance.output.generate_output
         assert res == instance

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -18,6 +18,47 @@ def instance_fixture():
     return QueryAPI(query_components=MagicMock())
 
 
+@pytest.fixture(name="run_with_test_case_with_subset")
+def run_with_test_case_with_subset_fixture(instance):
+    """
+    Fixture for running run() with a subset
+    """
+
+    def _run_with_test_case(mock_kwargs):
+        """
+        Runs a test case for the run() method
+        """
+        mock_query_results = ("object-list", "property-list")
+        instance.executer.run_query.return_value = mock_query_results
+        instance.builder.client_side_filters = ["client-filters"]
+        instance.builder.server_filter_fallback = ["fallback-client-filters"]
+        instance.builder.server_side_filters = ["server-filters"]
+
+        if not mock_kwargs:
+            mock_kwargs = {}
+
+        res = instance.run("test-account", ["item1", "item2"], **mock_kwargs)
+        instance.executer.run_query.assert_called_once_with(
+            cloud_account="test-account", from_subset=["item1", "item2"], **mock_kwargs
+        )
+
+        # test that data is marshalled correctly to executer
+        # - this differs based on if from_subset is given
+        client_filters = (
+            instance.builder.client_side_filters
+            + instance.builder.server_filter_fallback
+        )
+        server_filters = None
+
+        assert instance.executer.client_side_filters == client_filters
+        assert instance.executer.server_side_filters == server_filters
+        assert instance.executer.parse_func == instance.parser.run_parser
+        assert instance.executer.output_func == instance.output.generate_output
+        assert res == instance
+
+    return _run_with_test_case
+
+
 @pytest.fixture(name="run_with_test_case")
 def run_with_test_case_fixture(instance):
     """
@@ -44,15 +85,8 @@ def run_with_test_case_fixture(instance):
 
         # test that data is marshalled correctly to executer
         # - this differs based on if from_subset is given
-        if data_subset:
-            client_filters = (
-                instance.builder.client_side_filters
-                + instance.builder.server_filter_fallback
-            )
-            server_filters = None
-        else:
-            client_filters = instance.builder.client_side_filters
-            server_filters = instance.builder.server_side_filters
+        client_filters = instance.builder.client_side_filters
+        server_filters = instance.builder.server_side_filters
 
         assert instance.executer.client_side_filters == client_filters
         assert instance.executer.server_side_filters == server_filters
@@ -147,13 +181,13 @@ def test_where_with_kwargs(instance):
     assert res == instance
 
 
-def test_run_with_optional_params(run_with_test_case):
+def test_run_with_optional_params(run_with_test_case_with_subset):
     """
     Tests that run method works expectedly - with subset meta_params kwargs
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case(data_subset=["obj1", "obj2", "obj3"], mock_kwargs=None)
+    run_with_test_case_with_subset(mock_kwargs=None)
 
 
 def test_run_with_kwargs(run_with_test_case):
@@ -174,14 +208,13 @@ def test_run_with_nothing(run_with_test_case):
     run_with_test_case(None, None)
 
 
-def test_run_with_kwargs_and_subset(run_with_test_case):
+def test_run_with_kwargs_and_subset(run_with_test_case_with_subset):
     """
     Tests that run method works expectedly - with subset kwargs
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case(
-        data_subset=["obj1", "obj2", "obj3"],
+    run_with_test_case_with_subset(
         mock_kwargs={"arg1": "val1", "arg2": "val2"},
     )
 

--- a/tests/lib/openstack_query/handlers/test_client_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler.py
@@ -289,3 +289,19 @@ def test_check_filter_func_invalid_entry(instance):
     res = instance._check_filter_func(_mock_filter_func, mock_func_kwargs)
     assert not res[0]
     assert res[1] == "some error"
+
+
+def test_check_filter_func_no_params_needed(instance):
+    """
+    Tests that check_filter_func method works expectedly - for filter_func which needs no extra params
+    """
+
+    # need prop since we essentially 'mock' it in check_filter_func - to check the function works
+    # pylint:disable=unused-argument
+
+    def _mock_filter_func(prop: str):
+        pass
+
+    res = instance._check_filter_func(_mock_filter_func, None)
+    assert res[0]
+    assert res[1] == ""

--- a/tests/lib/openstack_query/handlers/test_client_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Union
 from unittest.mock import MagicMock, patch, NonCallableMock
 
 import pytest

--- a/tests/lib/openstack_query/handlers/test_client_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 from unittest.mock import MagicMock, patch, NonCallableMock
 
 import pytest
@@ -258,7 +258,9 @@ def test_check_filter_func_valid_filters(input_val, instance):
     """
 
     # pylint:disable=unused-argument
-    def _mock_filter_func(prop, arg1: int, arg2: str = "some-default", **kwargs):
+    def _mock_filter_func(
+        prop: str, arg1: Union[int, float], arg2: str = "some-default", **kwargs
+    ):
         # Fake the filter function not finding anything,
         # so we can test that it handles when args not matched extra args available
         # based on the arguments in this function, e.g. arg2
@@ -269,79 +271,21 @@ def test_check_filter_func_valid_filters(input_val, instance):
     assert res[1] == ""
 
 
-@pytest.mark.parametrize(
-    "input_val",
-    [
-        # no but required"
-        {},
-        # required wrong type
-        {"arg1": "non-default"},
-        # optional wrong type
-        {"arg1": 12, "arg2": 12},
-    ],
-)
-def test_check_filter_func_invalid_entry(input_val, instance):
+def test_check_filter_func_invalid_entry(instance):
     """
     Tests that check_filter_func method works expectedly - for filter_func which takes extra params
-    when args don't match expected args required by client-side filter function
+    when given invalid args
     """
 
-    # pylint:disable=unused-argument
-    def _mock_filter_func(prop, arg1: int, arg2: str = "some-default", **kwargs):
-        return None
+    def _mock_filter_func(
+        prop: str, arg1: Union[int, float], arg2: str = "some-default", **kwargs
+    ):
+        # Fake the filter function not finding anything,
+        # so we can test that it handles when args not matched extra args available
+        # based on the arguments in this function, e.g. arg2
+        raise TypeError("some error")
 
-    res = instance._check_filter_func(_mock_filter_func, func_kwargs=input_val)
+    mock_func_kwargs = {"arg1": "val1", "arg2": "val2"}
+    res = instance._check_filter_func(_mock_filter_func, mock_func_kwargs)
     assert not res[0]
-    assert isinstance(res[1], str) and len(res[1]) > 0
-
-
-def test_check_filter_func_with_no_args(instance):
-    """
-    Tests that check_filter_func method works expectedly - for filter_func which takes no extra params
-    returns True if args match expected args required by client-side filter function
-    """
-
-    # pylint:disable=unused-argument
-    def _mock_filter_func(prop):
-        return None
-
-    res = instance._check_filter_func(_mock_filter_func, func_kwargs={})
-    assert res[0]
-
-
-def test_check_filter_func_with_extra_arg(instance):
-    """
-    Tests that check_filter_func method works expectedly - for filter_func which takes no extra params
-    if the user tries to pass one that doesn't exist
-    """
-
-    # pylint:disable=unused-argument
-    def _mock_filter_func(prop):
-        return None
-
-    res = instance._check_filter_func(
-        _mock_filter_func, func_kwargs={"arg1": "not-there"}
-    )
-    assert not res[0]
-
-
-def test_check_filter_func_with_any_typing(instance):
-    """
-    Tests that check_filter_func method works expectedly - for filter_func which takes a param with Any
-    returns True for any args which match.
-    Also tests that variables with no type definition are also accepted (and type checking is ignored)
-    """
-
-    # pylint:disable=unused-argument
-    def _mock_filter_func(prop, arg1, arg2, arg3: Any):
-        return None
-
-    res = instance._check_filter_func(
-        _mock_filter_func, func_kwargs={"arg1": 1, "arg2": bool, "arg3": "string"}
-    )
-    assert res[0]
-
-    res = instance._check_filter_func(
-        _mock_filter_func, func_kwargs={"arg1": 1, "arg2": bool, "arg3": "string"}
-    )
-    assert res[0]
+    assert res[1] == "some error"

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_generic.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_generic.py
@@ -3,6 +3,7 @@ import pytest
 from openstack_query.handlers.client_side_handler_generic import (
     ClientSideHandlerGeneric,
 )
+from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
 from enums.query.query_presets import QueryPresetsGeneric
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
@@ -70,3 +71,51 @@ def test_prop_not_equal_to_invalid(instance, test_corpus):
     """
     for i in test_corpus:
         assert not instance._prop_not_equal_to(i, i)
+
+
+def test_prop_any_in_when_there(instance):
+    """
+    Tests that method prop_any_in functions expectedly
+    Returns True if test_prop matches any values in a given list val_list
+    """
+    test_prop = "val3"
+    val_list = ["val1", "val2", "val3"]
+    assert instance._prop_any_in(test_prop, val_list)
+
+
+def test_prop_any_in_when_not_there(instance):
+    """
+    Tests that method prop_any_in functions expectedly
+    Returns True if test_prop matches any values in a given list val_list
+    """
+    test_prop = "val3"
+    val_list = ["val1", "val2"]
+    assert not instance._prop_any_in(test_prop, val_list)
+
+
+def test_prop_any_in_empty_list(instance):
+    """
+    Tests that method prop_any_in functions expectedly - when given empty list raise error
+    """
+    with pytest.raises(MissingMandatoryParamError):
+        instance._prop_any_in("some-prop-val", [])
+
+
+def test_prop_not_any_in_when_there(instance):
+    """
+    Tests that method prop_any_not_in functions expectedly
+    Returns True if test_prop does not match any values in a given list val_list
+    """
+    val_list = ["val1", "val2", "val3"]
+    test_prop = "val3"
+    assert not instance._prop_not_any_in(test_prop, val_list)
+
+
+def test_prop_not_any_in_when_not_there(instance):
+    """
+    Tests that method prop_any_not_in functions expectedly
+    Returns True if test_prop does not match any values in a given list val_list
+    """
+    val_list = ["val1", "val2"]
+    test_prop = "val3"
+    assert instance._prop_not_any_in(test_prop, val_list)

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_string.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_string.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, NonCallableMock
 import pytest
 
 from enums.query.query_presets import QueryPresetsString
-from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
 from openstack_query.handlers.client_side_handler_string import ClientSideHandlerString
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
@@ -62,51 +61,3 @@ def test_prop_matches_regex_valid(
     instance._prop_matches_regex(test_prop, regex_string)
     mock_regex_match.assert_called_once_with(mock_compile, test_prop)
     mock_regex_compile.assert_called_once_with(regex_string)
-
-
-def test_prop_any_in_when_there(instance):
-    """
-    Tests that method prop_any_in functions expectedly
-    Returns True if test_prop matches any values in a given list val_list
-    """
-    test_prop = "val3"
-    val_list = ["val1", "val2", "val3"]
-    assert instance._prop_any_in(test_prop, val_list)
-
-
-def test_prop_any_in_when_not_there(instance):
-    """
-    Tests that method prop_any_in functions expectedly
-    Returns True if test_prop matches any values in a given list val_list
-    """
-    test_prop = "val3"
-    val_list = ["val1", "val2"]
-    assert not instance._prop_any_in(test_prop, val_list)
-
-
-def test_prop_any_in_empty_list(instance):
-    """
-    Tests that method prop_any_in functions expectedly - when given empty list raise error
-    """
-    with pytest.raises(MissingMandatoryParamError):
-        instance._prop_any_in("some-prop-val", [])
-
-
-def test_prop_not_any_in_when_there(instance):
-    """
-    Tests that method prop_any_not_in functions expectedly
-    Returns True if test_prop does not match any values in a given list val_list
-    """
-    val_list = ["val1", "val2", "val3"]
-    test_prop = "val3"
-    assert not instance._prop_not_any_in(test_prop, val_list)
-
-
-def test_prop_not_any_in_when_not_there(instance):
-    """
-    Tests that method prop_any_not_in functions expectedly
-    Returns True if test_prop does not match any values in a given list val_list
-    """
-    val_list = ["val1", "val2"]
-    test_prop = "val3"
-    assert instance._prop_not_any_in(test_prop, val_list)

--- a/tests/lib/openstack_query/handlers/test_server_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_server_side_handler.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, NonCallableMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -85,9 +85,9 @@ def test_get_mapping_invalid(instance):
     "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
 )
 @patch("openstack_query.handlers.server_side_handler.ServerSideHandler._get_mapping")
-def test_get_filters_valid(mock_get_mapping, mock_check_filter_mapping, instance):
+def test_get_filters_valid_list(mock_get_mapping, mock_check_filter_mapping, instance):
     """
-    Tests that get_filters method works expectedly
+    Tests that get_filters method works expectedly - filters returned are a list
     returns server-side filters as a set of kwargs
         - Prop Enum and Preset Enum are supported
         - and filter_params are valid
@@ -95,7 +95,7 @@ def test_get_filters_valid(mock_get_mapping, mock_check_filter_mapping, instance
     mock_params = {"arg1": "val1", "arg2": "val2"}
     mock_filter_func = MagicMock()
 
-    mock_filters = NonCallableMock()
+    mock_filters = ["filter1", "filter2"]
     mock_filter_func.return_value = mock_filters
 
     mock_check_filter_mapping.return_value = True, ""
@@ -108,6 +108,37 @@ def test_get_filters_valid(mock_get_mapping, mock_check_filter_mapping, instance
     mock_check_filter_mapping.assert_called_once_with(mock_filter_func, mock_params)
     mock_filter_func.assert_called_once_with(**mock_params)
     assert res == mock_filters
+
+
+@patch(
+    "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
+)
+@patch("openstack_query.handlers.server_side_handler.ServerSideHandler._get_mapping")
+def test_get_filters_valid_not_list(
+    mock_get_mapping, mock_check_filter_mapping, instance
+):
+    """
+    Tests that get_filters method works expectedly - filters returned are a not a list
+    returns server-side filters as a set of kwargs
+        - Prop Enum and Preset Enum are supported
+        - and filter_params are valid
+    """
+    mock_params = {"arg1": "val1", "arg2": "val2"}
+    mock_filter_func = MagicMock()
+
+    mock_filters = "filter1"
+    mock_filter_func.return_value = mock_filters
+
+    mock_check_filter_mapping.return_value = True, ""
+    mock_get_mapping.return_value = mock_filter_func
+
+    res = instance.get_filters(
+        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
+    )
+
+    mock_check_filter_mapping.assert_called_once_with(mock_filter_func, mock_params)
+    mock_filter_func.assert_called_once_with(**mock_params)
+    assert res == [mock_filters]
 
 
 @patch(

--- a/tests/lib/openstack_query/managers/test_manager_wrapper.py
+++ b/tests/lib/openstack_query/managers/test_manager_wrapper.py
@@ -342,7 +342,7 @@ class ManagerWrapperTests(unittest.TestCase):
 
         mock_build_and_run_query.assert_called_once_with(
             preset_details=QueryPresetDetails(
-                preset=QueryPresetsString.ANY_IN,
+                preset=QueryPresetsGeneric.ANY_IN,
                 prop=self.prop_cls.from_string.return_value,
                 args={"values": ["image-id1", "image-id2"]},
             ),

--- a/tests/lib/openstack_query/mappings/conftest.py
+++ b/tests/lib/openstack_query/mappings/conftest.py
@@ -90,7 +90,7 @@ def server_side_test_mappings_fixture(client_side_match):
             server_filter = server_side_handler.get_filters(
                 preset_to_test, prop, {"value": "test"}
             )
-            assert server_filter == {expected: "test"}
+            assert server_filter == [{expected: "test"}]
         client_side_match(
             client_side_handler, preset_to_test, list(expected_mappings.keys())
         )

--- a/tests/lib/openstack_query/mappings/conftest.py
+++ b/tests/lib/openstack_query/mappings/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 from custom_types.openstack_query.aliases import PresetPropMappings
 from enums.query.props.prop_enum import PropEnum
-from enums.query.query_presets import QueryPresets
+from enums.query.query_presets import QueryPresets, QueryPresetsGeneric
 from openstack_query.handlers.client_side_handler import ClientSideHandler
 from openstack_query.handlers.server_side_handler import ServerSideHandler
 
@@ -96,3 +96,60 @@ def server_side_test_mappings_fixture(client_side_match):
         )
 
     return _server_side_test_case
+
+
+@pytest.fixture(scope="function", name="server_side_any_in_mappings")
+def server_side_test_any_in_mappings_fixture(
+    client_side_match, server_side_test_mappings
+):
+    """
+    Fixture to test server side mappings for ANY_IN
+    """
+
+    def _server_side_any_in_test_case(
+        server_side_handler: ServerSideHandler,
+        client_side_handler: ClientSideHandler,
+        expected_mappings: Dict[PropEnum, str],
+    ):
+        """
+        Tests server side handler mappings for ANY_IN preset are correct, and line up to the expected
+        server side params for equal to params. Will test with one and with multiple values
+        Also tests that server-side mapping has equivalent client-side mapping.
+        :param server_side_handler: server-side handler to test
+        :param client_side_handler: equivalent client-side handler to test
+        :param expected_mappings: dictionary mapping expected properties to the filter param they should output
+        """
+        supported_props = server_side_handler.get_supported_props(
+            QueryPresetsGeneric.ANY_IN
+        )
+        assert all(
+            key_to_check in supported_props for key_to_check in expected_mappings
+        )
+        for prop, expected in expected_mappings.items():
+            # test with one value
+            server_filter = server_side_handler.get_filters(
+                QueryPresetsGeneric.ANY_IN, prop, {"values": ["test"]}
+            )
+            assert server_filter == [{expected: "test"}]
+
+            # test with multiple values
+            server_filter = server_side_handler.get_filters(
+                QueryPresetsGeneric.ANY_IN, prop, {"values": ["test1", "test2"]}
+            )
+            assert server_filter == [{expected: "test1"}, {expected: "test2"}]
+
+        # EQUAL_TO should have the same mappings for ANY_IN
+        server_side_test_mappings(
+            server_side_handler,
+            client_side_handler,
+            QueryPresetsGeneric.EQUAL_TO,
+            expected_mappings,
+        )
+
+        client_side_match(
+            client_side_handler,
+            QueryPresetsGeneric.ANY_IN,
+            list(expected_mappings.keys()),
+        )
+
+    return _server_side_any_in_test_case

--- a/tests/lib/openstack_query/mappings/test_server_mapping.py
+++ b/tests/lib/openstack_query/mappings/test_server_mapping.py
@@ -42,12 +42,42 @@ def test_server_side_handler_mappings_equal_to(server_side_test_mappings):
         ServerProperties.SERVER_NAME: "hostname",
         ServerProperties.SERVER_STATUS: "vm_state",
         ServerProperties.SERVER_DESCRIPTION: "description",
+        ServerProperties.SERVER_CREATION_DATE: "created_at",
+        ServerProperties.FLAVOR_ID: "flavor",
+        ServerProperties.IMAGE_ID: "image",
         ServerProperties.PROJECT_ID: "project_id",
     }
     server_side_test_mappings(
         ServerMapping.get_server_side_handler(),
         ServerMapping.get_client_side_handlers().generic_handler,
         QueryPresetsGeneric.EQUAL_TO,
+        mappings,
+    )
+
+
+def test_server_side_handler_mappings_any_in(server_side_any_in_mappings):
+    """
+    Tests server side handler mappings are correct for ANY_IN, and line up to the expected
+    server side params for equal to params
+    Tests that mappings render multiple server-side filters if multiple values given.
+    Tests that equivalent equal to server-side filter exists for each ANY_IN filter - since they
+    produce equivalent filters
+    """
+
+    mappings = {
+        ServerProperties.USER_ID: "user_id",
+        ServerProperties.SERVER_ID: "uuid",
+        ServerProperties.SERVER_NAME: "hostname",
+        ServerProperties.SERVER_STATUS: "vm_state",
+        ServerProperties.SERVER_DESCRIPTION: "description",
+        ServerProperties.SERVER_CREATION_DATE: "created_at",
+        ServerProperties.FLAVOR_ID: "flavor",
+        ServerProperties.IMAGE_ID: "image",
+        ServerProperties.PROJECT_ID: "project_id",
+    }
+    server_side_any_in_mappings(
+        ServerMapping.get_server_side_handler(),
+        ServerMapping.get_client_side_handlers().generic_handler,
         mappings,
     )
 
@@ -117,6 +147,8 @@ def test_client_side_handlers_generic(client_side_test_mappings):
     mappings = {
         QueryPresetsGeneric.EQUAL_TO: ["*"],
         QueryPresetsGeneric.NOT_EQUAL_TO: ["*"],
+        QueryPresetsGeneric.ANY_IN: ["*"],
+        QueryPresetsGeneric.NOT_ANY_IN: ["*"],
     }
     client_side_test_mappings(handler, mappings)
 

--- a/tests/lib/openstack_query/mappings/test_user_mapping.py
+++ b/tests/lib/openstack_query/mappings/test_user_mapping.py
@@ -45,6 +45,28 @@ def test_server_side_handler_mappings_equal_to(server_side_test_mappings):
     )
 
 
+def test_server_side_handler_mappings_any_in(server_side_any_in_mappings):
+    """
+    Tests server side handler mappings are correct for ANY_IN, and line up to the expected
+    server side params for equal to params
+    Tests that mappings render multiple server-side filters if multiple values given.
+    Tests that equivalent equal to server-side filter exists for each ANY_IN filter - since they
+    produce equivalent filters
+    """
+
+    mappings = {
+        UserProperties.USER_DOMAIN_ID: "domain_id",
+        UserProperties.USER_NAME: "name",
+        UserProperties.USER_ID: "id",
+    }
+
+    server_side_any_in_mappings(
+        UserMapping.get_server_side_handler(),
+        UserMapping.get_client_side_handlers().generic_handler,
+        mappings,
+    )
+
+
 def test_client_side_handlers_generic(client_side_test_mappings):
     """
     Tests client side handler mappings are correct, and line up to the expected
@@ -54,6 +76,8 @@ def test_client_side_handlers_generic(client_side_test_mappings):
     mappings = {
         QueryPresetsGeneric.EQUAL_TO: ["*"],
         QueryPresetsGeneric.NOT_EQUAL_TO: ["*"],
+        QueryPresetsGeneric.ANY_IN: ["*"],
+        QueryPresetsGeneric.NOT_ANY_IN: ["*"],
     }
     client_side_test_mappings(handler, mappings)
 

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -62,11 +62,14 @@ def test_parse_where_valid(mock_server_side_filter, instance, mock_server_side_h
     with patch(
         "openstack_query.query_blocks.query_builder.QueryBuilder._get_preset_handler"
     ) as mock_get_preset_handler:
-        mock_get_preset_handler.return_value = mock_client_side_handler
-        with patch.object(MockProperties, "get_prop_mapping") as mock_prop_func:
-            instance.parse_where(
-                MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_kwargs
-            )
+        with patch(
+            "openstack_query.query_blocks.query_builder.QueryBuilder._add_filter"
+        ) as mock_add_filter:
+            mock_get_preset_handler.return_value = mock_client_side_handler
+            with patch.object(MockProperties, "get_prop_mapping") as mock_prop_func:
+                instance.parse_where(
+                    MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_kwargs
+                )
 
     mock_get_preset_handler.assert_called_once_with(
         MockQueryPresets.ITEM_1, MockProperties.PROP_1
@@ -83,20 +86,10 @@ def test_parse_where_valid(mock_server_side_filter, instance, mock_server_side_h
         params=mock_kwargs,
     )
 
-    assert instance.client_side_filter == mock_client_filter_func
-    assert instance.server_side_filters == mock_server_side_filter
-
-
-def test_parse_where_filter_already_set(instance):
-    """
-    Tests that parse_where functions expectedly
-    method raises ParseQueryError when client_side_filter already set
-    """
-
-    instance.client_side_filter = "previously-set-func"
-
-    with pytest.raises(ParseQueryError):
-        instance.parse_where(MockQueryPresets.ITEM_1, MockProperties.PROP_1)
+    mock_add_filter.assert_called_once_with(
+        client_side_filter=mock_client_filter_func,
+        server_side_filters=mock_server_side_filter,
+    )
 
 
 def test_parse_where_prop_invalid(instance):

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -3,7 +3,6 @@ import pytest
 
 from openstack_query.query_blocks.query_builder import QueryBuilder
 
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_preset_mapping_error import QueryPresetMappingError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
@@ -171,6 +170,7 @@ def test_add_filter_no_server_side_filter(instance):
     """
     mock_client_side_filter = MagicMock()
 
+    # pylint:disable=protected-access
     instance._add_filter(
         client_side_filter=mock_client_side_filter, server_side_filters=None
     )
@@ -224,6 +224,7 @@ def test_add_filter_with_server_side_filter(
     mock_client_side_filter = MagicMock()
     instance.server_side_filters = set_server_side_filters
 
+    # pylint:disable=protected-access
     instance._add_filter(
         client_side_filter=mock_client_side_filter,
         server_side_filters=server_side_filters,

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -169,3 +169,71 @@ def test_server_side_filters(instance):
     instance.server_side_filters = "some-server-side-filter"
     res = instance.server_side_filters
     assert res == "some-server-side-filter"
+
+
+def test_add_filter_no_server_side_filter(instance):
+    """
+    Tests add_filter method works properly - with no server filters
+    Should only set client_side_filter
+    """
+    mock_client_side_filter = MagicMock()
+
+    instance._add_filter(
+        client_side_filter=mock_client_side_filter, server_side_filters=None
+    )
+    instance.client_side_filters = [mock_client_side_filter]
+
+
+@pytest.mark.parametrize(
+    "set_server_side_filters, server_side_filters, expected_values",
+    [
+        # no previous filters set
+        # one server-side filter to add
+        ([], {"filter1": "val1"}, [{"filter1": "val1"}]),
+        # one (non-overlapping) server-side filter set
+        # one server-side filter set to add
+        (
+            [{"filter1": "val1"}],
+            {"filter2": "val2"},
+            [{"filter1": "val1", "filter2": "val2"}],
+        ),
+        # multiple (non-overlapping) server-side filters set, one
+        # one server-side filter set to add
+        (
+            [{"filter1": "val1"}, {"filter2": "val2"}],
+            {"filter3": "val3"},
+            [
+                {"filter1": "val1", "filter3": "val3"},
+                {"filter2": "val2", "filter3": "val3"},
+            ],
+        ),
+        # multiple (non-overlapping) server-side filters set
+        # multiple server-side filter sets to add
+        (
+            [{"filter1": "val1"}, {"filter2": "val2"}],
+            [{"filter3": "val3"}, {"filter4": "val4"}],
+            [
+                {"filter1": "val1", "filter3": "val3"},
+                {"filter1": "val1", "filter4": "val4"},
+                {"filter2": "val2", "filter3": "val3"},
+                {"filter2": "val2", "filter4": "val4"},
+            ],
+        ),
+    ],
+)
+def test_add_filter_with_server_side_filter(
+    set_server_side_filters, server_side_filters, expected_values, instance
+):
+    """
+    Tests add_filter method works properly - with one set of server side filters
+    Should only set client_side_filter
+    """
+    mock_client_side_filter = MagicMock()
+    instance.server_side_filters = set_server_side_filters
+
+    instance._add_filter(
+        client_side_filter=mock_client_side_filter,
+        server_side_filters=server_side_filters,
+    )
+
+    assert instance.server_side_filters == expected_values

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -87,7 +87,7 @@ def test_parse_where_valid(mock_server_side_filter, instance, mock_server_side_h
 
     mock_add_filter.assert_called_once_with(
         client_side_filter=mock_client_filter_func,
-        server_side_filters=mock_server_side_filter,
+        server_side_filters=[mock_server_side_filter],
     )
 
 

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -163,6 +163,15 @@ def test_server_side_filters(instance):
     assert res == "some-server-side-filter"
 
 
+def test_server_filter_fallback(instance):
+    """
+    Tests server_filter_fallback property methods
+    """
+    instance.server_filter_fallback = "some-client-side-filter"
+    res = instance.server_filter_fallback
+    assert res == "some-client-side-filter"
+
+
 def test_add_filter_no_server_side_filter(instance):
     """
     Tests add_filter method works properly - with no server filters
@@ -231,3 +240,4 @@ def test_add_filter_with_server_side_filter(
     )
 
     assert instance.server_side_filters == expected_values
+    assert instance.server_filter_fallback == [mock_client_side_filter]

--- a/tests/lib/openstack_query/query_blocks/test_query_executer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_executer.py
@@ -96,9 +96,8 @@ def test_run_query_without_parse_func(mock_get_output, instance):
     Should call runner.run() and return a tuple of runner.run result and get_output result
     """
 
-    instance._client_side_filter_func = MagicMock()
-    instance._server_side_filters = MagicMock()
-    instance._parse_func = None
+    instance.client_side_filters = MagicMock()
+    instance.server_side_filters = MagicMock()
 
     res1, res2 = instance.run_query(
         cloud_account=CloudDomains.PROD,
@@ -108,8 +107,8 @@ def test_run_query_without_parse_func(mock_get_output, instance):
 
     instance.runner.run.assert_called_once_with(
         cloud_account="prod",
-        client_side_filter_func=instance._client_side_filter_func,
-        server_side_filters=instance._server_side_filters,
+        client_side_filters=instance.client_side_filters,
+        server_side_filters=instance.server_side_filters,
         from_subset=["res1", "res2", "res3"],
         **{"arg1": "val1"}
     )
@@ -126,11 +125,11 @@ def test_run_query_with_parse_func(mock_get_output, instance):
     Should call runner.run() and then parse_func, and then output a tuple of
     parse_func result and get_output result
     """
-    instance._client_side_filter_func = MagicMock()
-    instance._server_side_filters = MagicMock()
+    instance.client_side_filters = MagicMock()
+    instance.server_side_filters = MagicMock()
 
     mock_parse_func = MagicMock()
-    instance._parse_func = mock_parse_func
+    instance.parse_func = mock_parse_func
 
     res1, res2 = instance.run_query(
         cloud_account=CloudDomains.PROD,
@@ -140,8 +139,8 @@ def test_run_query_with_parse_func(mock_get_output, instance):
 
     instance.runner.run.assert_called_once_with(
         cloud_account="prod",
-        client_side_filter_func=instance._client_side_filter_func,
-        server_side_filters=instance._server_side_filters,
+        client_side_filters=instance.client_side_filters,
+        server_side_filters=instance.server_side_filters,
         from_subset=["res1", "res2", "res3"],
         **{"arg1": "val1"}
     )
@@ -160,9 +159,9 @@ def test_run_query_with_string_as_domain(mock_get_output, instance):
     Should call runner.run() and return a tuple of runner.run result and get_output result
     """
 
-    instance._client_side_filter_func = MagicMock()
-    instance._server_side_filters = MagicMock()
-    instance._parse_func = None
+    instance.client_side_filters = MagicMock()
+    instance.server_side_filters = MagicMock()
+    instance.parse_func = None
 
     res1, res2 = instance.run_query(
         cloud_account="test-account",
@@ -172,8 +171,8 @@ def test_run_query_with_string_as_domain(mock_get_output, instance):
 
     instance.runner.run.assert_called_once_with(
         cloud_account="test-account",
-        client_side_filter_func=instance._client_side_filter_func,
-        server_side_filters=instance._server_side_filters,
+        client_side_filters=instance.client_side_filters,
+        server_side_filters=instance.server_side_filters,
         from_subset=["res1", "res2", "res3"],
         **{"arg1": "val1"}
     )

--- a/tests/lib/openstack_query/runners/test_runner_wrapper.py
+++ b/tests/lib/openstack_query/runners/test_runner_wrapper.py
@@ -76,15 +76,15 @@ def run_paginated_query_test_fixture(instance):
 
 
 @pytest.fixture(name="runner_run_test_case")
-def runner_run_test_case_fixture(instance, mock_connection):
+def runner_run_test_case_fixture(instance, mock_connection, mock_openstack_connection):
     """
     Fixture to run run() test cases with different args
     """
 
     def _runner_run_test_case(
-        mock_client_side_filters,
-        mock_server_side_filters,
-        mock_from_subset,
+        mock_client_side_filters=None,
+        mock_server_side_filters=None,
+        mock_from_subset=None,
         **mock_kwargs,
     ):
         """
@@ -93,18 +93,202 @@ def runner_run_test_case_fixture(instance, mock_connection):
         prior to this and any asserts need to be done by the test function
         """
 
-        # TODO this fixture needs editing
-        _ = instance.run(
-            cloud_account="test-account",
-            client_side_filters=mock_client_side_filters,
-            server_side_filters=mock_server_side_filters,
-            from_subset=mock_from_subset,
-            **mock_kwargs,
-        )
+        with patch(
+            "openstack_query.runners.runner_wrapper.RunnerWrapper._parse_subset"
+        ) as mock_parse_subset:
+            with patch(
+                "openstack_query.runners.runner_wrapper.RunnerWrapper._run_with_openstacksdk"
+            ) as mock_run_with_openstacksdk:
+                with patch(
+                    "openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filters"
+                ) as mock_apply_client_side_filters:
+                    res = instance.run(
+                        cloud_account="test-account",
+                        client_side_filters=mock_client_side_filters,
+                        server_side_filters=mock_server_side_filters,
+                        from_subset=mock_from_subset,
+                        **mock_kwargs,
+                    )
+
+        if mock_from_subset:
+            mock_parse_subset.assert_called_once_with(
+                conn=mock_openstack_connection, subset=mock_from_subset
+            )
+            mock_run_with_openstacksdk.assert_not_called()
+
+        else:
+            mock_run_with_openstacksdk.assert_called_once_with(
+                conn=mock_openstack_connection,
+                server_filters=mock_server_side_filters,
+                **mock_kwargs,
+            )
+            mock_parse_subset.assert_not_called()
+
+        query_out = mock_run_with_openstacksdk.return_value
+        if mock_from_subset:
+            query_out = mock_parse_subset.return_value
+
+        if mock_client_side_filters:
+            mock_apply_client_side_filters.assert_called_once_with(
+                items=query_out, filters=mock_client_side_filters
+            )
+            query_out = mock_apply_client_side_filters.return_value
+
+        assert res == query_out
         mock_connection.assert_called_once_with("test-account")
 
+    return _runner_run_test_case
 
-# TODO add run() tests and run_with_openstacksdk tests
+
+def test_run_with_subset_no_client_filters(runner_run_test_case):
+    """
+    Tests run() method functions expectedly - given subset and no client filters
+    """
+    runner_run_test_case(
+        mock_from_subset=["item1", "item2", "item3"],
+    )
+
+
+def test_run_with_subset_and_client_filter(runner_run_test_case):
+    """
+    Tests run() method functions expectedly - given subset and client filters
+    """
+    runner_run_test_case(
+        mock_client_side_filters=["client-filter1", "client-filter2"],
+        mock_from_subset=["item1", "item2", "item3"],
+    )
+
+
+def test_run_with_server_side_filter_no_client_filter(runner_run_test_case):
+    """
+    Tests run() method functions expectedly - given subset and kwargs, no client filters
+    """
+    runner_run_test_case(
+        mock_server_side_filters=["server-filter1", "server-filter2"],
+        mock_kwargs={"arg1": "val1", "arg2": "val2"},
+    )
+
+
+def test_run_with_server_side_filter_and_client_filter(runner_run_test_case):
+    """
+    Tests run() method functions expectedly - given subset and client filters
+    """
+    runner_run_test_case(
+        mock_client_side_filters=["client-filter1", "client-filter2"],
+        mock_server_side_filters=["server-filter1", "server-filter2"],
+    )
+
+
+def test_run_both_server_filter_and_subset(instance):
+    """
+    Tests run() method functions expectedly - given subset and server filters
+    should raise an error
+    """
+    with pytest.raises(RuntimeError):
+        instance.run(
+            cloud_account="test_account",
+            from_subset=["item1", "item2"],
+            server_side_filters=["server-filter1", "server-filter2"],
+        )
+
+
+@pytest.fixture(name="run_with_openstacksdk_test_case")
+def run_with_openstacksdk_test_case_fixture(instance, mock_connection):
+    """
+    Fixture to test _run_with_openstacksdk with different test cases
+    """
+
+    def _run_with_openstacksdk_test_case(mock_server_filters, **mock_kwargs):
+        with patch(
+            "openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params"
+        ) as mock_parse_meta_params:
+            with patch(
+                "openstack_query.runners.runner_wrapper.RunnerWrapper._run_query"
+            ) as mock_run_query:
+                mock_parse_meta_params.return_value = {"parsed_arg1": "val1"}
+                mock_run_query.return_value = ["query_outputs"]
+                res = instance._run_with_openstacksdk(
+                    conn=mock_connection,
+                    server_filters=mock_server_filters,
+                    **mock_kwargs,
+                )
+
+        if mock_kwargs:
+            mock_parse_meta_params.assert_called_once_with(
+                mock_connection, **mock_kwargs
+            )
+            run_query_kwargs = mock_parse_meta_params.return_value
+        else:
+            mock_parse_meta_params.assert_not_called()
+            run_query_kwargs = {}
+
+        # check that run_query has been called correctly for each mock filter given
+        for mock_filter in mock_server_filters:
+            mock_run_query.assert_any_call(
+                mock_connection, mock_filter, **run_query_kwargs
+            )
+        # assert that result contains concatenated results of mock_run_query
+        assert res == [
+            i for i in mock_run_query.return_value for _ in mock_server_filters
+        ]
+
+    return _run_with_openstacksdk_test_case
+
+
+def test_run_with_openstacksdk_one_filter_and_kwargs(run_with_openstacksdk_test_case):
+    """
+    Tests _run_with_openstacksdk works properly - with one filter, and with kwargs
+    """
+    run_with_openstacksdk_test_case(
+        [{"filter1": "val1"}], **{"arg1": "val1", "arg2": "val2"}
+    )
+
+
+def test_run_with_openstacksdk_one_filter_no_kwargs(run_with_openstacksdk_test_case):
+    """
+    Tests _run_with_openstacksdk works properly - with one filter, and with no kwargs
+    """
+    run_with_openstacksdk_test_case([{"filter1": "val1"}])
+
+
+def test_run_with_openstacksdk_two_filters_no_kwargs(run_with_openstacksdk_test_case):
+    """
+    Tests _run_with_openstacksdk works properly - with two filters, and with no kwargs
+    """
+    run_with_openstacksdk_test_case([{"filter1": "val1"}, {"filter2": "val2"}])
+
+
+def test_run_with_openstacksdk_two_filters_and_kwargs(run_with_openstacksdk_test_case):
+    """
+    Tests _run_with_openstacksdk works properly - with two filters, and with kwargs
+    """
+    run_with_openstacksdk_test_case(
+        [{"filter1": "val1"}, {"filter2": "val2"}], **{"arg1": "val1", "arg2": "val2"}
+    )
+
+
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
+@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
+def test_run_with_openstacksdk_no_filters(
+    mock_run_query, mock_parse_meta_params, instance, mock_connection
+):
+    """
+    Tests _run_with_openstacksdk works properly - with no filters
+    run_query should be called with no filters
+    """
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    mock_parse_meta_params.return_value = {"parsed-arg1": "val1"}
+    mock_run_query.return_value = ["query-output"]
+    res = instance._run_with_openstacksdk(
+        conn=mock_connection, server_filters=None, **mock_kwargs
+    )
+
+    mock_parse_meta_params.assert_called_once_with(mock_connection, **mock_kwargs)
+
+    mock_run_query.assert_called_once_with(
+        mock_connection, None, **mock_parse_meta_params.return_value
+    )
+    assert res == mock_run_query.return_value
 
 
 def test_apply_client_side_filters_one_filter(instance):

--- a/tests/lib/openstack_query/runners/test_runner_wrapper.py
+++ b/tests/lib/openstack_query/runners/test_runner_wrapper.py
@@ -75,144 +75,74 @@ def run_paginated_query_test_fixture(instance):
 # pylint:disable=too-many-arguments
 
 
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter")
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
-def test_run_with_only_client_side_filter(
-    mock_parse_meta_params,
-    mock_run_query,
-    mock_apply_client_side_filter,
-    instance,
-    mock_connection,
-    mock_openstack_connection,
-):
+@pytest.fixture(name="runner_run_test_case")
+def runner_run_test_case_fixture(instance, mock_connection):
     """
-    Tests that run method functions expectedly - with only client_side_filter_func set
-    method should call run_query and run apply_client_side_filter and return results
-    also tests with no meta-params set
+    Fixture to run run() test cases with different args
     """
 
-    mock_run_query.return_value = ["openstack-resource-1", "openstack-resource-2"]
-    mock_apply_client_side_filter.return_value = ["openstack-resource-1"]
+    def _runner_run_test_case(
+        mock_client_side_filters,
+        mock_server_side_filters,
+        mock_from_subset,
+        **mock_kwargs,
+    ):
+        """
+        method to run run() test case with provided input values
+        The individual methods that are called in run must be patched out by the test function
+        prior to this and any asserts need to be done by the test function
+        """
 
-    mock_client_side_filter_func = MagicMock()
-    mock_cloud_domain = MagicMock()
-
-    res = instance.run(
-        cloud_account=mock_cloud_domain,
-        client_side_filter_func=mock_client_side_filter_func,
-    )
-    mock_connection.assert_called_once_with(mock_cloud_domain)
-
-    mock_parse_meta_params.assert_not_called()
-    mock_run_query.assert_called_once_with(mock_openstack_connection, None)
-
-    mock_apply_client_side_filter.assert_called_once_with(
-        ["openstack-resource-1", "openstack-resource-2"],
-        mock_client_side_filter_func,
-    )
-    mock_client_side_filter_func.assert_not_called()
-    assert ["openstack-resource-1"] == res
-
-
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
-def test_run_with_server_side_filters(
-    mock_parse_meta_params,
-    mock_run_query,
-    instance,
-    mock_connection,
-    mock_openstack_connection,
-):
-    """
-    Tests that run method functions expectedly - with server_side_filters set
-    method should call run_query and return results
-    """
-    mock_server_filters = {"server_filter1": "abc", "server_filter2": False}
-    mock_run_query.return_value = ["openstack-resource-1"]
-    instance._run_query = mock_run_query
-    mock_client_side_filter_func = MagicMock()
-    mock_user_domain = MagicMock()
-
-    mock_parse_meta_params.return_value = {
-        "parsed_arg1": "val1",
-        "parsed_arg2": "val2",
-    }
-
-    res = instance.run(
-        cloud_account=mock_user_domain,
-        client_side_filter_func=mock_client_side_filter_func,
-        server_side_filters=mock_server_filters,
-        **{"arg1": "val1", "arg2": "val2"},
-    )
-    mock_connection.assert_called_once_with(mock_user_domain)
-
-    mock_parse_meta_params.assert_called_once_with(
-        mock_openstack_connection, **{"arg1": "val1", "arg2": "val2"}
-    )
-
-    mock_run_query.assert_called_once_with(
-        mock_openstack_connection,
-        mock_server_filters,
-        **{"parsed_arg1": "val1", "parsed_arg2": "val2"},
-    )
-
-    # if we have server-side filters, don't use client_side_filters
-    mock_client_side_filter_func.assert_not_called()
-    assert res == ["openstack-resource-1"]
+        # TODO this fixture needs editing
+        _ = instance.run(
+            cloud_account="test-account",
+            client_side_filters=mock_client_side_filters,
+            server_side_filters=mock_server_side_filters,
+            from_subset=mock_from_subset,
+            **mock_kwargs,
+        )
+        mock_connection.assert_called_once_with("test-account")
 
 
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_subset")
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter")
-def test_run_with_subset(
-    mock_apply_filter_func,
-    mock_parse_subset,
-    instance,
-    mock_connection,
-    mock_openstack_connection,
-):
-    """
-    Tests that run method functions expectedly - with meta param 'from_subset' set
-    method should run parse_subset on 'from_subset' values and then apply_client_side_filter and return results
-    """
-    mock_parse_subset.return_value = [
-        "parsed-openstack-resource-1",
-        "parsed-openstack-resource-2",
-    ]
-    mock_apply_filter_func.return_value = ["parsed-openstack-resource-1"]
-    mock_client_side_filter_func = MagicMock()
-    mock_cloud_domain = MagicMock()
-
-    res = instance.run(
-        cloud_account=mock_cloud_domain,
-        client_side_filter_func=mock_client_side_filter_func,
-        from_subset=["openstack-resource-1", "openstack-resource-2"],
-    )
-    mock_connection.assert_any_call(mock_cloud_domain)
-
-    mock_parse_subset.assert_called_once_with(
-        mock_openstack_connection, ["openstack-resource-1", "openstack-resource-2"]
-    )
-
-    mock_apply_filter_func.assert_called_once_with(
-        ["parsed-openstack-resource-1", "parsed-openstack-resource-2"],
-        mock_client_side_filter_func,
-    )
-    assert res == ["parsed-openstack-resource-1"]
+# TODO add run() tests and run_with_openstacksdk tests
 
 
-def test_apply_filter_func(instance):
+def test_apply_client_side_filters_one_filter(instance):
     """
     Tests that apply_filter_func method functions expectedly
-    method should iteratively run filter_func on each item and return only those that filter_function returned True
+    with one filter function
+    method should iteratively run single filter function on each
+    item and return only those that filter_function returned True
     """
-    mock_client_side_filter_func = MagicMock()
-    mock_client_side_filter_func.side_effect = [False, True]
+    mock_filters = MagicMock()
+    mock_filters.side_effect = [False, True]
 
     mock_items = ["openstack-resource-1", "openstack-resource-2"]
-
-    res = instance._apply_client_side_filter(mock_items, mock_client_side_filter_func)
+    res = instance._apply_client_side_filters(mock_items, [mock_filters])
     assert ["openstack-resource-2"] == res
+
+
+def test_apply_client_side_filters_multi_filter(instance):
+    """
+    Tests that apply_filter_func method functions expectedly
+    - with  many filter functions
+    method should iteratively run each filter function on each item and
+    return only those that filter_function returned True
+    """
+    mock_filter1 = MagicMock()
+    mock_filter1.side_effect = [False, False, True, True]
+
+    mock_filter2 = MagicMock()
+    mock_filter2.side_effect = [False, True, False, True]
+
+    mock_items = [
+        "openstack-resource-1",
+        "openstack-resource-2",
+        "openstack-resource-3",
+        "openstack-resource-4",
+    ]
+    res = instance._apply_client_side_filters(mock_items, [mock_filter1, mock_filter2])
+    assert ["openstack-resource-4"] == res
 
 
 def test_run_pagination_query_gt_0(run_paginated_query_test):


### PR DESCRIPTION
refactored builder and runner methods to allow multiple where() methods to be run. This allows you to define multiple presets to filter by.

This change also fixes ANY_IN - now using ANY_IN will run multiple server-side EQUAL_TO queries and aggregate the results - acting essentially as OR

server side and client side fiilters now accept a list instead of just one 
