### PR TITLE
MAINT: add Results and ResultsQuery classes

### DIFF
--- a/lib/openstack_query/query_blocks/result.py
+++ b/lib/openstack_query/query_blocks/result.py
@@ -1,0 +1,48 @@
+from typing import Dict
+from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
+from enums.query.props.prop_enum import PropEnum
+
+
+class Result:
+    """Class that holds a single result item"""
+
+    def __init__(
+        self, prop_enum_cls, obj_result: OpenstackResourceObj, default_value="Not Found"
+    ):
+        self._prop_enum_cls = prop_enum_cls
+        self._obj_result = obj_result
+        self._forwarded_props = {}
+        self._default_prop_value = default_value
+
+    def as_object(self) -> OpenstackResourceObj:
+        return self._obj_result
+
+    def as_props(self, *props: PropEnum) -> Dict[str, PropValue]:
+        """
+        return stored result, only outputting the properties given
+        :props: A set of prop enums to select
+        """
+        selected_props = {}
+        for prop in props:
+            key = prop.name.lower()
+            selected_props[key] = self.get_prop(prop)
+
+        return {**selected_props, **self._forwarded_props}
+
+    def get_prop(self, prop: PropEnum) -> PropValue:
+        """
+        return value of prop enum for stored result
+        :prop: a prop enum to select
+        """
+        try:
+            return self._prop_enum_cls.get_prop_mapping(prop)(self._obj_result)
+        except AttributeError:
+            return self._default_prop_value
+
+    def update_forwarded_properties(self, forwarded_props: Dict[str, PropValue]):
+        """
+        updates the set of forwarded properties to be associated with query result
+        :param forwarded_props: a dictionary containing property name: property value of
+        props to be associated with this result forwarded from previous queries
+        """
+        self._forwarded_props.update(forwarded_props)

--- a/lib/openstack_query/query_blocks/results_container.py
+++ b/lib/openstack_query/query_blocks/results_container.py
@@ -1,0 +1,126 @@
+from typing import Union, List, Dict, Callable
+from enums.query.props.prop_enum import PropEnum
+from exceptions.query_chaining_error import QueryChainingError
+from openstack_query.query_blocks.result import Result
+from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
+
+
+class ResultsContainer:
+    """
+    Helper class to store query results and forwarded results
+    """
+
+    DEFAULT_OUT = "Not Found"
+
+    def __init__(self, prop_enum_cls):
+        self._prop_enum_cls = prop_enum_cls
+        self._results: List = []
+        self._parsed_results: Union[List, Dict] = []
+
+    def to_props(self, *props: PropEnum) -> Union[Dict, List]:
+        """
+        Output the stored results, only outputting the properties given
+        :props: A set of prop enums to select
+        """
+        results = self._parsed_results or self._results
+        if not results:
+            return []
+
+        if isinstance(results, list):
+            return [item.as_props(*props) for item in results]
+        return {
+            name: [item.as_props(*props) for item in group]
+            for name, group in results.items()
+        }
+
+    def to_objects(self) -> Union[Dict, List]:
+        """
+        Output the results stored - as openstack objects
+        """
+
+        results = self._parsed_results or self._results
+        if not results:
+            return []
+
+        if isinstance(results, list):
+            return [item.as_object() for item in results]
+        return {
+            name: [item.as_object() for item in group]
+            for name, group in results.items()
+        }
+
+    def store_query_results(self, query_results: List[OpenstackResourceObj]):
+        """
+        a setter to set results after running the query with query results
+        :param query_results: A list of openstack objects returned after running query
+        """
+        self._results = [
+            Result(self._prop_enum_cls, item, self.DEFAULT_OUT)
+            for item in query_results
+        ]
+
+    def apply_forwarded_results(
+        self,
+        link_prop: PropEnum,
+        forwarded_results: Dict[PropValue, List[Dict]],
+    ):
+        """
+        public method that when called will add appropriate forwarded result entry onto each result.
+        (expects results to be a list)
+        :param forwarded_results: A set of grouped results forwarded from a previous query to attach to results
+        :param link_prop: An prop enum that the forwarded results are grouped by
+        """
+
+        if not self._results:
+            raise QueryChainingError(
+                "Query Chaining Error: Tried to apply a set of forwarded results when query has not been run yet"
+            )
+
+        for item in self._results:
+            prop_val = item.get_prop(link_prop)
+
+            # NOTE: This mutates forwarded_results
+            forwarded_result = self._get_forwarded_result(prop_val, forwarded_results)
+
+            item.update_forwarded_properties(forwarded_result)
+
+    @staticmethod
+    def _get_forwarded_result(prop_val: str, forwarded_results: Dict[str, List]):
+        """
+        static helper method to return forwarded values that match a given property value. Used for chaining
+        This handles two chaining cases:
+            - many-to-one (or one-to-one as we're using duplicates)
+                - where multiple forwarded outputs maps to one openstack object in result
+                - the result will contain exact number of duplicate openstack objects so each forwarded output is
+                assigned to an appropriate copy
+
+            - one-to-many - where one forwarded output needs to map to multiple openstack objects in results
+
+        :param prop_val: common property value to use to find a set of forwarded values to return
+        :param forwarded_results: a grouped dictionary which holds forwarded values grouped by common property value
+        """
+
+        if not forwarded_results:
+            return {}
+
+        result_to_attach = forwarded_results[prop_val][0]
+
+        # if forwarded_results group contains only one item:
+        #   - we assume we're chaining a one-to-many and keep at least one value
+
+        # if it contains multiple item:
+        #   - we assume many-to-one and delete the value
+
+        # deleting is a nice way of making sure each value is set - otherwise we need to keep track
+        # of the index position of last read item for each group
+        if len(forwarded_results[prop_val]) > 1:
+            del forwarded_results[prop_val][0]
+
+        return result_to_attach
+
+    def parse_results(self, parse_func: Callable[[List[Result]], Union[List]]):
+        """
+        This method applies a pre-set parse function which will sort and/or group the results
+        :param parse_func: parse function
+        """
+        self._parsed_results = parse_func(self._results)

--- a/lib/openstack_query/query_blocks/results_container.py
+++ b/lib/openstack_query/query_blocks/results_container.py
@@ -85,7 +85,9 @@ class ResultsContainer:
             item.update_forwarded_properties(forwarded_result)
 
     @staticmethod
-    def _get_forwarded_result(prop_val: str, forwarded_results: Dict[str, List]):
+    def _get_forwarded_result(
+        prop_val: str, forwarded_results: Dict[str, List]
+    ) -> Dict:
         """
         static helper method to return forwarded values that match a given property value. Used for chaining
         This handles two chaining cases:

--- a/lib/openstack_query/query_blocks/results_container.py
+++ b/lib/openstack_query/query_blocks/results_container.py
@@ -7,7 +7,7 @@ from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
 
 class ResultsContainer:
     """
-    Helper class to store query results and forwarded results
+    Helper class to manage a list of query results as Result objects
     """
 
     DEFAULT_OUT = "Not Found"

--- a/tests/lib/openstack_query/query_blocks/test_result.py
+++ b/tests/lib/openstack_query/query_blocks/test_result.py
@@ -1,0 +1,107 @@
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from openstack_query.query_blocks.result import Result
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(name="mock_get_prop_func")
+def get_prop_func_fixture():
+    """
+    Stubs out get_prop_func method to return a
+    stub callable based on prop enum
+    """
+    mock_prop_1_func = MagicMock()
+    mock_prop_1_func.return_value = "prop 1 out"
+
+    mock_prop_2_func = MagicMock()
+    mock_prop_2_func.side_effect = AttributeError
+
+    def _mock_get_prop_func(prop):
+        return {
+            MockProperties.PROP_1: mock_prop_1_func,
+            MockProperties.PROP_2: mock_prop_2_func,
+        }.get(prop, None)
+
+    return _mock_get_prop_func
+
+
+@pytest.fixture(name="instance")
+def instance_fixture():
+    """
+    Returns an instance with mocked prop_enum_cls inject
+    """
+    return Result(prop_enum_cls=MockProperties, obj_result=MagicMock())
+
+
+def test_as_object():
+    """
+    test property getter as_object
+    """
+    mock_obj = MagicMock()
+    assert Result(MockProperties, mock_obj).as_object() == mock_obj
+
+
+@patch("openstack_query.query_blocks.result.Result.get_prop")
+def test_as_props_no_forwarded_props(mock_get_prop, instance):
+    """
+    test property getter as_props just gets as_props when no forwarded_props given
+    """
+    mock_props = [MockProperties.PROP_1, MockProperties.PROP_2]
+    res = instance.as_props(*mock_props)
+    mock_get_prop.assert_has_calls(
+        [call(MockProperties.PROP_1), call(MockProperties.PROP_2)]
+    )
+
+    assert res == {
+        "prop_1": mock_get_prop.return_value,
+        "prop_2": mock_get_prop.return_value,
+    }
+
+
+@patch("openstack_query.query_blocks.result.Result.get_prop")
+def test_as_props_with_forwarded_props(mock_get_prop, instance):
+    """
+    test property getter as_props gets as_props result and forwarded_props set,
+    concatenates them together
+    """
+    instance.update_forwarded_properties({"fwd_prop1": "val1", "fwd_prop2": "val2"})
+
+    mock_props = [MockProperties.PROP_1, MockProperties.PROP_2]
+    res = instance.as_props(*mock_props)
+    mock_get_prop.assert_has_calls(
+        [call(MockProperties.PROP_1), call(MockProperties.PROP_2)]
+    )
+
+    assert res == {
+        "prop_1": mock_get_prop.return_value,
+        "prop_2": mock_get_prop.return_value,
+        "fwd_prop1": "val1",
+        "fwd_prop2": "val2",
+    }
+
+
+def test_get_prop_found(mock_get_prop_func, instance):
+    """
+    Test get_prop method.
+    Method should call prop_enum_cls.get_prop_mapping on given prop and run returned function on stored obj_result
+    """
+    with patch.object(
+        MockProperties, "get_prop_mapping", wraps=mock_get_prop_func
+    ) as mock_get_prop_mapping:
+        res = instance.get_prop(MockProperties.PROP_1)
+    mock_get_prop_mapping.assert_called_once_with(MockProperties.PROP_1)
+    assert res == "prop 1 out"
+
+
+def test_get_prop_not_found(mock_get_prop_func, instance):
+    """
+    Test get_prop method - when function to get property fails with Attribute error - meaning property does not exist
+    method should return the default value attribute
+    """
+    with patch.object(
+        MockProperties, "get_prop_mapping", wraps=mock_get_prop_func
+    ) as mock_get_prop_mapping:
+        res = instance.get_prop(MockProperties.PROP_2)
+    mock_get_prop_mapping.assert_called_once_with(MockProperties.PROP_2)
+    assert res == "Not Found"

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -299,3 +299,11 @@ def test_get_forwarded_result_one_to_many():
     )
 
     assert all(len(val) == 1 for val in forwarded_values.values())
+
+
+def test_get_forwarded_result_empty():
+    """
+    Tests get_forwarded_results static method, where forwarded results are empty
+    should return an empty dict
+    """
+    assert ResultsContainer._get_forwarded_result("grouped_value1", {}) == {}

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -114,7 +114,8 @@ def test_to_objects_results_empty(setup_instance_with_results):
     Test to_objects method when results are empty - return empty list
     """
     instance = setup_instance_with_results([])
-    instance.to_objects()
+    res = instance.to_objects()
+    assert res == []
 
 
 def test_to_objects_not_parsed(setup_instance_with_results):

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -1,0 +1,300 @@
+from unittest.mock import MagicMock, patch, call, NonCallableMock
+import pytest
+
+from exceptions.query_chaining_error import QueryChainingError
+from openstack_query.query_blocks.results_container import ResultsContainer
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(name="setup_instance_with_results")
+def setup_instance_with_results_fixture():
+    """
+    Returns an instance of ResultContainer with mocked results
+    """
+
+    def _setup_instance_with_results(mock_results):
+        val = ResultsContainer(prop_enum_cls=MockProperties)
+        # pylint:disable=protected-access
+        val._results = mock_results
+        return val
+
+    return _setup_instance_with_results
+
+
+def test_to_props_results_empty(setup_instance_with_results):
+    """
+    Test to_props method when results are empty - return empty list
+    """
+    instance = setup_instance_with_results([])
+    instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+
+def test_to_props_not_parsed(setup_instance_with_results):
+    """
+    Test to_props method when results are not parsed
+    """
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    res = instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+    mock_res1.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    mock_res2.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    assert res == [mock_res1.as_props.return_value, mock_res2.as_props.return_value]
+
+
+def test_to_props_parsed_to_list(setup_instance_with_results):
+    """
+    Test to_props method when results are parsed into a list
+    """
+
+    def mock_parse_func(results):
+        """a parse func that doesn't do anything"""
+        return results
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+    mock_res1.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    mock_res2.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    assert res == [mock_res1.as_props.return_value, mock_res2.as_props.return_value]
+
+
+def test_to_props_parsed_and_grouped(setup_instance_with_results):
+    """
+    Test to_props method when results are parsed into a dict (grouped)
+    """
+
+    def mock_parse_func(results):
+        """a parse func that returns a dictionary"""
+        return {"group1": [results[0]], "group2": [results[1]]}
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_props(MockProperties.PROP_1, MockProperties.PROP_2)
+
+    mock_res1.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    mock_res2.as_props.assert_called_once_with(
+        MockProperties.PROP_1, MockProperties.PROP_2
+    )
+
+    assert res == {
+        "group1": [mock_res1.as_props.return_value],
+        "group2": [mock_res2.as_props.return_value],
+    }
+
+
+def test_to_objects_results_empty(setup_instance_with_results):
+    """
+    Test to_objects method when results are empty - return empty list
+    """
+    instance = setup_instance_with_results([])
+    instance.to_objects()
+
+
+def test_to_objects_not_parsed(setup_instance_with_results):
+    """
+    Test to_objects method when results are not parsed
+    """
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    res = instance.to_objects()
+
+    mock_res1.as_object.assert_called_once()
+
+    mock_res2.as_object.assert_called_once()
+
+    assert res == [mock_res1.as_object.return_value, mock_res2.as_object.return_value]
+
+
+def test_to_object_parsed_to_list(setup_instance_with_results):
+    """
+    Test to_object method when results are parsed into a list
+    """
+
+    def mock_parse_func(results):
+        """a parse func that doesn't do anything"""
+        return results
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_objects()
+    mock_res1.as_object.assert_called_once()
+    mock_res2.as_object.assert_called_once()
+
+    assert res == [mock_res1.as_object.return_value, mock_res2.as_object.return_value]
+
+
+def test_to_object_parsed_and_grouped(setup_instance_with_results):
+    """
+    Test to_object method when results are parsed into a dict (grouped)
+    """
+
+    def mock_parse_func(results):
+        """a parse func that returns a dictionary"""
+        return {"group1": [results[0]], "group2": [results[1]]}
+
+    mock_res1 = MagicMock()
+    mock_res2 = MagicMock()
+
+    instance = setup_instance_with_results([mock_res1, mock_res2])
+    instance.parse_results(mock_parse_func)
+
+    res = instance.to_objects()
+    mock_res1.as_object.assert_called_once()
+    mock_res2.as_object.assert_called_once()
+
+    assert res == {
+        "group1": [mock_res1.as_object.return_value],
+        "group2": [mock_res2.as_object.return_value],
+    }
+
+
+@patch("openstack_query.query_blocks.results_container.Result")
+def test_store_query_results(mock_results):
+    """
+    Test store_query_results method creates a Result mock object for each item given
+    """
+    mock_prop_enum_cls = NonCallableMock()
+    instance = ResultsContainer(mock_prop_enum_cls)
+    instance.store_query_results(["item1", "item2"])
+    mock_results.side_effect = ["item1_obj", "item2_obj"]
+
+    mock_results.assert_has_calls(
+        [
+            call(mock_prop_enum_cls, "item1", "Not Found"),
+            call(mock_prop_enum_cls, "item2", "Not Found"),
+        ]
+    )
+
+
+def test_apply_forwarded_result_empty():
+    """
+    Test apply_forwarded_results when no results set - raise error
+    """
+    instance = ResultsContainer(NonCallableMock())
+    with pytest.raises(QueryChainingError):
+        instance.apply_forwarded_results(NonCallableMock(), NonCallableMock())
+
+
+@patch(
+    "openstack_query.query_blocks.results_container.ResultsContainer._get_forwarded_result"
+)
+def test_apply_forwarded_result(mock_get_forwarded_result, setup_instance_with_results):
+    """
+    Test apply_forwarded_results once results set
+    """
+    res1 = MagicMock()
+    res2 = MagicMock()
+    mock_link_prop = NonCallableMock()
+    mock_forwarded_results = NonCallableMock()
+
+    instance = setup_instance_with_results([res1, res2])
+    instance.apply_forwarded_results(mock_link_prop, mock_forwarded_results)
+
+    res1.get_prop.assert_called_once_with(mock_link_prop)
+    res2.get_prop.assert_called_once_with(mock_link_prop)
+
+    mock_get_forwarded_result.assert_has_calls(
+        [
+            call(res1.get_prop.return_value, mock_forwarded_results),
+            call(res2.get_prop.return_value, mock_forwarded_results),
+        ]
+    )
+
+    res1.update_forwarded_properties(mock_get_forwarded_result.return_value)
+    res2.update_forwarded_properties(mock_get_forwarded_result.return_value)
+
+
+def test_get_forwarded_results_many_to_one():
+    """
+    Tests get_forwarded_results static method, where forwarded results contains
+    multiple instances in each group.
+    should remove value from forwarded result from the group one at a time as
+    it is encountered, except the last one
+    """
+    forwarded_values = {
+        "grouped_value": ["value1", "value2", "value3"],
+    }
+    # pylint:disable=protected-access
+
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value", forwarded_values)
+        == "value1"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value", forwarded_values)
+        == "value2"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value", forwarded_values)
+        == "value3"
+    )
+    assert len(forwarded_values["grouped_value"]) == 1
+
+
+def test_get_forwarded_result_one_to_many():
+    """
+    Tests get_forwarded_results static method, where forwarded results contains
+    one instance in each group.
+
+    Should not remove forwarded result as there is only one item in each group.
+    Duplicate calls with the same value should return the same result
+    """
+    forwarded_values = {
+        "grouped_value1": ["value1"],
+        "grouped_value2": ["value2"],
+        "grouped_value3": ["value3"],
+    }
+    # pylint:disable=protected-access
+
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value1", forwarded_values)
+        == "value1"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value1", forwarded_values)
+        == "value1"
+    )
+
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value2", forwarded_values)
+        == "value2"
+    )
+    assert (
+        ResultsContainer._get_forwarded_result("grouped_value2", forwarded_values)
+        == "value2"
+    )
+
+    assert all(len(val) == 1 for val in forwarded_values.values())

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -306,4 +306,5 @@ def test_get_forwarded_result_empty():
     Tests get_forwarded_results static method, where forwarded results are empty
     should return an empty dict
     """
+    # pylint:disable=protected-access
     assert ResultsContainer._get_forwarded_result("grouped_value1", {}) == {}


### PR DESCRIPTION
This PR does adds the following - part of a larger PR - see #173 for the full picture 

**`Result` class** 
which is used to store a single query result item. 
It stores the openstack item as well as any forwarded properties.
This class is responsible for outputting the value stored as_object or as_props. 
When as_props() is selected, it will concatenate any forwarded properties stored automatically 

**`ResultContainer` class** 
which is responsible for storing multiple Result objects and returning the total output to_objects/to_props. 
It is responsible for creating and managing each Result item once a query is run
Currently neither class is being used - Query Executer will make use of  this in future - this PR is being split up so it can be reviewed quicker