### PR TITLE
MAINT: separate out executing and parsing

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -23,11 +23,6 @@ class QueryAPI:
         self.output = query_components.output
         self._query_results = None
         self._query_results_as_objects = None
-
-        # setup executer functions
-        self.executer.parse_func = self.parser.run_parser
-        self.executer.output_func = self.output.generate_output
-
         self._query_run = False
 
     def select(self, *props: PropEnum):
@@ -164,7 +159,9 @@ class QueryAPI:
         :param flatten: boolean which will flatten results if true
         :param groups: a list group to limit output by
         """
-        result_as_objects, selected_results = self.executer.parse_results()
+        result_as_objects, selected_results = self.executer.parse_results(
+            parse_func=self.parser.run_parser, output_func=self.output.generate_output
+        )
         results = result_as_objects if as_objects else selected_results
 
         if groups:
@@ -191,7 +188,10 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        _, selected_results = self.executer.parse_results()
+        _, selected_results = self.executer.parse_results(
+            parse_func=self.parser.run_parser, output_func=self.output.generate_output
+        )
+
         return self.output.to_string(selected_results, title, groups, **kwargs)
 
     def to_html(
@@ -203,5 +203,7 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        _, selected_results = self.executer.parse_results()
+        _, selected_results = self.executer.parse_results(
+            parse_func=self.parser.run_parser, output_func=self.output.generate_output
+        )
         return self.output.to_html(selected_results, title, groups, **kwargs)

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -24,6 +24,12 @@ class QueryAPI:
         self._query_results = None
         self._query_results_as_objects = None
 
+        # setup executer functions
+        self.executer.parse_func = self.parser.run_parser
+        self.executer.output_func = self.output.generate_output
+
+        self._query_run = False
+
     def select(self, *props: PropEnum):
         """
         Public method used to 'select' properties that the query will return the value of.
@@ -94,6 +100,7 @@ class QueryAPI:
             - False (ascending) or True (descending)
         """
         self.parser.parse_sort_by(*sort_by)
+        return self
 
     def group_by(
         self,
@@ -110,10 +117,9 @@ class QueryAPI:
         output of values found that were
         not specified in group mappings - ignored if group ranges not given
         """
-        if self.parser.group_by:
-            raise ParseQueryError("group by already set")
-
         self.parser.parse_group_by(group_by, group_ranges, include_ungrouped_results)
+
+        return self
 
     def run(
         self,
@@ -141,14 +147,12 @@ class QueryAPI:
             self.executer.client_side_filters = self.builder.client_side_filters
             self.executer.server_side_filters = self.builder.server_side_filters
 
-        self.executer.parse_func = self.parser.run_parser
-        self.executer.output_func = self.output.generate_output
-
-        self._query_results_as_objects, self._query_results = self.executer.run_query(
+        self.executer.run_query(
             cloud_account=cloud_account,
             from_subset=from_subset,
             **kwargs,
         )
+        self._query_run = True
         return self
 
     def to_list(
@@ -160,9 +164,8 @@ class QueryAPI:
         :param flatten: boolean which will flatten results if true
         :param groups: a list group to limit output by
         """
-        results = self._query_results
-        if as_objects:
-            results = self._query_results_as_objects
+        result_as_objects, selected_results = self.executer.parse_results()
+        results = result_as_objects if as_objects else selected_results
 
         if groups:
             if not isinstance(results, dict):
@@ -188,7 +191,8 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        return self.output.to_string(self._query_results, title, groups, **kwargs)
+        _, selected_results = self.executer.parse_results()
+        return self.output.to_string(selected_results, title, groups, **kwargs)
 
     def to_html(
         self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
@@ -199,4 +203,5 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        return self.output.to_html(self._query_results, title, groups, **kwargs)
+        _, selected_results = self.executer.parse_results()
+        return self.output.to_html(selected_results, title, groups, **kwargs)

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -140,8 +140,7 @@ class QueryOutput:
                 )
             all_props.add(prop)
 
-        selected_props = set(self.selected_props)
-        self.selected_props = selected_props.union(all_props)
+        self.selected_props = set(all_props)
 
     def generate_output(
         self, openstack_resources: List[OpenstackResourceObj]

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, NonCallableMock
+from unittest.mock import MagicMock
 import pytest
 
 from openstack_query.api.query_api import QueryAPI
@@ -222,12 +222,10 @@ def test_run_with_kwargs_and_subset(run_with_test_case_with_subset):
 def test_to_list_as_objects_false(instance):
     """
     Tests that to_list method functions expectedly
-    method should return _query_results attribute when as_objects is false
+    method should return _query_results attribute when as_objects is false and flatten is false
     """
-    # pylint: disable=protected-access
-    mock_query_results = NonCallableMock()
-    instance._query_results = mock_query_results
-    assert instance.to_list() == mock_query_results
+    instance.executer.parse_results.return_value = "", "parsed-list"
+    assert instance.to_list() == "parsed-list"
 
 
 def test_to_list_as_objects_true(instance):
@@ -236,9 +234,8 @@ def test_to_list_as_objects_true(instance):
     method should return _query_results_as_objects attribute when as_objects is true
     """
     # pylint: disable=protected-access
-    mock_query_results_as_obj = NonCallableMock()
-    instance._query_results_as_objects = mock_query_results_as_obj
-    assert instance.to_list(as_objects=True) == mock_query_results_as_obj
+    instance.executer.parse_results.return_value = "object-list", ""
+    assert instance.to_list(as_objects=True) == "object-list"
 
 
 def test_to_list_flatten_true(instance):
@@ -246,11 +243,9 @@ def test_to_list_flatten_true(instance):
     Tests that to_list method functions expectedly
     method should call output.flatten() with query_results
     """
-    # pylint: disable=protected-access
-    mock_query_results = NonCallableMock()
-    instance._query_results = mock_query_results
+    instance.executer.parse_results.return_value = "", "parsed-list"
     res = instance.to_list(flatten=True)
-    instance.output.flatten.assert_called_once_with(mock_query_results)
+    instance.output.flatten.assert_called_once_with("parsed-list")
     assert res == instance.output.flatten.return_value
 
 
@@ -259,11 +254,9 @@ def test_to_list_flatten_and_as_objects(instance):
     Tests that to_list method functions expectedly
     method should call output.flatten() with query_results_as_obj
     """
-    # pylint: disable=protected-access
-    mock_query_results_as_obj = NonCallableMock()
-    instance._query_results_as_objects = mock_query_results_as_obj
+    instance.executer.parse_results.return_value = "object-list", ""
     res = instance.to_list(as_objects=True, flatten=True)
-    instance.output.flatten.assert_called_once_with(mock_query_results_as_obj)
+    instance.output.flatten.assert_called_once_with("object-list")
     assert res == instance.output.flatten.return_value
 
 
@@ -272,9 +265,7 @@ def test_to_list_groups_not_dict(instance):
     Tests that to_list method functions expectedly
     method should raise error when given group and results are not dict
     """
-    # pylint: disable=protected-access
-    mock_query_results = ["result1", "result2"]
-    instance._query_results = mock_query_results
+    instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
     with pytest.raises(ParseQueryError):
         instance.to_list(groups=["group1", "group2"])
 
@@ -284,12 +275,11 @@ def test_to_list_groups_dict(instance):
     Tests that to_list method functions expectedly
     method should return subset of results which match keys (groups) given
     """
-    # pylint: disable=protected-access
     mock_query_results = {
         "group1": ["result1", "result2"],
         "group2": ["result3", "result4"],
     }
-    instance._query_results = mock_query_results
+    instance.executer.parse_results.return_value = "", mock_query_results
     res = instance.to_list(groups=["group1"])
     assert res == {"group1": mock_query_results["group1"]}
 
@@ -299,12 +289,11 @@ def test_to_list_group_not_valid(instance):
     Tests that to_list method functions expectedly
     method should return subset of results which match keys (groups) given
     """
-    # pylint: disable=protected-access
     mock_query_results = {
         "group1": ["result1", "result2"],
         "group2": ["result3", "result4"],
     }
-    instance._query_results = mock_query_results
+    instance.executer.parse_results.return_value = "", mock_query_results
     with pytest.raises(ParseQueryError):
         instance.to_list(groups=["group3"])
 
@@ -314,10 +303,9 @@ def test_to_string(instance):
     Tests that to_string method functions expectedly
     method should call QueryOutput object to_string() and return results
     """
-    mock_query_output = MagicMock()
-    instance.output = mock_query_output
-    instance.output.to_string.return_value = "string-out"
-    assert instance.to_string() == "string-out"
+    instance.executer.parse_results.return_value = "", "parsed-list"
+    assert instance.to_string() == instance.output.to_string.return_value
+    instance.output.to_string.assert_called_once_with("parsed-list", None, None)
 
 
 def test_to_html(instance):
@@ -325,10 +313,9 @@ def test_to_html(instance):
     Tests that to_html method functions expectedly
     method should call QueryOutput object to_html() and return results
     """
-    mock_query_output = MagicMock()
-    instance.output = mock_query_output
-    instance.output.to_html.return_value = "html-out"
-    assert instance.to_html() == "html-out"
+    instance.executer.parse_results.return_value = "", "parsed-list"
+    assert instance.to_html() == instance.output.to_html.return_value
+    instance.output.to_html.assert_called_once_with("parsed-list", None, None)
 
 
 def test_sort_by(instance):
@@ -337,8 +324,9 @@ def test_sort_by(instance):
     method should call QueryParser object parse_sort_by() and return results
     """
     mock_sort_by = [("some-prop-enum", False), ("some-prop-enum-2", True)]
-    instance.sort_by(*mock_sort_by)
+    res = instance.sort_by(*mock_sort_by)
     instance.parser.parse_sort_by.assert_called_once_with(*mock_sort_by)
+    assert res == instance
 
 
 def test_group_by(instance):
@@ -351,17 +339,10 @@ def test_group_by(instance):
     mock_include_ungrouped_results = False
     instance.parser.group_by = None
 
-    instance.group_by(mock_group_by, mock_group_ranges, mock_include_ungrouped_results)
+    res = instance.group_by(
+        mock_group_by, mock_group_ranges, mock_include_ungrouped_results
+    )
     instance.parser.parse_group_by.assert_called_once_with(
         mock_group_by, mock_group_ranges, mock_include_ungrouped_results
     )
-
-
-def test_group_by_already_set(instance):
-    """
-    Tests that group_by method functions expectedly
-    Should raise error when attempting to set group by when already set
-    """
-    instance.parser.group_by_prop = "prop1"
-    with pytest.raises(ParseQueryError):
-        instance.group_by("prop2")
+    assert res == instance

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -52,8 +52,6 @@ def run_with_test_case_with_subset_fixture(instance):
 
         assert instance.executer.client_side_filters == client_filters
         assert instance.executer.server_side_filters == server_filters
-        assert instance.executer.parse_func == instance.parser.run_parser
-        assert instance.executer.output_func == instance.output.generate_output
         assert res == instance
 
     return _run_with_test_case
@@ -90,8 +88,6 @@ def run_with_test_case_fixture(instance):
 
         assert instance.executer.client_side_filters == client_filters
         assert instance.executer.server_side_filters == server_filters
-        assert instance.executer.parse_func == instance.parser.run_parser
-        assert instance.executer.output_func == instance.output.generate_output
         assert res == instance
 
     return _run_with_test_case

--- a/tests/lib/openstack_query/query_blocks/test_query_output.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_output.py
@@ -313,6 +313,16 @@ def test_parse_select_given_invalid(instance):
         instance.parse_select(MockProperties.PROP_1, ServerProperties.SERVER_ID)
 
 
+def test_parse_select_overwrites_old(instance):
+    """
+    Tests that parse_select overwrites old selected_props
+    method should overwrite internal attribute selected_props if already set
+    """
+    instance.selected_props = [MockProperties.PROP_1]
+    instance.parse_select(MockProperties.PROP_2)
+    assert instance.selected_props == [MockProperties.PROP_2]
+
+
 def test_generate_output_no_items(instance):
     """
     Tests that generate_output method works expectedly - no openstack items


### PR DESCRIPTION
methods which handle sorting, grouping and generating output now decoupled with actually running the query - now these things can be changed at anytime and will only be calculated at the time of output without needing to re-run the query

I.e. you can do things like:
```
q1 = ServerQuery().where(...).run(...)
print(q1.group_by(a...).select(a, b, c).to_list())
print(q1.select(d, e, f).group_by(b..).sort_by(c..).to_string())
```

This will also have the hidden caveat that calling `select` will overwrite what was selected from previous calls - which means that a single select call must be used to set properties when outputting - which seems an okay trade-off
i.e. This is not possible anymore
```
q1.select(a).select(b).to_string()
```
you must do 
```
q1.select(a, b).to_string()
```