### PR TITLE
MAINT: Allow query objects to be imported at root level

### DIFF
--- a/lib/openstack_query/__init__.py
+++ b/lib/openstack_query/__init__.py
@@ -1,5 +1,7 @@
 import sys
 import logging
+from .api.query_objects import ServerQuery
+from .api.query_objects import UserQuery
 
 # Create logger
 openstack_query_loggers = logging.getLogger(__name__)

--- a/tests/lib/openstack_query/test_api_imports.py
+++ b/tests/lib/openstack_query/test_api_imports.py
@@ -1,0 +1,9 @@
+import pytest
+
+import openstack_query
+
+
+@pytest.mark.parametrize("test_module_name", ["ServerQuery", "UserQuery"])
+def test_query_server_import(test_module_name):
+    """Tests that query object imports can be done at root level"""
+    assert getattr(openstack_query, test_module_name)


### PR DESCRIPTION
makes the importing of query objects easier for users
