### PR TITLE
BUG: fix one-to-many chaining bug

### DIFF
--- a/lib/openstack_query/query_blocks/query_chainer.py
+++ b/lib/openstack_query/query_blocks/query_chainer.py
@@ -77,15 +77,14 @@ class QueryChainer:
                 "Have you run the query first?"
             )
 
-        selected_props = current_query.output.selected_props
+        prev_selected_props = current_query.output.selected_props
 
         # grab all link prop values - including duplicates
         search_values = current_query.select(link_props[0]).to_props(flatten=True)[
             link_props[0].name.lower()
         ]
 
-        # reset select
-        current_query.select(*selected_props)
+        current_query.output.selected_props = prev_selected_props
 
         to_forward = None
         if keep_previous_results:

--- a/lib/openstack_query/query_blocks/query_chainer.py
+++ b/lib/openstack_query/query_blocks/query_chainer.py
@@ -77,13 +77,18 @@ class QueryChainer:
                 "Have you run the query first?"
             )
 
+        # remove user-defined parsing
         prev_selected_props = current_query.output.selected_props
+        prev_grouping = current_query.parser.group_by
+        current_query.parser.group_by = None
 
         # grab all link prop values - including duplicates
         search_values = current_query.select(link_props[0]).to_props(flatten=True)[
             link_props[0].name.lower()
         ]
 
+        # re-configure user-defined parsing
+        current_query.parser.group_by = prev_grouping
         current_query.output.selected_props = prev_selected_props
 
         to_forward = None

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -206,7 +206,12 @@ class QueryOutput:
                 # forwarded properties might contain more than one value
                 # then() will keep duplicates so each one in the list will be shunted into an output
                 forwarded_output_dict.update(output_list[0])
-                del output_list[0]
+
+                # a hacky way to prevent one-to-many chaining erroring - keep at least one value
+                # one-to-many/one-to-one will only ever contain one value per grouped_value
+                # many-to-one will contain multiple values per grouped values
+                if len(output_list) > 1:
+                    del output_list[0]
             except KeyError as exp:
                 raise QueryChainingError(
                     "Error: Chaining failed. Could not attach forwarded outputs.\n"

--- a/tests/lib/openstack_query/query_blocks/test_query_chainer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_chainer.py
@@ -59,8 +59,6 @@ def run_parse_then_query_valid_fixture(instance):
                 mock_current_query.group_by.return_value.to_props.return_value,
             )
 
-        mock_current_query.output.selected_props = ["selected-prop1", "selected-props2"]
-
         res = instance.parse_then(
             current_query=mock_current_query,
             query_type="query-type",
@@ -73,7 +71,6 @@ def run_parse_then_query_valid_fixture(instance):
         # test getting link prop values works
         mock_current_query.select.assert_any_call(MockProperties.PROP_1)
         mock_current_query.select.return_value.to_props.assert_any_call(flatten=True)
-        mock_current_query.select.assert_any_call("selected-prop1", "selected-props2")
 
         if mock_keep_previous_results:
             mock_group_by = mock_current_query.group_by


### PR DESCRIPTION
When going back from UserQuery to ServerQuery - we get a singleton list for each user-id we fine - each of these can match to multiple servers - i.e. a single entry shunting into many other entries - one-to-many.

This is a hacky fix where if grouped properties only contains one item - we don't delete it.
This works because:

- many-to-one relationships will contain a list with multiple items - each will be assigned to a duplicate as the output is parsed - hence deleting each one after being read is fine

- one-to-one, one-to-many relationships will contain a single list - each can be assigned to any number of outputs - hence we need to keep them around - we know it only contains one item - so not deleting it is fine

I'm happy to refactor this if it doesn't make sense to people - it's just to get it to work
