### PR TITLE
BUG: Duplicates are no longer removed implicitly

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -158,6 +158,12 @@ class QueryAPI:
         This is either returned as a list if no groups are specified, or as a dict if they grouping was requested
         :param groups: a list of group keys to limit output by
         """
+        if self.output.forwarded_outputs:
+            logger.warning(
+                "This Query has properties from previous queries. Running to_objects WILL IGNORE THIS "
+                "Use to_props() instead if you want to include these properties"
+            )
+
         results, _ = self.executer.parse_results(
             parse_func=self.parser.run_parser, output_func=self.output.generate_output
         )

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -305,6 +305,5 @@ class QueryOutput:
         keys = list(data[0].keys())
         res = {}
         for key in keys:
-            vals = [d[key] for d in data]
-            res[key] = list(vals)
+            res[key] = [d[key] for d in data]
         return res

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -201,8 +201,12 @@ class QueryOutput:
             # but sometimes resolving the property fails for whatever reason - fail noisily
             try:
                 output_list = outputs[prop_val]
-                # should only ever contain one element since it's grouped by a unique id
+                # we update with first result in grouped list and delete it
+
+                # forwarded properties might contain more than one value
+                # then() will keep duplicates so each one in the list will be shunted into an output
                 forwarded_output_dict.update(output_list[0])
+                del output_list[0]
             except KeyError as exp:
                 raise QueryChainingError(
                     "Error: Chaining failed. Could not attach forwarded outputs.\n"
@@ -304,6 +308,6 @@ class QueryOutput:
             vals = [d[key] for d in data]
             # converting into a set preserving order
             # https://stackoverflow.com/a/53657523
-            vals = list(dict.fromkeys(vals))
-            res[key] = vals
+            # vals = list(dict.fromkeys(vals))
+            res[key] = list(vals)
         return res

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -306,8 +306,5 @@ class QueryOutput:
         res = {}
         for key in keys:
             vals = [d[key] for d in data]
-            # converting into a set preserving order
-            # https://stackoverflow.com/a/53657523
-            # vals = list(dict.fromkeys(vals))
             res[key] = list(vals)
         return res

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -230,6 +230,20 @@ def test_to_objects(instance):
     method should just return _query_results_as_objects attribute when groups is None
     """
     # pylint: disable=protected-access
+    instance.output.forwarded_outputs = {}
+    instance.executer.parse_results.return_value = "object-list", ""
+    assert instance.to_objects() == "object-list"
+
+
+def test_to_objects_forwarded_outputs_warning(instance):
+    """
+    Tests that to_objects method functions expectedly
+    prints warning when forwarded_outputs is not empty
+    """
+    # pylint: disable=protected-access
+    instance.output.forwarded_outputs = {"out1": "val1"}
+
+    # should just continue running as normal after printing warning
     instance.executer.parse_results.return_value = "object-list", ""
     assert instance.to_objects() == "object-list"
 
@@ -260,6 +274,7 @@ def test_to_objects_with_groups_not_dict(instance):
     Tests that to_objects method functions expectedly
     method should raise error when given group and results are not dict
     """
+    instance.output.forwarded_outputs = {}
     instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
     with pytest.raises(ParseQueryError):
         instance.to_objects(groups=["group1", "group2"])
@@ -284,6 +299,7 @@ def test_to_objects_groups_dict(instance):
     Tests that to_objects method functions expectedly
     method should return subset of results which match keys (groups) given
     """
+    instance.output.forwarded_outputs = {}
     mock_query_results = {
         "group1": ["obj1", "obj2"],
         "group2": ["obj3", "obj4"],
@@ -312,6 +328,7 @@ def test_to_objects_group_not_valid(instance):
     Tests that to_objects method functions expectedly
     method should raise error if group specified is not a key in results
     """
+    instance.output.forwarded_outputs = {}
     mock_query_results = {
         "group1": ["result1", "result2"],
         "group2": ["result3", "result4"],

--- a/tests/lib/openstack_query/query_blocks/test_query_output.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_output.py
@@ -559,6 +559,15 @@ def test_flatten_list_many_keys_many_items(instance):
     ) == {"prop1": ["val1", "val3"], "prop2": ["val2", "val4"]}
 
 
+def test_flatten_with_duplicates(instance):
+    """
+    Tests flatten_list() function with duplicates - should keep duplicates as is
+    """
+    assert instance._flatten_list(
+        [{"prop1": "val1", "prop2": "val2"}, {"prop1": "val1", "prop2": "val2"}]
+    ) == {"prop1": ["val1", "val1"], "prop2": ["val2", "val2"]}
+
+
 def test_update_forwarded_outputs(instance):
     """
     Tests update_forwarded_outputs() method


### PR DESCRIPTION
Queries now don't implicitly remove duplicates. Especially when chaining.

This fixes issue with keep_previous_results not working with Many-to-One type queries.

flatten() does not remove duplicates any more