### PR TITLE
BUG: fix regex bug

### DIFF
--- a/lib/openstack_query/handlers/client_side_handler_string.py
+++ b/lib/openstack_query/handlers/client_side_handler_string.py
@@ -23,10 +23,10 @@ class ClientSideHandlerString(ClientSideHandler):
             QueryPresetsString.MATCHES_REGEX: self._prop_matches_regex,
         }
 
-    def _prop_matches_regex(self, prop: Any, regex_string: str) -> bool:
+    def _prop_matches_regex(self, prop: Any, value: str) -> bool:
         """
         Filter function which returns true if a prop matches a regex pattern
         :param prop: prop value to check against
-        :param regex_string: a string which can be converted into a valid regex pattern to run
+        :param value: a string which can be converted into a valid regex pattern to run
         """
-        return bool(re.match(re.compile(regex_string), prop))
+        return bool(re.match(re.compile(rf"{value}"), prop))

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_string.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_string.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch, NonCallableMock
-
 import pytest
 
 from enums.query.query_presets import QueryPresetsString
@@ -32,32 +30,23 @@ def test_check_supported_all_presets(instance):
 
 
 @pytest.mark.parametrize(
-    "regex_string, test_prop",
+    "regex_string, test_prop, expected",
     [
         # "Numeric digits only",
-        ("[0-9]+", "123"),
+        ("[0-9]+", "123", True),
         # "Alphabetic characters only",
-        ("[A-Za-z]+", "abc"),
+        ("[A-Za-z]+", "abc", True),
         # "No alphabetic characters",
-        ("[A-Za-z]+", "123"),
+        ("[A-Za-z]+", "123", False),
         # "Alphabetic and numeric characters",
-        ("[A-Za-z0-9]+", "abc123"),
+        ("[A-Za-z0-9]+", "abc123", True),
         # "Empty string, no match",
-        ("[A-Za-z]+", ""),
+        ("[0-9]+", "", False),
     ],
 )
-@patch("re.match")
-@patch("re.compile")
-def test_prop_matches_regex_valid(
-    mock_regex_compile, mock_regex_match, regex_string, test_prop, instance
-):
+def test_prop_matches_regex(regex_string, test_prop, expected, instance):
     """
     Tests that method prop_matches_regex functions expectedly - with valid regex patterns
     Returns True if test_prop matches given regex pattern regex_string
     """
-    mock_compile = NonCallableMock()
-    mock_regex_match.return_value = test_prop
-    mock_regex_compile.return_value = mock_compile
-    instance._prop_matches_regex(test_prop, regex_string)
-    mock_regex_match.assert_called_once_with(mock_compile, test_prop)
-    mock_regex_compile.assert_called_once_with(regex_string)
+    assert instance._prop_matches_regex(test_prop, regex_string) == expected


### PR DESCRIPTION
fix regex client-side handler regex not working

change to use a regular string because running re.compile on a normal string doesn't work
change the test to actually test whether regex works instead of just mocking it
