### PR TITLE
BUG: Fix all_tenants not being used as filter kwargs

### DIFF
--- a/lib/openstack_query/runners/server_runner.py
+++ b/lib/openstack_query/runners/server_runner.py
@@ -118,6 +118,16 @@ class ServerRunner(RunnerWrapper):
                 "- or you are not running as admin"
             )
 
+        if "all_tenants" in meta_params:
+            filter_kwargs["all_tenants"] = meta_params["all_tenants"]
+
+        if "projects" not in meta_params:
+            logger.debug(
+                "running openstacksdk command conn.compute.servers (%s)",
+                ", ".join(f"{key}={value}" for key, value in filter_kwargs.items()),
+            )
+            return self._run_paginated_query(conn.compute.servers, dict(filter_kwargs))
+
         query_res = []
         project_num = len(meta_params["projects"])
         logger.debug("running query on %s projects", project_num)

--- a/tests/lib/openstack_query/runners/test_server_runner.py
+++ b/tests/lib/openstack_query/runners/test_server_runner.py
@@ -237,6 +237,23 @@ def test_run_query_with_meta_arg_projects_with_server_side_queries(
 
 
 @patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+def test_run_query_meta_arg_all_tenants_no_projects(
+    mock_run_paginated_query, instance, mock_openstack_connection
+):
+    """
+    Tests _run_query method works expectedly - when meta arg all_tenants given
+    """
+    mock_run_paginated_query.return_value = ["server1", "server2"]
+    res = instance._run_query(
+        mock_openstack_connection, filter_kwargs={}, all_tenants=True
+    )
+    mock_run_paginated_query.assert_called_once_with(
+        mock_openstack_connection.compute.servers, {"all_tenants": True}
+    )
+    assert res == ["server1", "server2"]
+
+
+@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
 def test_run_query_with_meta_arg_projects_with_no_server_queries(
     mock_run_paginated_query, instance, mock_openstack_connection
 ):


### PR DESCRIPTION
### Description:

Fixed a bug where "all_tenants" isn't being converted properly from meta_param into a filter kwarg 

This meant that we couldn't find all servers from all projects and it would print out the VMs on the project attached to the clouds.yaml file over and over :/


