### PR TITLE
MAINT: update to_list API method into to_objects, to_props

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,3 +38,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          token: ${{secrets.CODECOV_TOKEN}}

--- a/lib/openstack_query/README.md
+++ b/lib/openstack_query/README.md
@@ -126,7 +126,7 @@ user_query.run("prod")
 # We're going to create a Server Query using the results from the first query
 
 # This is the same as doing:
-# user_ids = user_query.group_by(UserProperties.USER_ID).to_list().keys()
+# user_ids = user_query.group_by(UserProperties.USER_ID).to_props().keys()
 # ServerQuery().where(QueryPresetsGeneric.ANY_IN, ServerProperties.USER_ID, values=list(user_ids))
 
 # NOTE: setting keep_previous_results=True will carry over properties we've selected for from the previous query
@@ -173,12 +173,12 @@ server_query.run("prod", as_admin=True, all_projects=True)
 
 # We need to get project name by running append_from()
 # append_from() command below is the same as doing the following:
-#   project_ids = server_query.group_by(ServerProperties.PROJECT_ID).to_list().keys()
+#   project_ids = server_query.group_by(ServerProperties.PROJECT_ID).to_props().keys()
 #   p = ProjectQuery().select(ProjectProperties.PROJECT_NAME).where(
 #        QueryPresetsGeneric.ANY_IN, ProjectProperties.PROJECT_ID, values=list(project_ids)
 #   )
 #   p.run("prod")
-#   res = p.to_list()
+#   res = p.to_props()
 # `res` is then combined zipped together into the current output
 server_query.append_from("PROJECT_QUERY", "prod", ProjectProperties.PROJECT_ID)
 
@@ -196,15 +196,11 @@ server_query.to_string()
 
 you can output the results of your query in the following ways:
 
-`to_list()` - output the info to a list or a dict (if grouped)
+`to_props()` - output the info to a list or a dict (if grouped)
+
+- will output selected props as dictionary of property name to property value for each openstack resource found
 
 **optional params:**
-
-- `as_objects`: `bool`
-    - if True will return results as Openstack Objects instead of selected for properties
-      - if group_by() was run - then the results will be a dictionary
-    - if False will return selected for results as normal
-
 
 - `flatten`: `bool`
 
@@ -212,7 +208,7 @@ If True will flatten the results by selected for properties:
 
 Instead of returning:
 ```python
-print(query.to_list(flatten=False))
+print(query.to_props(flatten=False))
 
 [
 
@@ -227,7 +223,7 @@ print(query.to_list(flatten=False))
 
 it will return:
 ```python
-print(query.to_list(flatten=True))
+print(query.to_props(flatten=True))
 
 {
     "project_name": ["foo", "foo1"],
@@ -239,7 +235,7 @@ If the results are grouped:
 
 Instead of returning:
 ```python
-print(grouped_query.to_list(flatten=False))
+print(grouped_query.to_props(flatten=False))
 
 {
     "group1": [
@@ -254,7 +250,7 @@ print(grouped_query.to_list(flatten=False))
 ```
 It will return:
 ```python
-print(grouped_query.to_list(flatten=True))
+print(grouped_query.to_props(flatten=True))
 
 {
     "group1": {
@@ -271,17 +267,22 @@ print(grouped_query.to_list(flatten=True))
   - `groups`: List[str] - limit output to only a set of specified group keys
 
 
+`to_objects()` - output results as objects
+- optional param `groups` works same as `to_props`
+
+
+
 `to_string()` - output results as a tabulate table
 
 - accepts tabulate kwargs - see [tabulate](https://pypi.org/project/tabulate/)
-- optional param `groups` works same as `to_list`
+- optional param `groups` works same as `to_props`
 - optional param `title` - allows you to set a heading title for the table
 
 `to_html()`- output results as a tabulate html compatible table
 
 - accepts tabulate kwargs - see [tabulate](https://pypi.org/project/tabulate/)
 - optional param `title` - allows you to set a html heading title for the table
-- optional param `groups` works same as  `to_list`
+- optional param `groups` works same as  `to_props`
 
 `to_csv` - in development
 

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -150,20 +150,41 @@ class QueryAPI:
         self._query_run = True
         return self
 
-    def to_list(
-        self, as_objects=False, flatten=False, groups: Optional[List[str]] = None
-    ) -> Union[Dict[str, List], List[Dict[str, str]]]:
+    def to_objects(
+        self, groups: Optional[List[str]] = None
+    ) -> Union[Dict[str, List], List]:
         """
-        Public method to return results as a list (ungrouped) or dict (if grouped/flattened)
-        :param as_objects: if true return result as openstack objects
-        :param flatten: boolean which will flatten results if true
-        :param groups: a list group to limit output by
+        Public method to return results as openstack objects
+        :param groups: a list of group keys to limit output by
+        :return: List of openstacksdk resource objects or Dictionary of grouped openstacksdk resource objects
         """
-        result_as_objects, selected_results = self.executer.parse_results(
+        results, _ = self.executer.parse_results(
             parse_func=self.parser.run_parser, output_func=self.output.generate_output
         )
-        results = result_as_objects if as_objects else selected_results
+        if groups:
+            if not isinstance(results, dict):
+                raise ParseQueryError(
+                    f"Result is not grouped - cannot filter by given group(s) {groups}"
+                )
+            if not all(group in results.keys() for group in groups):
+                raise ParseQueryError(
+                    f"Group(s) given are invalid - valid groups {list(results.keys())}"
+                )
+            return {group_key: results[group_key] for group_key in groups}
+        return results
 
+    def to_props(
+        self, flatten: bool = False, groups: Optional[List[str]] = None
+    ) -> Union[Dict[str, List], List]:
+        """
+        Public method to return results as openstack objects
+        :param flatten: boolean which will flatten results if true
+        :param groups: a list of group keys to limit output by
+        :return: List of selected props for each openstack resource object or Dictionary of grouped selected props
+        """
+        _, results = self.executer.parse_results(
+            parse_func=self.parser.run_parser, output_func=self.output.generate_output
+        )
         if groups:
             if not isinstance(results, dict):
                 raise ParseQueryError(

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -154,9 +154,9 @@ class QueryAPI:
         self, groups: Optional[List[str]] = None
     ) -> Union[Dict[str, List], List]:
         """
-        Public method to return results as openstack objects
+        Public method to return results as openstack objects.
+        This is either returned as a list if no groups are specified, or as a dict if they grouping was requested
         :param groups: a list of group keys to limit output by
-        :return: List of openstacksdk resource objects or Dictionary of grouped openstacksdk resource objects
         """
         results, _ = self.executer.parse_results(
             parse_func=self.parser.run_parser, output_func=self.output.generate_output
@@ -177,10 +177,10 @@ class QueryAPI:
         self, flatten: bool = False, groups: Optional[List[str]] = None
     ) -> Union[Dict[str, List], List]:
         """
-        Public method to return results as openstack objects
+        Public method to return results as openstack properties.
+        This is either returned as a list if no groups are specified, or as a dict if they grouping was requested
         :param flatten: boolean which will flatten results if true
         :param groups: a list of group keys to limit output by
-        :return: List of selected props for each openstack resource object or Dictionary of grouped selected props
         """
         _, results = self.executer.parse_results(
             parse_func=self.parser.run_parser, output_func=self.output.generate_output

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -277,5 +277,5 @@ class QueryAPI:
         link_props = self.chainer.get_link_props(query_type)
         new_query.group_by(link_props[1])
 
-        self.output.update_forwarded_outputs(link_props[0], new_query.to_list())
+        self.output.update_forwarded_outputs(link_props[0], new_query.to_props())
         return self

--- a/lib/openstack_query/query_blocks/query_chainer.py
+++ b/lib/openstack_query/query_blocks/query_chainer.py
@@ -44,14 +44,14 @@ class QueryChainer:
 
     @staticmethod
     def parse_then(
-        curr_query,
+        current_query,
         query_type: Union[str, QueryTypes],
         keep_previous_results: bool = False,
     ):
         """
         Public static method to chain current query into another query of a different type
         and return the new query so that it will work only on the results of the original query.
-        :param curr_query: current QueryAPI object
+        :param current_query: current QueryAPI object
         :param query_type: an enum representing the new query to chain into
         :param keep_previous_results: boolean that if true - will forward outputs from
         this query (and previous chained queries) onto new query.
@@ -65,15 +65,15 @@ class QueryChainer:
         if isinstance(query_type, str):
             query_type = QueryTypes.from_string(query_type)
 
-        link_props = curr_query.chainer.get_link_props(query_type)
+        link_props = current_query.chainer.get_link_props(query_type)
         if not link_props:
             raise QueryChainingError(
                 f"Query Chaining Error: Could not find a way to chain current query into {query_type}"
             )
 
         # we group the current results by the link property as this is the way we forward results
-        curr_query_results = curr_query.group_by(link_props[0]).to_props()
-        if not curr_query_results:
+        current_query_results = current_query.group_by(link_props[0]).to_props()
+        if not current_query_results:
             raise QueryChainingError(
                 "Query Chaining Error: No values found after running this query - aborting. "
                 "Have you run the query first?"
@@ -81,7 +81,7 @@ class QueryChainer:
 
         to_forward = None
         if keep_previous_results:
-            to_forward = (link_props[1], curr_query_results)
+            to_forward = (link_props[1], current_query_results)
 
         new_query = QueryAPI(
             QueryFactory.build_query_deps(query_type.value, to_forward)
@@ -89,5 +89,5 @@ class QueryChainer:
         return new_query.where(
             QueryPresetsGeneric.ANY_IN,
             link_props[1],
-            values=list(curr_query_results.keys()),
+            values=list(current_query_results.keys()),
         )

--- a/lib/openstack_query/query_blocks/query_chainer.py
+++ b/lib/openstack_query/query_blocks/query_chainer.py
@@ -72,7 +72,7 @@ class QueryChainer:
             )
 
         # we group the current results by the link property as this is the way we forward results
-        curr_query_results = curr_query.group_by(link_props[0]).to_list()
+        curr_query_results = curr_query.group_by(link_props[0]).to_props()
         if not curr_query_results:
             raise QueryChainingError(
                 "Query Chaining Error: No values found after running this query - aborting. "

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -395,7 +395,7 @@ def test_append_from(mock_query_types_cls, mock_then, instance):
     mock_query_type = "query-type"
 
     mock_props = ["prop1", "prop2", "prop3"]
-    instance.chainer.get_link_props.return_value = ("curr-prop", "link-prop")
+    instance.chainer.get_link_props.return_value = ("current-prop", "link-prop")
     mock_then.return_value = mock_new_query
 
     res = instance.append_from(mock_query_type, mock_cloud_account, *mock_props)
@@ -412,6 +412,6 @@ def test_append_from(mock_query_types_cls, mock_then, instance):
     mock_new_query.group_by.assert_called_once_with("link-prop")
     mock_new_query.to_props.assert_called_once()
     instance.output.update_forwarded_outputs.assert_called_once_with(
-        "curr-prop", mock_new_query.to_props.return_value
+        "current-prop", mock_new_query.to_props.return_value
     )
     assert res == instance

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -410,8 +410,8 @@ def test_append_from(mock_query_types_cls, mock_then, instance):
         mock_query_types_cls.from_string.return_value
     )
     mock_new_query.group_by.assert_called_once_with("link-prop")
-    mock_new_query.to_list.assert_called_once()
+    mock_new_query.to_props.assert_called_once()
     instance.output.update_forwarded_outputs.assert_called_once_with(
-        "curr-prop", mock_new_query.to_list.return_value
+        "curr-prop", mock_new_query.to_props.return_value
     )
     assert res == instance

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -215,60 +215,59 @@ def test_run_with_kwargs_and_subset(run_with_test_case_with_subset):
     )
 
 
-def test_to_list_as_objects_false(instance):
+def test_to_props(instance):
     """
-    Tests that to_list method functions expectedly
-    method should return _query_results attribute when as_objects is false and flatten is false
+    Tests that to_props method functions expectedly - with no extra params
+    method should just return _query_results attribute when groups is None and flatten is false
     """
     instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_list() == "parsed-list"
+    assert instance.to_props() == "parsed-list"
 
 
-def test_to_list_as_objects_true(instance):
+def test_to_objects(instance):
     """
-    Tests that to_list method functions expectedly
-    method should return _query_results_as_objects attribute when as_objects is true
+    Tests that to_objects method functions expectedly - with no extra params
+    method should just return _query_results_as_objects attribute when groups is None
     """
     # pylint: disable=protected-access
     instance.executer.parse_results.return_value = "object-list", ""
-    assert instance.to_list(as_objects=True) == "object-list"
+    assert instance.to_objects() == "object-list"
 
 
-def test_to_list_flatten_true(instance):
+def test_to_props_flatten_true(instance):
     """
-    Tests that to_list method functions expectedly
+    Tests that to_props method functions expectedly
     method should call output.flatten() with query_results
     """
     instance.executer.parse_results.return_value = "", "parsed-list"
-    res = instance.to_list(flatten=True)
+    res = instance.to_props(flatten=True)
     instance.output.flatten.assert_called_once_with("parsed-list")
     assert res == instance.output.flatten.return_value
 
 
-def test_to_list_flatten_and_as_objects(instance):
+def test_to_props_with_groups_not_dict(instance):
     """
-    Tests that to_list method functions expectedly
-    method should call output.flatten() with query_results_as_obj
-    """
-    instance.executer.parse_results.return_value = "object-list", ""
-    res = instance.to_list(as_objects=True, flatten=True)
-    instance.output.flatten.assert_called_once_with("object-list")
-    assert res == instance.output.flatten.return_value
-
-
-def test_to_list_groups_not_dict(instance):
-    """
-    Tests that to_list method functions expectedly
+    Tests that to_props method functions expectedly
     method should raise error when given group and results are not dict
     """
     instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
     with pytest.raises(ParseQueryError):
-        instance.to_list(groups=["group1", "group2"])
+        instance.to_props(groups=["group1", "group2"])
 
 
-def test_to_list_groups_dict(instance):
+def test_to_objects_with_groups_not_dict(instance):
     """
-    Tests that to_list method functions expectedly
+    Tests that to_objects method functions expectedly
+    method should raise error when given group and results are not dict
+    """
+    instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
+    with pytest.raises(ParseQueryError):
+        instance.to_objects(groups=["group1", "group2"])
+
+
+def test_to_props_groups_dict(instance):
+    """
+    Tests that to_props method functions expectedly
     method should return subset of results which match keys (groups) given
     """
     mock_query_results = {
@@ -276,14 +275,28 @@ def test_to_list_groups_dict(instance):
         "group2": ["result3", "result4"],
     }
     instance.executer.parse_results.return_value = "", mock_query_results
-    res = instance.to_list(groups=["group1"])
+    res = instance.to_props(groups=["group1"])
     assert res == {"group1": mock_query_results["group1"]}
 
 
-def test_to_list_group_not_valid(instance):
+def test_to_objects_groups_dict(instance):
     """
-    Tests that to_list method functions expectedly
+    Tests that to_objects method functions expectedly
     method should return subset of results which match keys (groups) given
+    """
+    mock_query_results = {
+        "group1": ["obj1", "obj2"],
+        "group2": ["obj3", "obj4"],
+    }
+    instance.executer.parse_results.return_value = mock_query_results, ""
+    res = instance.to_objects(groups=["group1"])
+    assert res == {"group1": mock_query_results["group1"]}
+
+
+def test_to_props_group_not_valid(instance):
+    """
+    Tests that to_props method functions expectedly
+    method should raise error if group specified is not a key in results
     """
     mock_query_results = {
         "group1": ["result1", "result2"],
@@ -291,7 +304,21 @@ def test_to_list_group_not_valid(instance):
     }
     instance.executer.parse_results.return_value = "", mock_query_results
     with pytest.raises(ParseQueryError):
-        instance.to_list(groups=["group3"])
+        instance.to_props(groups=["group3"])
+
+
+def test_to_objects_group_not_valid(instance):
+    """
+    Tests that to_objects method functions expectedly
+    method should raise error if group specified is not a key in results
+    """
+    mock_query_results = {
+        "group1": ["result1", "result2"],
+        "group2": ["result3", "result4"],
+    }
+    instance.executer.parse_results.return_value = mock_query_results, ""
+    with pytest.raises(ParseQueryError):
+        instance.to_objects(groups=["group3"])
 
 
 def test_to_string(instance):

--- a/tests/lib/openstack_query/query_blocks/test_query_chainer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_chainer.py
@@ -44,7 +44,7 @@ def run_parse_then_query_valid_fixture(instance):
         mock_curr_query.chainer.get_link_props.return_value = ("curr-prop", "new-prop")
 
         mock_curr_query_results = {"prop-val1": "out1", "prop-val2": "out2"}
-        mock_curr_query.group_by.return_value.to_list.return_value = (
+        mock_curr_query.group_by.return_value.to_props.return_value = (
             mock_curr_query_results
         )
 
@@ -61,7 +61,7 @@ def run_parse_then_query_valid_fixture(instance):
         mock_query_types_cls.from_string.assert_called_once_with("query-type")
 
         mock_curr_query.group_by.assert_called_once_with("curr-prop")
-        mock_curr_query.group_by.return_value.to_list.assert_called_once()
+        mock_curr_query.group_by.return_value.to_props.assert_called_once()
 
         mock_query_factory.build_query_deps.assert_called_once_with(
             mock_query_types_cls.from_string.return_value.value, to_forward
@@ -174,7 +174,7 @@ def test_parse_then_no_results(instance):
     """
     mock_curr_query = MagicMock()
     mock_curr_query.chainer.get_link_props.return_value = ("curr-prop", "new-prop")
-    mock_curr_query.group_by.return_value.to_list.return_value = None
+    mock_curr_query.group_by.return_value.to_props.return_value = None
     mock_query_type = MagicMock()
 
     with pytest.raises(QueryChainingError):
@@ -185,4 +185,4 @@ def test_parse_then_no_results(instance):
         )
     mock_curr_query.chainer.get_link_props.assert_called_once_with(mock_query_type)
     mock_curr_query.group_by.assert_called_once_with("curr-prop")
-    mock_curr_query.group_by.return_value.to_list.assert_called_once()
+    mock_curr_query.group_by.return_value.to_props.assert_called_once()

--- a/tests/lib/openstack_query/query_blocks/test_query_chainer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_chainer.py
@@ -40,28 +40,31 @@ def run_parse_then_query_valid_fixture(instance):
         """
         runs a then_query() test case with keep_previous_results being either True or False
         """
-        mock_curr_query = MagicMock()
-        mock_curr_query.chainer.get_link_props.return_value = ("curr-prop", "new-prop")
+        mock_current_query = MagicMock()
+        mock_current_query.chainer.get_link_props.return_value = (
+            "current-prop",
+            "new-prop",
+        )
 
-        mock_curr_query_results = {"prop-val1": "out1", "prop-val2": "out2"}
-        mock_curr_query.group_by.return_value.to_props.return_value = (
-            mock_curr_query_results
+        mock_current_query_results = {"prop-val1": "out1", "prop-val2": "out2"}
+        mock_current_query.group_by.return_value.to_props.return_value = (
+            mock_current_query_results
         )
 
         to_forward = None
         if mock_keep_previous_results:
-            to_forward = ("new-prop", mock_curr_query_results)
+            to_forward = ("new-prop", mock_current_query_results)
 
         res = instance.parse_then(
-            curr_query=mock_curr_query,
+            current_query=mock_current_query,
             query_type="query-type",
             keep_previous_results=mock_keep_previous_results,
         )
 
         mock_query_types_cls.from_string.assert_called_once_with("query-type")
 
-        mock_curr_query.group_by.assert_called_once_with("curr-prop")
-        mock_curr_query.group_by.return_value.to_props.assert_called_once()
+        mock_current_query.group_by.assert_called_once_with("current-prop")
+        mock_current_query.group_by.return_value.to_props.assert_called_once()
 
         mock_query_factory.build_query_deps.assert_called_once_with(
             mock_query_types_cls.from_string.return_value.value, to_forward
@@ -153,18 +156,20 @@ def test_parse_then_no_link_props(instance):
     Tests parse_then method - where no link props available
     should raise error
     """
-    mock_curr_query = MagicMock()
-    mock_curr_query.chainer.get_link_props.return_value = None
+    mock_current_query = MagicMock()
+    mock_current_query.chainer.get_link_props.return_value = None
 
     mock_query_type = MagicMock()
 
     with pytest.raises(QueryChainingError):
         instance.parse_then(
-            curr_query=mock_curr_query,
+            current_query=mock_current_query,
             query_type=mock_query_type,
             keep_previous_results=False,
         )
-        mock_curr_query.chainer.get_link_props.assert_called_once_with(mock_query_type)
+        mock_current_query.chainer.get_link_props.assert_called_once_with(
+            mock_query_type
+        )
 
 
 def test_parse_then_no_results(instance):
@@ -172,17 +177,20 @@ def test_parse_then_no_results(instance):
     Tests parse_then method - where no results found
     should raise error
     """
-    mock_curr_query = MagicMock()
-    mock_curr_query.chainer.get_link_props.return_value = ("curr-prop", "new-prop")
-    mock_curr_query.group_by.return_value.to_props.return_value = None
+    mock_current_query = MagicMock()
+    mock_current_query.chainer.get_link_props.return_value = (
+        "current-prop",
+        "new-prop",
+    )
+    mock_current_query.group_by.return_value.to_props.return_value = None
     mock_query_type = MagicMock()
 
     with pytest.raises(QueryChainingError):
         instance.parse_then(
-            curr_query=mock_curr_query,
+            current_query=mock_current_query,
             query_type=mock_query_type,
             keep_previous_results=False,
         )
-    mock_curr_query.chainer.get_link_props.assert_called_once_with(mock_query_type)
-    mock_curr_query.group_by.assert_called_once_with("curr-prop")
-    mock_curr_query.group_by.return_value.to_props.assert_called_once()
+    mock_current_query.chainer.get_link_props.assert_called_once_with(mock_query_type)
+    mock_current_query.group_by.assert_called_once_with("current-prop")
+    mock_current_query.group_by.return_value.to_props.assert_called_once()


### PR DESCRIPTION
since to_list() can output a dictionary (if results are grouped) so the method may be misleading

change to:
- to_objects() - to return openstacksdk objects
- to_props() - to return selected properties
