### PR TITLE
BUG: Make sure email addresses to email are provided as a list

### DIFF
--- a/lib/custom_types/email_api/aliases.py
+++ b/lib/custom_types/email_api/aliases.py
@@ -1,7 +1,7 @@
-from typing import Dict, Tuple
+from typing import Dict, List
 
 EmailAddress = str
-EmailAddresses = Tuple[EmailAddress]
+EmailAddresses = List[EmailAddress]
 
 # Maps name of a template to a set of kwargs that the template will use to render string output
 TemplateMappings = Dict[str, Dict[str, str]]


### PR DESCRIPTION
### Description:

If an email address has something like an apostrophe, it will split the email address into individual characters. Email params has been updated to take email addresses as a list of addresses

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
