### PR TITLE
MAINT: improve query chaining

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -273,15 +273,5 @@ class QueryAPI:
         :param cloud_account: A String or a CloudDomains Enum for the clouds configuration to use
         :param props: list of props from new queries to get
         """
-        if isinstance(query_type, str):
-            query_type = QueryTypes.from_string(query_type)
-
-        new_query = self.then(query_type, keep_previous_results=False)
-        new_query.select(*props)
-        new_query.run(cloud_account)
-
-        link_props = self.chainer.get_link_props(query_type)
-        new_query.group_by(link_props[1])
-
-        self.output.update_forwarded_outputs(link_props[0], new_query.to_props())
+        self.chainer.parse_append_from(self, query_type, cloud_account, *props)
         return self

--- a/lib/openstack_query/query_blocks/query_executer.py
+++ b/lib/openstack_query/query_blocks/query_executer.py
@@ -1,3 +1,4 @@
+import copy
 import time
 import logging
 from typing import Tuple, Callable, Optional, Dict, List, Any, Union, Type
@@ -10,6 +11,7 @@ from custom_types.openstack_query.aliases import (
     OpenstackResourceObj,
     ServerSideFilters,
     ClientSideFilters,
+    PropValue,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,7 +31,11 @@ class QueryExecuter:
         self.runner = runner_cls(self._prop_enum_cls.get_marker_prop_func())
         self._client_side_filters = None
         self._server_side_filters = None
-        self._raw_results = []
+        self._results = []
+
+        # for chaining
+        self._forwarded_values = {}
+        self._link_prop_func = lambda a: None
 
     @property
     def client_side_filters(self):
@@ -63,18 +69,43 @@ class QueryExecuter:
         self._server_side_filters = server_filters
 
     @property
-    def raw_results(self) -> List[OpenstackResourceObj]:
+    def results(self) -> List[OpenstackResourceObj]:
         """
         a getter for raw results
         """
-        return self._raw_results
+        return self._results
 
-    @raw_results.setter
-    def raw_results(self, results: List[OpenstackResourceObj]):
+    @results.setter
+    def results(self, results: List[OpenstackResourceObj]):
         """
         a setter for raw results
         """
-        self._raw_results = results
+        self._results = results
+
+    @property
+    def forwarded_values(self) -> Dict[PropValue, List]:
+        """
+        a getter for forwarded results from previous queries
+        """
+        return self._forwarded_values
+
+    @property
+    def link_prop_func(self) -> Callable[[OpenstackResourceObj], PropValue]:
+        """
+        a getter for function to return link prop
+        """
+        return self._link_prop_func
+
+    def set_forwarded_values(
+        self,
+        link_prop_func: Callable[[OpenstackResourceObj], PropValue],
+        forwarded_values: Dict[PropValue, List],
+    ):
+        """
+        a setter for setting forwarded results from link prop func
+        """
+        self._link_prop_func = link_prop_func
+        self._forwarded_values = forwarded_values
 
     def run_query(
         self,
@@ -96,14 +127,57 @@ class QueryExecuter:
             cloud_account = cloud_account.name.lower()
 
         start = time.time()
-        self.raw_results = self.runner.run(
+        results = self.runner.run(
             cloud_account=cloud_account,
             client_side_filters=self.client_side_filters,
             server_side_filters=self.server_side_filters,
             from_subset=from_subset,
             **kwargs,
         )
+
+        forwarded_results = copy.deepcopy(self._forwarded_values)
+        self.results = self.apply_forwarded_results(
+            results, forwarded_results, self.link_prop_func
+        )
         logger.debug("run completed - time elapsed: %s seconds", time.time() - start)
+
+    def apply_forwarded_results(self, query_results, forwarded_results, link_prop_func):
+        if not query_results:
+            return []
+
+        return [
+            (
+                obj,
+                self._get_forwarded_result(link_prop_func(obj), forwarded_results),
+            )
+            for obj in query_results
+        ]
+
+    def append_forwarded_results(self, forwarded_results, link_prop_func):
+
+        self.results = [
+            (
+                tup[0],
+                {
+                    **tup[1],
+                    **self._get_forwarded_result(
+                        link_prop_func(tup[0]), forwarded_results
+                    ),
+                },
+            )
+            for tup in self.results
+        ]
+
+    @staticmethod
+    def _get_forwarded_result(prop_val: str, forwarded_results: Dict[str, List]):
+
+        if not forwarded_results:
+            return {}
+
+        result_to_attach = forwarded_results[prop_val][0]
+        if len(forwarded_results[prop_val]) > 1:
+            del forwarded_results[prop_val][0]
+        return result_to_attach
 
     def parse_results(
         self,
@@ -111,22 +185,31 @@ class QueryExecuter:
         output_func: Optional[Callable],
     ) -> Tuple[Union[List, Dict], Union[List, Dict]]:
         """
-        This method takes the raw results computed in run_query() and applies the pre-set parser
-        and generate output functions
-        :param parse_func: function that groups and sorts raw results
-        :param output_func: function that takes raw results and converts it into outputs
+        This method takes the results computed in run_query() and applies the pre-set parser
+        and generate output functions - outputs results as object list/dict and as selected props list/dict
+        (including forwarded outputs)
+        :param parse_func: function that groups and sorts object results
+        :param output_func: function that takes object results and converts it into selected outputs
         """
-        results = self.raw_results
+        results = self._results
         if parse_func:
-            results = parse_func(results)
-        return results, self.get_output(output_func, results)
+            results = parse_func(self._results)
+
+        if not isinstance(results, dict):
+            as_object_results = [result[0] for result in results]
+        else:
+            as_object_results = {
+                name: [result[0] for result in group] for name, group in results.items()
+            }
+
+        as_prop_results = self.get_output(output_func, results)
+
+        return as_object_results, as_prop_results
 
     @staticmethod
     def get_output(
         output_func: Optional[Callable],
-        results: Union[
-            List[OpenstackResourceObj], Dict[str, List[OpenstackResourceObj]]
-        ],
+        results: List[Tuple[OpenstackResourceObj, Dict]],
     ):
         """
         Helper method for getting the output using output func

--- a/lib/openstack_query/query_factory.py
+++ b/lib/openstack_query/query_factory.py
@@ -34,8 +34,6 @@ class QueryFactory:
         prop_mapping = mapping_cls.get_prop_mapping()
 
         output = QueryOutput(prop_mapping)
-        if forwarded_outputs:
-            output.update_forwarded_outputs(forwarded_outputs[0], forwarded_outputs[1])
         parser = QueryParser(prop_mapping)
         builder = QueryBuilder(
             prop_enum_cls=prop_mapping,
@@ -45,6 +43,11 @@ class QueryFactory:
         executer = QueryExecuter(
             prop_enum_cls=prop_mapping, runner_cls=mapping_cls.get_runner_mapping()
         )
+        if forwarded_outputs:
+            executer.set_forwarded_values(
+                lambda obj: output.parse_property(forwarded_outputs[0], obj),
+                forwarded_outputs[1],
+            )
 
         chainer = QueryChainer(chain_mappings=mapping_cls.get_chain_mappings())
 

--- a/tests/lib/openstack_query/query_blocks/test_query_output.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_output.py
@@ -331,7 +331,7 @@ def test_generate_output_no_items(instance):
     assert instance.generate_output([]) == []
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_properties")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.parse_properties")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._parse_forwarded_outputs")
 @patch("openstack_query.query_blocks.query_output.deepcopy")
 def test_generate_output_one_item(
@@ -363,7 +363,7 @@ def test_generate_output_one_item(
     ]
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_properties")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.parse_properties")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._parse_forwarded_outputs")
 @patch("openstack_query.query_blocks.query_output.deepcopy")
 def test_generate_output_many_items(
@@ -441,7 +441,7 @@ def test_parse_properties_no_props(instance):
     # mock get_prop_mapping to return a func string appropriate for that prop
     instance.selected_props = set()
     # pylint:disable=protected-access
-    assert instance._parse_properties("openstack-item") == {}
+    assert instance.parse_properties("openstack-item") == {}
 
 
 @patch.object(MockProperties, "get_prop_mapping")
@@ -457,7 +457,7 @@ def test_parse_properties_one_prop(mock_get_prop_func, instance):
 
     instance.selected_props = {MockProperties.PROP_1}
     # pylint:disable=protected-access
-    res = instance._parse_properties("openstack-item")
+    res = instance.parse_properties("openstack-item")
 
     mock_get_prop_func.assert_called_once_with(MockProperties.PROP_1)
     mock_prop_func.assert_called_once_with("openstack-item")
@@ -477,7 +477,7 @@ def test_parse_properties_many_props(mock_get_prop_func, instance):
         MockProperties, "get_prop_mapping", wraps=mock_get_prop_func
     ) as mock_get_prop_mapping:
         # pylint:disable=protected-access
-        res = instance._parse_properties("openstack-item")
+        res = instance.parse_properties("openstack-item")
 
     assert res == {"prop_1": "prop 1 out", "prop_2": "Not Found"}
     mock_get_prop_mapping.assert_has_calls(
@@ -611,7 +611,7 @@ def test_parse_forwarded_outputs_no_set(instance):
     assert instance._parse_forwarded_outputs("obj1", {}) == {}
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.parse_property")
 def test_parse_forwarded_outputs_one_to_many(mock_parse_property, instance):
     """
     Tests parse_forwarded_outputs() method - one set of forwarded_outputs
@@ -634,7 +634,7 @@ def test_parse_forwarded_outputs_one_to_many(mock_parse_property, instance):
     assert res == expected_out
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.parse_property")
 def test_parse_forwarded_outputs_multiple_sets(mock_parse_property, instance):
     """
     Tests parse_forwarded_outputs() method - a set of many forwarded_outputs
@@ -671,7 +671,7 @@ def test_parse_forwarded_outputs_multiple_sets(mock_parse_property, instance):
     assert res == {**one_to_many_out, **many_to_one_out2}
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.parse_property")
 def test_parse_forwarded_prop_value_not_found(mock_parse_property, instance):
     """
     Tests parse_forwarded_outputs() method
@@ -685,7 +685,7 @@ def test_parse_forwarded_prop_value_not_found(mock_parse_property, instance):
         instance._parse_forwarded_outputs("obj1", mock_forwarded_outputs)
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.parse_property")
 def test_parse_forwarded_outputs_many_to_one(mock_parse_property, instance):
     """
     Tests parse_forwarded_outputs() method - where forwarded outputs expects duplicates


### PR DESCRIPTION
A draft for improving how forwarded results are handled

These are a series of changes on how we calculate and store forwarded outputs from previous queries

Previously we evaluated these at the time of outputting. 
However, this complicates the code and slows down outputting significantly
- Also the data-structure was very complex to store forwarded outputs

Now we store a dictionary of forwarded outputs alongside the objects generated at the run() step.
    - we now parse the forwarded outputs at the earliest possible step - right after running the query
    - this couples forwarded outputs to the openstack object - and makes it much quicker to output

We've also simplified the datastructure holding forwarded outputs to just a dictionary of key-value pairs - so much easier to work with.




