### PR TITLE
MAINT: Add Result and ResultContainer Classes

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from typing import Union, List, Optional, Dict, Tuple
 
 from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
@@ -24,7 +25,7 @@ class QueryAPI:
         self.parser = query_components.parser
         self.output = query_components.output
         self.chainer = query_components.chainer
-        self._query_run = False
+        self.results_container = None
 
     def select(self, *props: PropEnum):
         """
@@ -147,7 +148,15 @@ class QueryAPI:
             from_subset=from_subset,
             **kwargs,
         )
-        self._query_run = True
+
+        link_prop, forwarded_vals = self.chainer.forwarded_info
+        if forwarded_vals:
+            self.executer.apply_forwarded_results(
+                link_prop,
+                deepcopy(forwarded_vals),
+            )
+
+        self.results_container = self.executer.results_container
         return self
 
     def to_objects(
@@ -158,26 +167,14 @@ class QueryAPI:
         This is either returned as a list if no groups are specified, or as a dict if they grouping was requested
         :param groups: a list of group keys to limit output by
         """
-        if self.output.forwarded_outputs:
+        if self.executer.has_forwarded_results:
             logger.warning(
                 "This Query has properties from previous queries. Running to_objects WILL IGNORE THIS "
                 "Use to_props() instead if you want to include these properties"
             )
 
-        results, _ = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-        if groups:
-            if not isinstance(results, dict):
-                raise ParseQueryError(
-                    f"Result is not grouped - cannot filter by given group(s) {groups}"
-                )
-            if not all(group in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"Group(s) given are invalid - valid groups {list(results.keys())}"
-                )
-            return {group_key: results[group_key] for group_key in groups}
-        return results
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_objects(self.results_container, groups)
 
     def to_props(
         self, flatten: bool = False, groups: Optional[List[str]] = None
@@ -188,23 +185,8 @@ class QueryAPI:
         :param flatten: boolean which will flatten results if true
         :param groups: a list of group keys to limit output by
         """
-        _, results = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-        if groups:
-            if not isinstance(results, dict):
-                raise ParseQueryError(
-                    f"Result is not grouped - cannot filter by given group(s) {groups}"
-                )
-            if not all(group in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"Group(s) given are invalid - valid groups {list(results.keys())}"
-                )
-            return {group_key: results[group_key] for group_key in groups}
-
-        if flatten:
-            return self.output.flatten(results)
-        return results
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_props(self.results_container, flatten, groups)
 
     def to_string(
         self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
@@ -215,11 +197,8 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        _, selected_results = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-
-        return self.output.to_string(selected_results, title, groups, **kwargs)
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_string(self.results_container, title, groups, **kwargs)
 
     def to_html(
         self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
@@ -230,10 +209,8 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        _, selected_results = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-        return self.output.to_html(selected_results, title, groups, **kwargs)
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_html(self.results_container, title, groups, **kwargs)
 
     def then(
         self, query_type: Union[str, QueryTypes], keep_previous_results: bool = True
@@ -273,15 +250,8 @@ class QueryAPI:
         :param cloud_account: A String or a CloudDomains Enum for the clouds configuration to use
         :param props: list of props from new queries to get
         """
-        if isinstance(query_type, str):
-            query_type = QueryTypes.from_string(query_type)
-
-        new_query = self.then(query_type, keep_previous_results=False)
-        new_query.select(*props)
-        new_query.run(cloud_account)
-
-        link_props = self.chainer.get_link_props(query_type)
-        new_query.group_by(link_props[1])
-
-        self.output.update_forwarded_outputs(link_props[0], new_query.to_props())
+        link_prop, results = self.chainer.run_append_from_query(
+            self, query_type, cloud_account, *props
+        )
+        self.results_container.apply_forwarded_results(link_prop, results)
         return self

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -1,14 +1,9 @@
-from copy import deepcopy
 from typing import List, Dict, Union, Type, Set, Optional
 from tabulate import tabulate
 from enums.query.props.prop_enum import PropEnum
-from custom_types.openstack_query.aliases import (
-    OpenstackResourceObj,
-    PropValue,
-    GroupedReturn,
-)
-from exceptions.query_chaining_error import QueryChainingError
+from custom_types.openstack_query.aliases import PropValue
 from exceptions.parse_query_error import ParseQueryError
+from openstack_query.query_blocks.results_container import ResultsContainer
 
 
 class QueryOutput:
@@ -25,22 +20,6 @@ class QueryOutput:
     def __init__(self, prop_enum_cls: Type[PropEnum]):
         self._prop_enum_cls = prop_enum_cls
         self._props = set()
-        self._forwarded_outputs: Dict[PropEnum, GroupedReturn] = {}
-
-    def update_forwarded_outputs(self, link_prop: PropEnum, values: Dict[str, List]):
-        """
-        method to set outputs to forward from other queries
-        :param link_prop: the property that the results are grouped by
-        :param values: grouped properties to forward
-        """
-        self._forwarded_outputs[link_prop] = values
-
-    @property
-    def forwarded_outputs(self) -> Dict[PropEnum, GroupedReturn]:
-        """
-        A getter for forwarded properties
-        """
-        return self._forwarded_outputs
 
     @property
     def selected_props(self) -> List[PropEnum]:
@@ -59,43 +38,80 @@ class QueryOutput:
         """
         self._props = props
 
+    @staticmethod
+    def _validate_groups(
+        results: Union[List, Dict], groups: Optional[List[str]] = None
+    ):
+        if not groups:
+            return results
+
+        if not isinstance(results, dict):
+            raise ParseQueryError(
+                f"Result is not grouped - cannot filter by given group(s) {groups}"
+            )
+        if not all(group in results.keys() for group in groups):
+            raise ParseQueryError(
+                f"Group(s) given are invalid - valid groups {list(results.keys())}"
+            )
+        return {group_key: results[group_key] for group_key in groups}
+
+    def to_objects(
+        self, results_container: ResultsContainer, groups: Optional[List[str]] = None
+    ) -> Union[Dict[str, List], List]:
+        """
+        return results as openstack objects
+        :param results_container: container object which stores results
+        :param groups: a list of group keys to limit output by
+
+        """
+        results = results_container.to_objects()
+        return self._validate_groups(results, groups)
+
+    def to_props(
+        self,
+        results_container: ResultsContainer,
+        flatten: bool = False,
+        groups: Optional[List[str]] = None,
+    ) -> Union[Dict[str, List], List]:
+        """
+        return results as selected props
+        :param results_container: container object which stores results
+        :param flatten: boolean which will flatten results if true
+        :param groups: a list of group keys to limit output by
+        """
+        results = results_container.to_props(*self.selected_props)
+        results = self._validate_groups(results, groups)
+        if flatten:
+            results = self.flatten(results)
+        return results
+
     def to_string(
         self,
-        results: Union[List, Dict],
+        results_container: ResultsContainer,
         title: str = None,
         groups: Optional[List[str]] = None,
         **kwargs,
     ):
         """
-        method to return results as a table
-        :param results: a list of parsed query results - either a list or a dict of grouped results
-        :param title: a title for the table(s) when it gets outputted
-        :param groups: a list group to limit output by
+        return results as a table of selected properties
+        :param results_container: container object which stores results
+        :param title: an optional title for the table when it gets outputted
+        :param groups: a list of groups to limit output by
         :param kwargs: kwargs to pass to _generate_table method
         """
-        output = ""
-        if title:
-            output += f"{title}:\n"
+        results = results_container.to_props(*self.selected_props)
+        results = self._validate_groups(results, groups)
+
+        output = "" if not title else f"{title}:\n"
 
         if isinstance(results, dict):
-            if groups and any(group not in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"given group(s) {groups} not found - available groups {list(results.keys())}"
-                )
-
-            if not groups:
-                groups = list(results.keys())
-
-            for group_title in groups:
-                group_list = results[group_title]
+            for group_title in list(results.keys()):
                 output += self._generate_table(
-                    group_list, return_html=False, title=f"{group_title}:\n", **kwargs
+                    results[group_title],
+                    return_html=False,
+                    title=f"{group_title}:\n",
+                    **kwargs,
                 )
-        elif groups:
-            raise ParseQueryError(
-                f"Result is not grouped - cannot filter by given group(s) {groups}"
-            )
-
         else:
             output += self._generate_table(
                 results, return_html=False, title=None, **kwargs
@@ -104,44 +120,30 @@ class QueryOutput:
 
     def to_html(
         self,
-        results: Union[List, Dict],
+        results_container: ResultsContainer,
         title: str = None,
         groups: Optional[List[str]] = None,
         **kwargs,
     ) -> str:
         """
         method to return results as html table
-        :param results: a list of parsed query results - either a list or a dict of grouped results
+        :param results_container: container object which stores results
         :param title: a title for the table(s) when it gets outputted
-        :param groups: a list group to limit output by
+        :param groups: a list of groups to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        output = ""
-        if title:
-            output += f"<b> {title} </b><br/> "
+        results = results_container.to_props(*self.selected_props)
+        results = self._validate_groups(results, groups)
+        output = "" if not title else f"<b> {title}: </b><br/> "
 
         if isinstance(results, dict):
-            if groups and any(group not in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"given group(s) {groups} not found - available groups {list(results.keys())}"
-                )
-
-            if not groups:
-                groups = list(results.keys())
-
-            for group_title in groups:
-                group_list = results[group_title]
+            for group_title in list(results.keys()):
                 output += self._generate_table(
-                    group_list,
+                    results[group_title],
                     return_html=True,
                     title=f"<b> {group_title}: </b><br/> ",
                     **kwargs,
                 )
-        elif groups:
-            raise ParseQueryError(
-                f"Result is not grouped - cannot filter by given group(s) {groups}"
-            )
-
         else:
             output += self._generate_table(
                 results, return_html=True, title=None, **kwargs
@@ -169,102 +171,18 @@ class QueryOutput:
 
         self.selected_props = set(all_props)
 
-    def generate_output(
-        self, openstack_resources: List[OpenstackResourceObj]
-    ) -> List[Dict[str, PropValue]]:
-        """
-        Generates a dictionary of queried properties from a list of openstack objects e.g. servers
-        e.g. {['server_name': 'server1', 'server_id': 'server1_id'],
-              ['server_name': 'server2', 'server_id': 'server2_id']} etc.
-        (if we selected 'server_name' and 'server_id' as properties
-        :param openstack_resources: List of openstack objects to obtain properties from - e.g. [Server1, Server2]
-        :return: List containing dictionaries of the requested properties obtained from the items
-        """
-        output = []
-        forwarded_outputs = deepcopy(self.forwarded_outputs)
-        for item in openstack_resources:
-            prop_list = self._parse_properties(item)
-            prop_list.update(self._parse_forwarded_outputs(item, forwarded_outputs))
-            output.append(prop_list)
-        return output
-
-    def _parse_forwarded_outputs(
-        self, openstack_resource: OpenstackResourceObj, forwarded_outputs: Dict
-    ) -> Dict[str, str]:
-        """
-        Generates a dictionary of forwarded outputs for the item given
-        :param openstack_resource: openstack resource item to parse forwarded outputs for
-        """
-        forwarded_output_dict = {}
-        for grouped_property, outputs in forwarded_outputs.items():
-            prop_val = self._parse_property(grouped_property, openstack_resource)
-
-            # this "should not" error because forwarded outputs should always be a super-set
-            # but sometimes resolving the property fails for whatever reason - fail noisily
-            try:
-                output_list = outputs[prop_val]
-                # we update with first result in grouped list and delete it
-
-                # forwarded properties might contain more than one value
-                # then() will keep duplicates so each one in the list will be shunted into an output
-                forwarded_output_dict.update(output_list[0])
-
-                # a hacky way to prevent one-to-many chaining erroring - keep at least one value
-                # one-to-many/one-to-one will only ever contain one value per grouped_value
-                # many-to-one will contain multiple values per grouped values
-                if len(output_list) > 1:
-                    del output_list[0]
-            except KeyError as exp:
-                raise QueryChainingError(
-                    "Error: Chaining failed. Could not attach forwarded outputs.\n"
-                    f"Property {grouped_property} extracted from has value {prop_val} which"
-                    "does not match any values from forwarded outputs. "
-                    "This is due to a mismatch in property mappings - likely an Openstack issue"
-                ) from exp
-        return forwarded_output_dict
-
-    def _parse_properties(
-        self, openstack_resource: OpenstackResourceObj
-    ) -> Dict[str, PropValue]:
-        """
-        Generates a dictionary of queried properties from a single openstack object
-        :param openstack_resource: openstack resource item to obtain properties from
-        """
-        obj_dict = {}
-        for prop in self.selected_props:
-            val = self._parse_property(prop, openstack_resource)
-            obj_dict[prop.name.lower()] = val
-        return obj_dict
-
-    def _parse_property(
-        self, prop: PropEnum, openstack_resource: OpenstackResourceObj
-    ) -> PropValue:
-        """
-        Parse single property from an openstack_object and return result
-        :param prop: property to parse
-        :param openstack_resource: openstack resource item to obtain property from
-        """
-        prop_func = self._prop_enum_cls.get_prop_mapping(prop)
-        try:
-            val = str(prop_func(openstack_resource))
-        except AttributeError:
-            val = self.DEFAULT_OUT
-        return val
-
     @staticmethod
     def _generate_table(
         results: List[Dict[str, PropValue]], return_html: bool, title=None, **kwargs
     ) -> str:
         """
-        Returns a table from the result of 'self._parse_properties'
+        Returns a table from the result of 'self.parse_properties'
         :param results: dict of query results
         :param return_html: True if output required in html table format else output plain text table
         :param kwargs: kwargs to pass to tabulate
         :return: String (html or plaintext table of results)
         """
-        output = ""
-        if title:
-            output += f"{title}\n"
+        output = "" if not title else f"{title}:\n"
 
         if results:
             headers = list(results[0].keys())

--- a/lib/openstack_query/query_blocks/result.py
+++ b/lib/openstack_query/query_blocks/result.py
@@ -1,0 +1,48 @@
+from typing import Dict
+from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
+from enums.query.props.prop_enum import PropEnum
+
+
+class Result:
+    """Class that holds a single result item"""
+
+    def __init__(
+        self, prop_enum_cls, obj_result: OpenstackResourceObj, default_value="Not Found"
+    ):
+        self._prop_enum_cls = prop_enum_cls
+        self._obj_result = obj_result
+        self._forwarded_props = {}
+        self._default_prop_value = default_value
+
+    def as_object(self) -> OpenstackResourceObj:
+        return self._obj_result
+
+    def as_props(self, *props: PropEnum) -> Dict[str, PropValue]:
+        """
+        return stored result, only outputting the properties given
+        :props: A set of prop enums to select
+        """
+        selected_props = {}
+        for prop in props:
+            key = prop.name.lower()
+            selected_props[key] = self.get_prop(prop)
+
+        return {**selected_props, **self._forwarded_props}
+
+    def get_prop(self, prop: PropEnum) -> PropValue:
+        """
+        return value of prop enum for stored result
+        :prop: a prop enum to select
+        """
+        try:
+            return self._prop_enum_cls.get_prop_mapping(prop)(self._obj_result)
+        except AttributeError:
+            return self._default_prop_value
+
+    def update_forwarded_properties(self, forwarded_props: Dict[str, PropValue]):
+        """
+        updates the set of forwarded properties to be associated with query result
+        :param forwarded_props: a dictionary containing property name: property value of
+        props to be associated with this result forwarded from previous queries
+        """
+        self._forwarded_props.update(forwarded_props)

--- a/lib/openstack_query/query_blocks/results_container.py
+++ b/lib/openstack_query/query_blocks/results_container.py
@@ -1,0 +1,126 @@
+from typing import Union, List, Dict, Callable
+from enums.query.props.prop_enum import PropEnum
+from exceptions.query_chaining_error import QueryChainingError
+from openstack_query.query_blocks.result import Result
+from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
+
+
+class ResultsContainer:
+    """
+    Helper class to store query results and forwarded results
+    """
+
+    DEFAULT_OUT = "Not Found"
+
+    def __init__(self, prop_enum_cls):
+        self._prop_enum_cls = prop_enum_cls
+        self._results: List = []
+        self._parsed_results: Union[List, Dict] = []
+
+    def to_props(self, *props: PropEnum) -> Union[Dict, List]:
+        """
+        Output the stored results, only outputting the properties given
+        :props: A set of prop enums to select
+        """
+        results = self._parsed_results or self._results
+        if not results:
+            return []
+
+        if isinstance(results, list):
+            return [item.as_props(*props) for item in results]
+        return {
+            name: [item.as_props(*props) for item in group]
+            for name, group in results.items()
+        }
+
+    def to_objects(self) -> Union[Dict, List]:
+        """
+        Output the results stored - as openstack objects
+        """
+
+        results = self._parsed_results or self._results
+        if not results:
+            return []
+
+        if isinstance(results, list):
+            return [item.as_object() for item in results]
+        return {
+            name: [item.as_object() for item in group]
+            for name, group in results.items()
+        }
+
+    def store_query_results(self, query_results: List[OpenstackResourceObj]):
+        """
+        a setter to set results after running the query with query results
+        :param query_results: A list of openstack objects returned after running query
+        """
+        self._results = [
+            Result(self._prop_enum_cls, item, self.DEFAULT_OUT)
+            for item in query_results
+        ]
+
+    def apply_forwarded_results(
+        self,
+        link_prop: PropEnum,
+        forwarded_results: Dict[PropValue, List[Dict]],
+    ):
+        """
+        public method that when called will add appropriate forwarded result entry onto each result.
+        (expects results to be a list)
+        :param forwarded_results: A set of grouped results forwarded from a previous query to attach to results
+        :param link_prop: An prop enum that the forwarded results are grouped by
+        """
+
+        if not self._results:
+            raise QueryChainingError(
+                "Query Chaining Error: Tried to apply a set of forwarded results when query has not been run yet"
+            )
+
+        for item in self._results:
+            prop_val = item.get_prop(link_prop)
+
+            # NOTE: This mutates forwarded_results
+            forwarded_result = self._get_forwarded_result(prop_val, forwarded_results)
+
+            item.update_forwarded_properties(forwarded_result)
+
+    @staticmethod
+    def _get_forwarded_result(prop_val: str, forwarded_results: Dict[str, List]):
+        """
+        static helper method to return forwarded values that match a given property value. Used for chaining
+        This handles two chaining cases:
+            - many-to-one (or one-to-one as we're using duplicates)
+                - where multiple forwarded outputs maps to one openstack object in result
+                - the result will contain exact number of duplicate openstack objects so each forwarded output is
+                assigned to an appropriate copy
+
+            - one-to-many - where one forwarded output needs to map to multiple openstack objects in results
+
+        :param prop_val: common property value to use to find a set of forwarded values to return
+        :param forwarded_results: a grouped dictionary which holds forwarded values grouped by common property value
+        """
+
+        if not forwarded_results:
+            return {}
+
+        result_to_attach = forwarded_results[prop_val][0]
+
+        # if forwarded_results group contains only one item:
+        #   - we assume we're chaining a one-to-many and keep at least one value
+
+        # if it contains multiple item:
+        #   - we assume many-to-one and delete the value
+
+        # deleting is a nice way of making sure each value is set - otherwise we need to keep track
+        # of the index position of last read item for each group
+        if len(forwarded_results[prop_val]) > 1:
+            del forwarded_results[prop_val][0]
+
+        return result_to_attach
+
+    def parse_results(self, parse_func: Callable[[List[Result]], Union[List]]):
+        """
+        This method applies a pre-set parse function which will sort and/or group the results
+        :param parse_func: parse function
+        """
+        self._parsed_results = parse_func(self._results)

--- a/lib/openstack_query/query_factory.py
+++ b/lib/openstack_query/query_factory.py
@@ -1,7 +1,5 @@
-from typing import Tuple, Type, Optional
+from typing import Type
 
-from enums.query.props.prop_enum import PropEnum
-from custom_types.openstack_query.aliases import GroupedReturn
 from openstack_query.mappings.mapping_interface import MappingInterface
 from openstack_query.query_blocks.query_builder import QueryBuilder
 from openstack_query.query_blocks.query_chainer import QueryChainer
@@ -21,21 +19,15 @@ class QueryFactory:
     """
 
     @staticmethod
-    def build_query_deps(
-        mapping_cls: Type[MappingInterface],
-        forwarded_outputs: Optional[Tuple[PropEnum, GroupedReturn]] = None,
-    ) -> QueryComponents:
+    def build_query_deps(mapping_cls: Type[MappingInterface]) -> QueryComponents:
         """
         Composes objects that make up the query - to allow dependency injection
         :param mapping_cls: A mapping class which is used to configure query objects
-        :param forwarded_outputs: A tuple containing grouped outputs to forward from another query
         and the enum they are grouped by
         """
         prop_mapping = mapping_cls.get_prop_mapping()
 
         output = QueryOutput(prop_mapping)
-        if forwarded_outputs:
-            output.update_forwarded_outputs(forwarded_outputs[0], forwarded_outputs[1])
         parser = QueryParser(prop_mapping)
         builder = QueryBuilder(
             prop_enum_cls=prop_mapping,

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -15,46 +15,10 @@ def instance_fixture():
     """
     Returns an instance to run tests with
     """
-    return QueryAPI(query_components=MagicMock())
-
-
-@pytest.fixture(name="run_with_test_case_with_subset")
-def run_with_test_case_with_subset_fixture(instance):
-    """
-    Fixture for running run() with a subset
-    """
-
-    def _run_with_test_case(mock_kwargs):
-        """
-        Runs a test case for the run() method
-        """
-        mock_query_results = ("object-list", "property-list")
-        instance.executer.run_query.return_value = mock_query_results
-        instance.builder.client_side_filters = ["client-filters"]
-        instance.builder.server_filter_fallback = ["fallback-client-filters"]
-        instance.builder.server_side_filters = ["server-filters"]
-
-        if not mock_kwargs:
-            mock_kwargs = {}
-
-        res = instance.run("test-account", ["item1", "item2"], **mock_kwargs)
-        instance.executer.run_query.assert_called_once_with(
-            cloud_account="test-account", from_subset=["item1", "item2"], **mock_kwargs
-        )
-
-        # test that data is marshalled correctly to executer
-        # - this differs based on if from_subset is given
-        client_filters = (
-            instance.builder.client_side_filters
-            + instance.builder.server_filter_fallback
-        )
-        server_filters = None
-
-        assert instance.executer.client_side_filters == client_filters
-        assert instance.executer.server_side_filters == server_filters
-        assert res == instance
-
-    return _run_with_test_case
+    res = QueryAPI(query_components=MagicMock())
+    # pylint: disable=protected-access
+    res.results_container = MagicMock()
+    return res
 
 
 @pytest.fixture(name="run_with_test_case")
@@ -63,12 +27,20 @@ def run_with_test_case_fixture(instance):
     Fixture for running run() with various test arguments
     """
 
-    def _run_with_test_case(data_subset, mock_kwargs):
+    @patch("openstack_query.api.query_api.deepcopy")
+    def _run_with_test_case(
+        mock_deepcopy,
+        mock_forwarded_info=(None, None),
+        data_subset=None,
+        mock_kwargs=None,
+    ):
         """
         Runs a test case for the run() method
         """
         mock_query_results = ("object-list", "property-list")
         instance.executer.run_query.return_value = mock_query_results
+        instance.chainer.forwarded_info = mock_forwarded_info
+
         instance.builder.client_side_filters = ["client-filters"]
         instance.builder.server_filter_fallback = ["fallback-client-filters"]
         instance.builder.server_side_filters = ["server-filters"]
@@ -81,10 +53,20 @@ def run_with_test_case_fixture(instance):
             cloud_account="test-account", from_subset=data_subset, **mock_kwargs
         )
 
-        # test that data is marshalled correctly to executer
-        # - this differs based on if from_subset is given
-        client_filters = instance.builder.client_side_filters
-        server_filters = instance.builder.server_side_filters
+        if data_subset:
+            client_filters = (
+                instance.builder.client_side_filters
+                + instance.builder.server_filter_fallback
+            )
+            server_filters = None
+        else:
+            client_filters = instance.builder.client_side_filters
+            server_filters = instance.builder.server_side_filters
+
+        # test if forwarded vals provided
+        if mock_forwarded_info[1]:
+            instance.executer.apply_forwarded_results.assert_called_once()
+            mock_deepcopy.assert_called_once_with(mock_forwarded_info[1])
 
         assert instance.executer.client_side_filters == client_filters
         assert instance.executer.server_side_filters == server_filters
@@ -177,13 +159,13 @@ def test_where_with_kwargs(instance):
     assert res == instance
 
 
-def test_run_with_optional_params(run_with_test_case_with_subset):
+def test_run_with_optional_params(run_with_test_case):
     """
     Tests that run method works expectedly - with subset meta_params kwargs
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case_with_subset(mock_kwargs=None)
+    run_with_test_case(data_subset=NonCallableMock(), mock_kwargs=None)
 
 
 def test_run_with_kwargs(run_with_test_case):
@@ -201,17 +183,29 @@ def test_run_with_nothing(run_with_test_case):
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case(None, None)
+    run_with_test_case(data_subset=None, mock_kwargs=None)
 
 
-def test_run_with_kwargs_and_subset(run_with_test_case_with_subset):
+def test_run_with_kwargs_and_subset(run_with_test_case):
     """
     Tests that run method works expectedly - with subset kwargs
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case_with_subset(
+    run_with_test_case(
+        data_subset=NonCallableMock(),
         mock_kwargs={"arg1": "val1", "arg2": "val2"},
+    )
+
+
+def test_run_with_forwarded_vals(run_with_test_case):
+    """
+    Tests that run method works - with forwarded vals
+    method run query as normal, then run executer.apply_forwarded_results
+    """
+    run_with_test_case(
+        data_subset=NonCallableMock(),
+        mock_forwarded_info=(NonCallableMock(), NonCallableMock()),
     )
 
 
@@ -220,8 +214,17 @@ def test_to_props(instance):
     Tests that to_props method functions expectedly - with no extra params
     method should just return _query_results attribute when groups is None and flatten is false
     """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_props() == "parsed-list"
+    mock_groups = NonCallableMock()
+    mock_flatten = NonCallableMock()
+
+    res = instance.to_props(mock_flatten, mock_groups)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_props.assert_called_once_with(
+        instance.results_container, mock_flatten, mock_groups
+    )
+    assert res == instance.output.to_props.return_value
 
 
 def test_to_objects(instance):
@@ -229,113 +232,39 @@ def test_to_objects(instance):
     Tests that to_objects method functions expectedly - with no extra params
     method should just return _query_results_as_objects attribute when groups is None
     """
-    # pylint: disable=protected-access
-    instance.output.forwarded_outputs = {}
-    instance.executer.parse_results.return_value = "object-list", ""
-    assert instance.to_objects() == "object-list"
+    mock_flatten = NonCallableMock()
+
+    instance.executer.has_forwarded_results = False
+
+    res = instance.to_objects(mock_flatten)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_objects.assert_called_once_with(
+        instance.results_container,
+        mock_flatten,
+    )
+    assert res == instance.output.to_objects.return_value
 
 
-def test_to_objects_forwarded_outputs_warning(instance):
+def test_to_objects_with_forwarded_results(instance):
     """
-    Tests that to_objects method functions expectedly
-    prints warning when forwarded_outputs is not empty
+    Tests that to_objects method - but where forwarded_results are given
+    method should output a warning but continue as normal
     """
-    # pylint: disable=protected-access
-    instance.output.forwarded_outputs = {"out1": "val1"}
+    mock_flatten = NonCallableMock()
 
-    # should just continue running as normal after printing warning
-    instance.executer.parse_results.return_value = "object-list", ""
-    assert instance.to_objects() == "object-list"
+    instance.executer.has_forwarded_results = True
 
-
-def test_to_props_flatten_true(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should call output.flatten() with query_results
-    """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    res = instance.to_props(flatten=True)
-    instance.output.flatten.assert_called_once_with("parsed-list")
-    assert res == instance.output.flatten.return_value
-
-
-def test_to_props_with_groups_not_dict(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should raise error when given group and results are not dict
-    """
-    instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
-    with pytest.raises(ParseQueryError):
-        instance.to_props(groups=["group1", "group2"])
-
-
-def test_to_objects_with_groups_not_dict(instance):
-    """
-    Tests that to_objects method functions expectedly
-    method should raise error when given group and results are not dict
-    """
-    instance.output.forwarded_outputs = {}
-    instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
-    with pytest.raises(ParseQueryError):
-        instance.to_objects(groups=["group1", "group2"])
-
-
-def test_to_props_groups_dict(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should return subset of results which match keys (groups) given
-    """
-    mock_query_results = {
-        "group1": ["result1", "result2"],
-        "group2": ["result3", "result4"],
-    }
-    instance.executer.parse_results.return_value = "", mock_query_results
-    res = instance.to_props(groups=["group1"])
-    assert res == {"group1": mock_query_results["group1"]}
-
-
-def test_to_objects_groups_dict(instance):
-    """
-    Tests that to_objects method functions expectedly
-    method should return subset of results which match keys (groups) given
-    """
-    instance.output.forwarded_outputs = {}
-    mock_query_results = {
-        "group1": ["obj1", "obj2"],
-        "group2": ["obj3", "obj4"],
-    }
-    instance.executer.parse_results.return_value = mock_query_results, ""
-    res = instance.to_objects(groups=["group1"])
-    assert res == {"group1": mock_query_results["group1"]}
-
-
-def test_to_props_group_not_valid(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should raise error if group specified is not a key in results
-    """
-    mock_query_results = {
-        "group1": ["result1", "result2"],
-        "group2": ["result3", "result4"],
-    }
-    instance.executer.parse_results.return_value = "", mock_query_results
-    with pytest.raises(ParseQueryError):
-        instance.to_props(groups=["group3"])
-
-
-def test_to_objects_group_not_valid(instance):
-    """
-    Tests that to_objects method functions expectedly
-    method should raise error if group specified is not a key in results
-    """
-    instance.output.forwarded_outputs = {}
-    mock_query_results = {
-        "group1": ["result1", "result2"],
-        "group2": ["result3", "result4"],
-    }
-    instance.executer.parse_results.return_value = mock_query_results, ""
-    with pytest.raises(ParseQueryError):
-        instance.to_objects(groups=["group3"])
+    res = instance.to_objects(mock_flatten)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_objects.assert_called_once_with(
+        instance.results_container,
+        mock_flatten,
+    )
+    assert res == instance.output.to_objects.return_value
 
 
 def test_to_string(instance):
@@ -343,9 +272,21 @@ def test_to_string(instance):
     Tests that to_string method functions expectedly
     method should call QueryOutput object to_string() and return results
     """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_string() == instance.output.to_string.return_value
-    instance.output.to_string.assert_called_once_with("parsed-list", None, None)
+    mock_groups = NonCallableMock()
+    mock_title = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    # pylint: disable=protected-access
+    instance.results_container = MagicMock()
+
+    res = instance.to_string(mock_title, mock_groups, **mock_kwargs)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_string.assert_called_once_with(
+        instance.results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    assert res == instance.output.to_string.return_value
 
 
 def test_to_html(instance):
@@ -353,9 +294,18 @@ def test_to_html(instance):
     Tests that to_html method functions expectedly
     method should call QueryOutput object to_html() and return results
     """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_html() == instance.output.to_html.return_value
-    instance.output.to_html.assert_called_once_with("parsed-list", None, None)
+    mock_groups = NonCallableMock()
+    mock_title = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    res = instance.to_html(mock_title, mock_groups, **mock_kwargs)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_html.assert_called_once_with(
+        instance.results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    assert res == instance.output.to_html.return_value
 
 
 def test_sort_by(instance):
@@ -401,34 +351,32 @@ def test_then(instance):
     assert res == instance.chainer.parse_then.return_value
 
 
-@patch("openstack_query.api.query_api.QueryAPI.then")
-@patch("openstack_query.api.query_api.QueryTypes")
-def test_append_from(mock_query_types_cls, mock_then, instance):
+def test_append_from(instance):
     """
-    Tests that append_from method creates new query
+    Tests that append_from method - should call run_append_from_query
+    and martial results into results_container.apply_forwarded_results
     """
-    mock_new_query = MagicMock()
+    mock_query_type = NonCallableMock()
     mock_cloud_account = NonCallableMock()
-    mock_query_type = "query-type"
+    mock_prop1 = NonCallableMock()
+    mock_prop2 = NonCallableMock()
 
-    mock_props = ["prop1", "prop2", "prop3"]
-    instance.chainer.get_link_props.return_value = ("current-prop", "link-prop")
-    mock_then.return_value = mock_new_query
+    mock_link_prop = NonCallableMock()
+    mock_new_query_results = NonCallableMock()
 
-    res = instance.append_from(mock_query_type, mock_cloud_account, *mock_props)
-    mock_query_types_cls.from_string.assert_called_once_with(mock_query_type)
-    mock_then.assert_called_once_with(
-        mock_query_types_cls.from_string.return_value, keep_previous_results=False
+    instance.chainer.run_append_from_query.return_value = (
+        mock_link_prop,
+        mock_new_query_results,
     )
 
-    mock_new_query.select.assert_called_once_with(*mock_props)
-    mock_new_query.run.assert_called_once_with(mock_cloud_account)
-    instance.chainer.get_link_props.assert_called_once_with(
-        mock_query_types_cls.from_string.return_value
+    res = instance.append_from(
+        mock_query_type, mock_cloud_account, mock_prop1, mock_prop2
     )
-    mock_new_query.group_by.assert_called_once_with("link-prop")
-    mock_new_query.to_props.assert_called_once()
-    instance.output.update_forwarded_outputs.assert_called_once_with(
-        "current-prop", mock_new_query.to_props.return_value
+    instance.chainer.run_append_from_query.assert_called_once_with(
+        instance, mock_query_type, mock_cloud_account, mock_prop1, mock_prop2
     )
+    instance.results_container.apply_forwarded_results(
+        mock_link_prop, mock_new_query_results
+    )
+
     assert res == instance

--- a/tests/lib/openstack_query/query_blocks/test_query_chainer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_chainer.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call, NonCallableMock
 
 import pytest
 
@@ -52,13 +52,6 @@ def run_parse_then_query_valid_fixture(instance):
             "prop_1": ["val1", "val2", "val3"]
         }
 
-        to_forward = None
-        if mock_keep_previous_results:
-            to_forward = (
-                MockProperties.PROP_2,
-                mock_current_query.group_by.return_value.to_props.return_value,
-            )
-
         res = instance.parse_then(
             current_query=mock_current_query,
             query_type="query-type",
@@ -73,6 +66,10 @@ def run_parse_then_query_valid_fixture(instance):
         mock_current_query.select.return_value.to_props.assert_any_call(flatten=True)
 
         if mock_keep_previous_results:
+            mock_query_api.return_value.chainer.set_forwarded_vals.assert_called_once_with(
+                MockProperties.PROP_2,
+                mock_current_query.group_by.return_value.to_props.return_value,
+            )
             mock_group_by = mock_current_query.group_by
             mock_group_by.assert_has_calls(
                 [
@@ -82,7 +79,7 @@ def run_parse_then_query_valid_fixture(instance):
             )
 
         mock_query_factory.build_query_deps.assert_called_once_with(
-            mock_query_types_cls.from_string.return_value.value, to_forward
+            mock_query_types_cls.from_string.return_value.value
         )
 
         mock_query_api.assert_called_once_with(
@@ -97,6 +94,17 @@ def run_parse_then_query_valid_fixture(instance):
         assert res == mock_query_api.return_value.where.return_value
 
     return _run_parse_then_query_valid
+
+
+def test_forwarded_info(instance):
+    """
+    Tests forwarded info property outputs a tuple of link_prop and
+    forwarded_values attributes. Uses set_forwarded_vals to set the properties
+    """
+    mock_forwarded_values = NonCallableMock()
+    mock_link_prop = NonCallableMock()
+    instance.set_forwarded_vals(mock_link_prop, mock_forwarded_values)
+    assert instance.forwarded_info == (mock_link_prop, mock_forwarded_values)
 
 
 def test_get_chaining_props(instance):
@@ -210,3 +218,39 @@ def test_parse_then_no_results(instance):
         )
     mock_current_query.chainer.get_link_props.assert_called_once_with(mock_query_type)
     mock_current_query.to_props.assert_called_once()
+
+
+@patch("openstack_query.query_blocks.query_chainer.QueryTypes")
+def test_run_append_from_query(mock_query_types, instance):
+    """
+    tests run_append_from_query method - calls then() to get a new query and runs it, selecting
+    given props and return grouped values
+    """
+    mock_current_query = NonCallableMock()
+    mock_cloud_account = NonCallableMock()
+    query_type = "query_type"
+    mock_props = ["prop1", "prop2"]
+
+    mock_current_query.chainer.get_link_props.return_value = (
+        "current_link_prop",
+        "new_link_prop",
+    )
+    mock_new_query = mock_current_query.then.return_value
+
+    res = instance.run_append_from_query(
+        mock_current_query, query_type, mock_cloud_account, *mock_props
+    )
+
+    mock_query_types.from_string.assert_called_once_with(query_type)
+    mock_current_query.then.assert_called_once_with(
+        mock_query_types.from_string.return_value, keep_previous_results=False
+    )
+    mock_new_query.select.assert_called_once_with(*mock_props)
+    mock_new_query.run.assert_called_once_with(mock_cloud_account)
+    mock_current_query.chainer.get_link_props.assert_called_once_with(
+        mock_query_types.from_string.return_value
+    )
+    assert res == (
+        "current_link_prop",
+        mock_new_query.group_by.return_value.to_props.return_value,
+    )

--- a/tests/lib/openstack_query/query_blocks/test_query_executer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_executer.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, NonCallableMock
 import pytest
 
 from enums.cloud_domains import CloudDomains
@@ -15,7 +15,17 @@ def instance_fixture():
     """
     mock_prop_enum_cls = MockProperties
     mock_runner_cls = MagicMock()
-    return QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
+    query_executer = QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
+    query_executer._results_container = MagicMock()
+    return query_executer
+
+
+def test_results_container(instance):
+    """
+    Tests that results container property works as expected
+    """
+    mock_results_container = instance._results_container
+    assert instance.results_container == mock_results_container
 
 
 def test_client_side_filter_func(instance):
@@ -36,75 +46,11 @@ def test_server_side_filters(instance):
     assert instance.server_side_filters == mock_client_filter
 
 
-def test_parse_func(instance):
-    """
-    Tests that parse_func property works as expected
-    """
-    mock_parse_func = MagicMock()
-    instance.parse_func = mock_parse_func
-    assert instance.parse_func == mock_parse_func
-
-
-def test_output_func(instance):
-    """
-    Tests that output_func property method works as expected
-    """
-    mock_output_func = MagicMock()
-    instance.output_func = mock_output_func
-    assert instance.output_func == mock_output_func
-
-
-def test_raw_results(instance):
-    """
-    Tests that raw_results property method works as expected
-    """
-    mock_raw_results = MagicMock()
-    instance.raw_results = mock_raw_results
-    assert instance.raw_results == mock_raw_results
-
-
-def test_get_output_list_input(instance):
-    """
-    Tests that get_output method works as expected - when given a list
-    Should output the results of calling function stored in output_func attribute with given list
-    """
-    mock_out = [1, 2, 3]
-
-    def output_func(_):
-        return mock_out
-
-    output = instance.get_output(output_func, ["mock-result1"])
-    assert output == mock_out
-
-
-def test_get_output_dict_input(instance):
-    """
-    Tests that get_output method works as expected - when given a grouped output (dictionary)
-    Should output a dictionary, with values being the output of calling output_func with each group
-    """
-    mock_out = [1, 2, 3]
-    expected_out = {"group1": mock_out, "group2": mock_out}
-
-    def output_func(_):
-        return mock_out
-
-    output = instance.get_output(
-        output_func, {"group1": ["mock-results"], "group2": ["mock-results2"]}
-    )
-    assert output == expected_out
-
-
-def test_get_output_no_output_func(instance):
-    """
-    Tests that get_output method works as expected - when given no ouptut_func
-    Should output an empty list
-    """
-    instance._output_func = None
-    output = instance.get_output(None, ["mock-results1"])
-    assert output == []
-
-
-def test_run_query(instance):
+@pytest.mark.parametrize(
+    "mock_cloud_account, expected_cloud_account_str",
+    [(CloudDomains.PROD, "prod"), ("domain", "domain")],
+)
+def test_run_query(mock_cloud_account, expected_cloud_account_str, instance):
     """
     Tests that run_query method works as expected
     simply calls runner.run() and saves result in raw_results
@@ -113,13 +59,17 @@ def test_run_query(instance):
     instance.server_side_filters = MagicMock()
 
     instance.run_query(
-        cloud_account=CloudDomains.PROD,
+        cloud_account=mock_cloud_account,
         from_subset="some-subset",
         **{"arg1": "val1", "arg2": "val2"}
     )
 
+    instance.results_container.store_query_results.assert_called_once_with(
+        instance.runner.run.return_value
+    )
+
     instance.runner.run.assert_called_once_with(
-        cloud_account="prod",
+        cloud_account=expected_cloud_account_str,
         client_side_filters=instance.client_side_filters,
         server_side_filters=instance.server_side_filters,
         from_subset="some-subset",
@@ -127,61 +77,15 @@ def test_run_query(instance):
     )
 
 
-def test_run_query_with_string_domain(instance):
+def test_apply_forwarded_results(instance):
     """
-    Tests that run_query method works as expected
-    simply calls runner.run() and saves result in raw_results
+    Test apply_forwarded_results method - should forward to results_container
+    and set has_forwarded_results flag to True
     """
-    instance.client_side_filters = MagicMock()
-    instance.server_side_filters = MagicMock()
-
-    instance.run_query(
-        cloud_account="domain",
-        from_subset="some-subset",
-        **{"arg1": "val1", "arg2": "val2"}
+    mock_link_prop = NonCallableMock()
+    mock_results = NonCallableMock()
+    instance.apply_forwarded_results(mock_link_prop, mock_results)
+    instance.results_container.apply_forwarded_results.assert_called_once_with(
+        mock_link_prop, mock_results
     )
-
-    instance.runner.run.assert_called_once_with(
-        cloud_account="domain",
-        client_side_filters=instance.client_side_filters,
-        server_side_filters=instance.server_side_filters,
-        from_subset="some-subset",
-        **{"arg1": "val1", "arg2": "val2"}
-    )
-
-
-def test_parse_results_no_parse_func(instance):
-    """
-    Tests that parse_results method works as expected
-    should return raw_results, and get_output(raw_results) tuple
-    """
-    instance.raw_results = MagicMock()
-    with patch(
-        "openstack_query.query_blocks.query_executer.QueryExecuter.get_output"
-    ) as mock_get_output:
-        res1, res2 = instance.parse_results(None, "output_func")
-
-    assert res1 == instance.raw_results
-    mock_get_output.assert_called_once_with("output_func", instance.raw_results)
-    assert res2 == mock_get_output.return_value
-
-
-def test_parse_results_with_parse_func(instance):
-    """
-    Tests that parse_results method works as expected
-    should return raw_results, and get_output(raw_results) tuple
-    """
-    instance.raw_results = MagicMock()
-    parse_func = MagicMock()
-    output_func = "output_func"
-
-    with patch(
-        "openstack_query.query_blocks.query_executer.QueryExecuter.get_output"
-    ) as mock_get_output:
-        res1, res2 = instance.parse_results(parse_func, output_func)
-
-    parse_func.assert_called_once_with(instance.raw_results)
-    assert res1 == parse_func.return_value
-
-    mock_get_output.assert_called_once_with("output_func", parse_func.return_value)
-    assert res2 == mock_get_output.return_value
+    assert instance.has_forwarded_results

--- a/tests/lib/openstack_query/query_blocks/test_query_parser.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_parser.py
@@ -9,6 +9,28 @@ from exceptions.parse_query_error import ParseQueryError
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
+@pytest.fixture(name="mock_results_container")
+def results_container_fixture():
+    """
+    Returns a list of mock results with each as_object return value set to
+    given values
+    """
+
+    def _setup_results_container(mock_as_objects):
+        """
+        function which sets up a list of mock Result objects each with
+        a different as_object return value - as specified by mock_as_objects input
+        :param mock_as_objects: a list of values that is to be assigned as the
+         return_value for each mock Result object
+        """
+        mock_results = [MagicMock() for _ in mock_as_objects]
+        for i, mock_result in enumerate(mock_results):
+            mock_result.as_object.return_value = mock_as_objects[i]
+        return mock_results
+
+    return _setup_results_container
+
+
 @pytest.fixture(name="instance")
 def instance_fixture():
     """
@@ -50,7 +72,8 @@ def run_sort_by_tests_fixture(instance, mock_get_prop_mapping):
         ) as mock_get_prop_func:
             # pylint:disable=protected-access
             res = instance._run_sort(obj_list)
-            assert res == expected_list
+            # test that res object list is sorted properly
+            assert [item.as_object() for item in res] == expected_list
             mock_get_prop_func.assert_has_calls(
                 [call(sort_key) for sort_key in reversed(sort_by_specs.keys())]
             )
@@ -104,6 +127,15 @@ def test_parse_sort_by_invalid(instance):
     """
     with pytest.raises(ParseQueryError):
         instance.parse_sort_by((ServerProperties.SERVER_ID, True))
+
+
+def test_parse_group_by_invalid(instance):
+    """
+    Tests parse_group_by - when given an invalid group by prop
+    """
+    with pytest.raises(ParseQueryError):
+        # we gave an unexpected enum value (sort-order) that's not supported
+        instance.parse_group_by(SortOrder.DESC)
 
 
 def test_parse_group_by_no_ranges(instance):
@@ -165,11 +197,16 @@ def test_run_parse_group_ranges(instance, mock_get_prop_mapping):
 
     assert instance.group_mappings
 
-    assert instance.group_mappings["group1"]({"prop_1": "val1"})
-    assert not instance.group_mappings["group2"]({"prop_1": "val1"})
+    prop_to_check = MagicMock()
+    prop_to_check.as_object.return_value = {"prop_1": "val1"}
+
+    assert instance.group_mappings["group1"](prop_to_check)
+    assert not instance.group_mappings["group2"](prop_to_check)
 
 
-def test_add_include_missing_group(instance, mock_get_prop_mapping):
+def test_add_include_missing_group(
+    instance, mock_get_prop_mapping, mock_results_container
+):
     """
     Tests add_include_missing_group functions expectedly
     Should create an extra "ungrouped results" group which includes values
@@ -186,9 +223,13 @@ def test_add_include_missing_group(instance, mock_get_prop_mapping):
         instance._add_include_missing_group(mock_group_ranges)
         mock_get_prop_func.assert_called_once_with(mock_group_by)
 
-    assert instance.group_mappings["ungrouped results"]({"prop_1": "val5"})
-    assert not instance.group_mappings["ungrouped results"]({"prop_1": "val1"})
-    assert not instance.group_mappings["ungrouped results"]({"prop_1": "val4"})
+    results_to_check = mock_results_container(
+        [{"prop_1": "val5"}, {"prop_1": "val1"}, {"prop_1": "val4"}]
+    )
+
+    assert instance.group_mappings["ungrouped results"](results_to_check[0])
+    assert not instance.group_mappings["ungrouped results"](results_to_check[1])
+    assert not instance.group_mappings["ungrouped results"](results_to_check[2])
 
 
 @patch("openstack_query.query_blocks.query_parser.QueryParser._run_sort")
@@ -197,9 +238,7 @@ def test_run_parser_with_sort_by(mock_run_sort, instance):
     Tests that run_parser functions expectedly - when giving only sort_by
     Should call run_sort method, and return result
     """
-    instance.sort_by = {MockProperties.PROP_1: False}
-    instance.group_by = None
-    instance.group_mappings = {}
+    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.DESC))
 
     mock_run_sort.return_value = "sort-out"
     mock_obj_list = ["obj1", "obj2", "obj3"]
@@ -215,9 +254,7 @@ def test_run_parser_no_sort_with_group_mappings(mock_run_group_by, instance):
     Tests that run_parser functions expectedly - when giving group_mappings
     Should call run_group_by with group mappings and return
     """
-    instance.sort_by = {}
-    instance.group_by = MockProperties.PROP_1
-    instance.group_mappings = {"group1": "some-mapping_func"}
+    instance.parse_group_by(MockProperties.PROP_1)
 
     mock_obj_list = ["obj1", "obj2", "obj3"]
     mock_run_group_by.return_value = "group-out"
@@ -235,11 +272,10 @@ def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instan
     Tests that run_parser functions expectedly - when giving both group_by and sort_by
     Should call run_sort method and then run_group_by on that output, then return
     """
-    instance.sort_by = {MockProperties.PROP_1: False}
-    instance.group_by = MockProperties.PROP_1
-    instance.group_mappings = {"group1": "some-mapping_func"}
-    mock_obj_list = ["obj1", "obj2", "obj3"]
+    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.DESC))
+    instance.parse_group_by(MockProperties.PROP_1)
 
+    mock_obj_list = ["obj1", "obj2", "obj3"]
     mock_run_group_by.return_value = "group-out"
     mock_run_sort.return_value = "sort-out"
 
@@ -247,6 +283,13 @@ def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instan
     assert res == "group-out"
     mock_run_sort.assert_called_once_with(mock_obj_list)
     mock_run_group_by.assert_called_once_with("sort-out")
+
+
+def test_run_parser_empty_list(instance):
+    """
+    Tests run_parser - when given empty list - output empty list
+    """
+    assert instance.run_parser([]) == []
 
 
 @pytest.mark.parametrize(
@@ -258,26 +301,29 @@ def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instan
         {MockProperties.PROP_2: True},
     ],
 )
-def test_run_sort_with_one_key(mock_sort_by_specs, run_sort_by_tests):
+def test_run_sort_with_one_key(
+    mock_sort_by_specs, run_sort_by_tests, mock_results_container
+):
     """
     Tests that run_sort functions expectedly - with one sorting key
     Should call run_sort method which should get the appropriate sorting
     key lambda function and sort dict accordingly
     """
-
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 2},
         {"prop_1": "c", "prop_2": 4},
         {"prop_1": "d", "prop_2": 3},
         {"prop_1": "b", "prop_2": 1},
     ]
 
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+
     # sorting by only one property so get first key in sort specs
     mock_enum = list(mock_sort_by_specs.keys())[0]
     reverse = mock_sort_by_specs[mock_enum]
     mock_prop_name = mock_enum.name.lower()
     expected_list = sorted(
-        mock_obj_list, key=lambda k: k[mock_prop_name], reverse=reverse
+        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
     )
     run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
 
@@ -324,20 +370,20 @@ def test_run_sort_with_one_key(mock_sort_by_specs, run_sort_by_tests):
     ],
 )
 def test_run_sort_with_multiple_key(
-    mock_sort_by_specs, expected_list, run_sort_by_tests
+    mock_sort_by_specs, expected_list, run_sort_by_tests, mock_results_container
 ):
     """
     Tests that run_sort functions expectedly - with one sorting key
     Should call run_sort method which should get the appropriate sorting
     key lambda function and sort dict accordingly
     """
-
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 1},
         {"prop_1": "b", "prop_2": 1},
         {"prop_1": "a", "prop_2": 2},
         {"prop_1": "b", "prop_2": 2},
     ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
     run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
 
 
@@ -345,23 +391,23 @@ def test_run_sort_with_multiple_key(
     "mock_sort_by_specs",
     [{MockProperties.PROP_1: False}, {MockProperties.PROP_1: True}],
 )
-def test_run_sort_with_boolean(mock_sort_by_specs, instance, run_sort_by_tests):
+def test_run_sort_with_boolean(
+    mock_sort_by_specs, instance, run_sort_by_tests, mock_results_container
+):
     """
     Tests that run_sort functions expectedly - sorting by boolean
     Should call run_sort method which should get the appropriate sorting
     key lambda function and sort dict accordingly
     """
-    mock_obj_list = [
-        {"prop_1": False},
-        {"prop_1": True},
-    ]
+    mock_as_object_vals = [{"prop_1": False}, {"prop_1": True}]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
     instance.sort_by = mock_sort_by_specs
     mock_enum = list(mock_sort_by_specs.keys())[0]
     reverse = mock_sort_by_specs[mock_enum]
     mock_prop_name = mock_enum.name.lower()
 
     expected_list = sorted(
-        mock_obj_list, key=lambda k: k[mock_prop_name], reverse=reverse
+        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
     )
     run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
 
@@ -422,7 +468,9 @@ def test_build_unique_val_groups(
 
 
 @patch("openstack_query.query_blocks.query_parser.QueryParser._build_unique_val_groups")
-def test_run_group_by_no_group_mappings(mock_build_unique_val_groups, instance):
+def test_run_group_by_no_group_mappings(
+    mock_build_unique_val_groups, instance, mock_results_container
+):
     """
     Tests run group_by method functions expectedly - when using no group mappings
     Should call build_unique_val_group and use the mappings returned to apply onto given object list
@@ -437,24 +485,33 @@ def test_run_group_by_no_group_mappings(mock_build_unique_val_groups, instance):
     }
     mock_build_unique_val_groups.return_value = mock_group_mappings
 
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 1},
         {"prop_1": "b", "prop_2": 2},
         {"prop_1": "c", "prop_2": 3},
     ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
     # pylint:disable=protected-access
     res = instance._run_group_by(mock_obj_list)
-    mock_build_unique_val_groups.assert_called_once_with(mock_obj_list)
+    mock_build_unique_val_groups.assert_called_once_with(
+        [item.as_object() for item in mock_obj_list]
+    )
 
-    assert res == {
-        "group1": [{"prop_1": "a", "prop_2": 1}],
-        "group2": [{"prop_1": "b", "prop_2": 2}],
-        "group3": [{"prop_1": "c", "prop_2": 3}],
-    }
+    assert [item.as_object() for item in res["group1"]] == [
+        {"prop_1": "a", "prop_2": 1}
+    ]
+    assert [item.as_object() for item in res["group2"]] == [
+        {"prop_1": "b", "prop_2": 2}
+    ]
+    assert [item.as_object() for item in res["group3"]] == [
+        {"prop_1": "c", "prop_2": 3}
+    ]
 
 
 @patch("openstack_query.query_blocks.query_parser.QueryParser._build_unique_val_groups")
-def test_run_group_by_with_group_mappings(mock_build_unique_val_groups, instance):
+def test_run_group_by_with_group_mappings(
+    mock_build_unique_val_groups, instance, mock_results_container
+):
     """
     Tests run group_by method functions expectedly - when using group mappings
     Should use the preset mappings and apply them onto given object list
@@ -467,17 +524,22 @@ def test_run_group_by_with_group_mappings(mock_build_unique_val_groups, instance
     }
     instance.group_mappings = mock_group_mappings
 
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 1},
         {"prop_1": "b", "prop_2": 2},
         {"prop_1": "c", "prop_2": 3},
     ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
 
     # pylint:disable=protected-access
     res = instance._run_group_by(mock_obj_list)
     mock_build_unique_val_groups.assert_not_called()
 
-    assert res == {
-        "group1": [{"prop_1": "a", "prop_2": 1}, {"prop_1": "b", "prop_2": 2}],
-        "group2": [{"prop_1": "c", "prop_2": 3}],
-    }
+    assert [item.as_object() for item in res["group1"]] == [
+        {"prop_1": "a", "prop_2": 1},
+        {"prop_1": "b", "prop_2": 2},
+    ]
+
+    assert [item.as_object() for item in res["group2"]] == [
+        {"prop_1": "c", "prop_2": 3}
+    ]

--- a/tests/lib/openstack_query/query_blocks/test_result.py
+++ b/tests/lib/openstack_query/query_blocks/test_result.py
@@ -1,0 +1,107 @@
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from openstack_query.query_blocks.result import Result
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(name="mock_get_prop_func")
+def get_prop_func_fixture():
+    """
+    Stubs out get_prop_func method to return a
+    stub callable based on prop enum
+    """
+    mock_prop_1_func = MagicMock()
+    mock_prop_1_func.return_value = "prop 1 out"
+
+    mock_prop_2_func = MagicMock()
+    mock_prop_2_func.side_effect = AttributeError
+
+    def _mock_get_prop_func(prop):
+        return {
+            MockProperties.PROP_1: mock_prop_1_func,
+            MockProperties.PROP_2: mock_prop_2_func,
+        }.get(prop, None)
+
+    return _mock_get_prop_func
+
+
+@pytest.fixture(name="instance")
+def instance_fixture():
+    """
+    Returns an instance with mocked prop_enum_cls inject
+    """
+    return Result(prop_enum_cls=MockProperties, obj_result=MagicMock())
+
+
+def test_as_object():
+    """
+    test property getter as_object
+    """
+    mock_obj = MagicMock()
+    assert Result(MockProperties, mock_obj).as_object() == mock_obj
+
+
+@patch("openstack_query.query_blocks.result.Result.get_prop")
+def test_as_props_no_forwarded_props(mock_get_prop, instance):
+    """
+    test property getter as_props just gets as_props when no forwarded_props given
+    """
+    mock_props = [MockProperties.PROP_1, MockProperties.PROP_2]
+    res = instance.as_props(*mock_props)
+    mock_get_prop.assert_has_calls(
+        [call(MockProperties.PROP_1), call(MockProperties.PROP_2)]
+    )
+
+    assert res == {
+        "prop_1": mock_get_prop.return_value,
+        "prop_2": mock_get_prop.return_value,
+    }
+
+
+@patch("openstack_query.query_blocks.result.Result.get_prop")
+def test_as_props_with_forwarded_props(mock_get_prop, instance):
+    """
+    test property getter as_props gets as_props result and forwarded_props set,
+    concatenates them together
+    """
+    instance.update_forwarded_properties({"fwd_prop1": "val1", "fwd_prop2": "val2"})
+
+    mock_props = [MockProperties.PROP_1, MockProperties.PROP_2]
+    res = instance.as_props(*mock_props)
+    mock_get_prop.assert_has_calls(
+        [call(MockProperties.PROP_1), call(MockProperties.PROP_2)]
+    )
+
+    assert res == {
+        "prop_1": mock_get_prop.return_value,
+        "prop_2": mock_get_prop.return_value,
+        "fwd_prop1": "val1",
+        "fwd_prop2": "val2",
+    }
+
+
+def test_get_prop_found(mock_get_prop_func, instance):
+    """
+    Test get_prop method.
+    Method should call prop_enum_cls.get_prop_mapping on given prop and run returned function on stored obj_result
+    """
+    with patch.object(
+        MockProperties, "get_prop_mapping", wraps=mock_get_prop_func
+    ) as mock_get_prop_mapping:
+        res = instance.get_prop(MockProperties.PROP_1)
+    mock_get_prop_mapping.assert_called_once_with(MockProperties.PROP_1)
+    assert res == "prop 1 out"
+
+
+def test_get_prop_not_found(mock_get_prop_func, instance):
+    """
+    Test get_prop method - when function to get property fails with Attribute error - meaning property does not exist
+    method should return the default value attribute
+    """
+    with patch.object(
+        MockProperties, "get_prop_mapping", wraps=mock_get_prop_func
+    ) as mock_get_prop_mapping:
+        res = instance.get_prop(MockProperties.PROP_2)
+    mock_get_prop_mapping.assert_called_once_with(MockProperties.PROP_2)
+    assert res == "Not Found"

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -1,0 +1,300 @@
+from unittest.mock import MagicMock, patch, call, NonCallableMock
+import pytest
+
+from exceptions.query_chaining_error import QueryChainingError
+from openstack_query.query_blocks.results_container import ResultsContainer
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(name="setup_instance_with_results")
+def setup_instance_with_results_fixture():
+    """
+    Returns an instance of ResultContainer with mocked results
+    """
+
+    def _setup_instance_with_results(mock_results):
+        val = ResultsContainer(prop_enum_cls=MockProperties)
+        # pylint:disable=protected-access
+        val._results = mock_results
+        return val
+
+    return _setup_instance_with_results
+
+
+def test_to_props_results_empty(setup_instance_with_results):
+    """
+    Test to_props method when results are empty - return empty list
+    """
+    instance = setup_instance_with_results([])
+    instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+
+def test_to_props_not_parsed(setup_instance_with_results):
+    """
+    Test to_props method when results are not parsed
+    """
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    res = instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+    mock_res1.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    mock_res2.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    assert res == [mock_res1.as_props.return_value, mock_res2.as_props.return_value]
+
+
+def test_to_props_parsed_to_list(setup_instance_with_results):
+    """
+    Test to_props method when results are parsed into a list
+    """
+
+    def mock_parse_func(results):
+        """a parse func that doesn't do anything"""
+        return results
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+    mock_res1.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    mock_res2.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    assert res == [mock_res1.as_props.return_value, mock_res2.as_props.return_value]
+
+
+def test_to_props_parsed_and_grouped(setup_instance_with_results):
+    """
+    Test to_props method when results are parsed into a dict (grouped)
+    """
+
+    def mock_parse_func(results):
+        """a parse func that returns a dictionary"""
+        return {"group1": [results[0]], "group2": [results[1]]}
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+    mock_res1.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    mock_res2.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    assert res == {
+        "group1": [mock_res1.as_props.return_value],
+        "group2": [mock_res2.as_props.return_value],
+    }
+
+
+def test_to_objects_results_empty(setup_instance_with_results):
+    """
+    Test to_objects method when results are empty - return empty list
+    """
+    instance = setup_instance_with_results([])
+    instance.to_objects()
+
+
+def test_to_objects_not_parsed(setup_instance_with_results):
+    """
+    Test to_objects method when results are not parsed
+    """
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    res = instance.to_objects()
+
+    mock_res1.as_object.assert_called_once()
+
+    mock_res2.as_object.assert_called_once()
+
+    assert res == [mock_res1.as_object.return_value, mock_res2.as_object.return_value]
+
+
+def test_to_object_parsed_to_list(setup_instance_with_results):
+    """
+    Test to_object method when results are parsed into a list
+    """
+
+    def mock_parse_func(results):
+        """a parse func that doesn't do anything"""
+        return results
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_objects()
+    mock_res1.as_object.assert_called_once()
+    mock_res2.as_object.assert_called_once()
+
+    assert res == [mock_res1.as_object.return_value, mock_res2.as_object.return_value]
+
+
+def test_to_object_parsed_and_grouped(setup_instance_with_results):
+    """
+    Test to_object method when results are parsed into a dict (grouped)
+    """
+
+    def mock_parse_func(results):
+        """a parse func that returns a dictionary"""
+        return {"group1": [results[0]], "group2": [results[1]]}
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_objects()
+    mock_res1.as_object.assert_called_once()
+    mock_res2.as_object.assert_called_once()
+
+    assert res == {
+        "group1": [mock_res1.as_object.return_value],
+        "group2": [mock_res2.as_object.return_value],
+    }
+
+
+@patch("openstack_query.query_blocks.results_container.Result")
+def test_store_query_results(mock_results):
+    """
+    Test store_query_results method creates a Result mock object for each item given
+    """
+    mock_prop_enum_cls = NonCallableMock()
+    instance = ResultsContainer(mock_prop_enum_cls)
+    instance.store_query_results(["item1", "item2"])
+    mock_results.side_effect = ["item1_obj", "item2_obj"]
+
+    mock_results.assert_has_calls(
+        [
+            call(mock_prop_enum_cls, "item1", "Not Found"),
+            call(mock_prop_enum_cls, "item2", "Not Found"),
+        ]
+    )
+
+
+def test_apply_forwarded_result_empty():
+    """
+    Test apply_forwarded_results when no results set - raise error
+    """
+    instance = ResultsContainer(NonCallableMock())
+    with pytest.raises(QueryChainingError):
+        instance.apply_forwarded_results(NonCallableMock(), NonCallableMock())
+
+
+@patch(
+    "openstack_query.query_blocks.results_container.ResultsContainer._get_forwarded_result"
+)
+def test_apply_forwarded_result(mock_get_forwarded_result, setup_instance_with_results):
+    """
+    Test apply_forwarded_results once results set
+    """
+    res1 = MagicMock()
+    res2 = MagicMock()
+    mock_link_prop = NonCallableMock()
+    mock_forwarded_results = NonCallableMock()
+
+    instance = setup_instance_with_results([res1, res2])
+    instance.apply_forwarded_results(mock_link_prop, mock_forwarded_results)
+
+    res1.get_prop.assert_called_once_with(mock_link_prop)
+    res2.get_prop.assert_called_once_with(mock_link_prop)
+
+    mock_get_forwarded_result.assert_has_calls(
+        [
+            call(res1.get_prop.return_value, mock_forwarded_results),
+            call(res2.get_prop.return_value, mock_forwarded_results),
+        ]
+    )
+
+    res1.update_forwarded_properties(mock_get_forwarded_result.return_value)
+    res2.update_forwarded_properties(mock_get_forwarded_result.return_value)
+
+
+def test_get_forwarded_results_many_to_one():
+    """
+    Tests get_forwarded_results static method, where forwarded results contains
+    multiple instances in each group.
+    should remove value from forwarded result from the group one at a time as
+    it is encountered, except the last one
+    """
+    forwarded_values = {
+        "grouped_value": ["value1", "value2", "value3"],
+    }
+    # pylint:disable=protected-access
+
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value", forwarded_values)
+        == "value1"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value", forwarded_values)
+        == "value2"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value", forwarded_values)
+        == "value3"
+    )
+    assert len(forwarded_values["grouped_value"]) == 1
+
+
+def test_get_forwarded_result_one_to_many():
+    """
+    Tests get_forwarded_results static method, where forwarded results contains
+    one instance in each group.
+
+    Should not remove forwarded result as there is only one item in each group.
+    Duplicate calls with the same value should return the same result
+    """
+    forwarded_values = {
+        "grouped_value1": ["value1"],
+        "grouped_value2": ["value2"],
+        "grouped_value3": ["value3"],
+    }
+    # pylint:disable=protected-access
+
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value1", forwarded_values)
+        == "value1"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value1", forwarded_values)
+        == "value1"
+    )
+
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value2", forwarded_values)
+        == "value2"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value2", forwarded_values)
+        == "value2"
+    )
+
+    assert all(len(val) == 1 for val in forwarded_values.values())

--- a/tests/lib/openstack_query/test_query_factory.py
+++ b/tests/lib/openstack_query/test_query_factory.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openstack_query.query_factory import QueryFactory
-from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
 @pytest.fixture(name="run_build_query_deps_test_case")
@@ -18,7 +17,6 @@ def run_build_query_deps_test_case_fixture():
     @patch("openstack_query.query_factory.QueryChainer")
     @patch("openstack_query.query_factory.QueryComponents")
     def _run_build_query_deps_test_case(
-        mock_forwarded_outputs,
         mock_query_components,
         mock_chainer,
         mock_executer,
@@ -31,14 +29,7 @@ def run_build_query_deps_test_case_fixture():
         if provided forwarded outputs or not
         """
         mock_mapping_cls = MagicMock()
-        res = QueryFactory.build_query_deps(
-            mock_mapping_cls, forwarded_outputs=mock_forwarded_outputs
-        )
-
-        if mock_forwarded_outputs:
-            mock_output.return_value.update_forwarded_outputs.assert_called_once_with(
-                MockProperties.PROP_1, {"val_1": ["output1", "output2"]}
-            )
+        res = QueryFactory.build_query_deps(mock_mapping_cls)
 
         mock_mapping_cls.get_prop_mapping.assert_called_once()
         mock_prop_mapping = mock_mapping_cls.get_prop_mapping.return_value
@@ -71,19 +62,9 @@ def run_build_query_deps_test_case_fixture():
     return _run_build_query_deps_test_case
 
 
-def test_build_query_deps_no_forwarded_outputs(run_build_query_deps_test_case):
+def test_build_query_deps(run_build_query_deps_test_case):
     """
     Test that function build_query_deps works - with no forwarded outputs
     should build all query blocks and return QueryComponent dataclass using them
     """
-    run_build_query_deps_test_case(None)
-
-
-def test_build_query_deps_with_forwarded_outputs(run_build_query_deps_test_case):
-    """
-    Test that function build_query_deps works - with forwarded outputs
-    should build all query blocks and return QueryComponent dataclass using them
-    """
-    run_build_query_deps_test_case(
-        (MockProperties.PROP_1, {"val_1": ["output1", "output2"]}),
-    )
+    run_build_query_deps_test_case()


### PR DESCRIPTION
#173 - a ready-to-review version of this

improves how query results and forwarded results are handled and stored.  The datastructure holding these parts together were getting too complicated

add Result class - query results are now stored in separate classes - keeping results encapsulated away from query blocks. 

Result class holds openstack item, and forwarded prop to attach
Modify QueryParser run functions to use list of Results instead 

add results container class which will store results and handle adding forwarded results and selecting results instead of QueryOutput. 