### PR TITLE
ENH: add email users with decom flavors stackstorm action

### DIFF
--- a/actions/email.users.with.decom.flavors.yaml
+++ b/actions/email.users.with.decom.flavors.yaml
@@ -21,7 +21,7 @@ parameters:
     default: "STFC Cloud Flavor Decommissioning Notice"
   smtp_account_name:
     type: string
-    description: "Name of SMTP Account to use. Must be configured in in the pack settings."
+    description: "Name of SMTP Account to use. Must be configured in the pack settings."
     required: true
     default: "default"
   cloud_account:

--- a/actions/email.users.with.decom.flavors.yaml
+++ b/actions/email.users.with.decom.flavors.yaml
@@ -1,0 +1,76 @@
+---
+description: Sends a test email
+enabled: true
+entry_point: src/workflow_actions.py
+name: email.users.with.decom.flavors
+parameters:
+  timeout:
+    default: 5400
+  submodule_name:
+    default: email
+    immutable: true
+    type: string
+  action_name:
+    default: send_decom_flavor_email
+    immutable: true
+    type: string
+  subject:
+    type: string
+    description: "Subject to add to each email"
+    required: true
+    default: "STFC Cloud Flavor Decommissioning Notice"
+  smtp_account_name:
+    type: string
+    description: "Name of SMTP Account to use. Must be configured in in the pack settings."
+    required: true
+    default: "default"
+  cloud_account:
+    description: "The clouds.yaml account to use whilst performing this action"
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  flavor_name_list:
+    type: array
+    description: "comma-spaced list of flavor names to decommission"
+    required: false
+    default: null
+  limit_by_projects:
+    type: array
+    description: "comma-spaced project to limit action to - incompatible with all_projects"
+    required: false
+    default: null
+  all_projects:
+    type: boolean
+    description: "tick to search in all projects - default True"
+    required: true
+    default: true
+  as_html:
+    type: boolean
+    description: "Send email body as HTML"
+    required: true
+    default: true
+  send_email:
+    type: boolean
+    description: "Set this flag to actually send emails instead of printing what will be sent"
+    required: true
+    default: false
+  override_email_address:
+    type: string
+    description: "Set an email address to override where to send the emails generated"
+    required: true
+    default: false
+  cc_cloud_support:
+    type: boolean
+    description: "Flag if set, will cc in cloud-support@stfc.ac.uk automatically"
+    required: false
+    default: false
+  email_from:
+    type: string
+    description: "Email address to send email from"
+    required: true
+    default: "cloud-support@stfc.ac.uk"
+    immutable: true
+runner_type: python-script

--- a/actions/src/workflow_actions.py
+++ b/actions/src/workflow_actions.py
@@ -7,9 +7,9 @@ class WorkflowActions(Action):
     def run(self, submodule_name: str, action_name: str, **kwargs):
         """
         Dynamically dispatches to the function wanted
-            :param submodule_name: submodule name which corresponds to module in workflow
-            :param action_name: name of file/function which corresponds to function that will handle the action
-            :param kwargs: all user-defined kwargs to pass to the function
+        :param submodule_name: submodule name which corresponds to module in workflow
+        :param action_name: name of file/function which corresponds to function that will handle the action
+        :param kwargs: all user-defined kwargs to pass to the function
         """
         workflow = __import__(f"workflows.{submodule_name}.{action_name}")
         submodule = getattr(workflow, f"{submodule_name}")

--- a/actions/src/workflow_actions.py
+++ b/actions/src/workflow_actions.py
@@ -1,0 +1,39 @@
+from st2common.runners.base_action import Action
+
+from structs.email.smtp_account import SMTPAccount
+
+
+class WorkflowActions(Action):
+    def run(self, submodule_name: str, action_name: str, **kwargs):
+        """
+        Dynamically dispatches to the function wanted
+            :param submodule_name: submodule name which corresponds to module in workflow
+            :param action_name: name of file/function which corresponds to function that will handle the action
+            :param kwargs: all user-defined kwargs to pass to the function
+        """
+        workflow = __import__(f"workflows.{submodule_name}.{action_name}")
+        submodule = getattr(workflow, f"{submodule_name}")
+        action_module = getattr(submodule, action_name)
+        action_func = getattr(action_module, action_name)
+
+        self.logger.info(
+            "Workflow Action Received - %s/%s", submodule_name, action_name
+        )
+        self.logger.debug(
+            "with Parameters: %s",
+            "\n".join([f"{key}: {val}" for key, val in kwargs.items()]),
+        )
+
+        kwargs = self.parse_configs(**kwargs)
+        return action_func(**kwargs)
+
+    def parse_configs(self, **kwargs):
+        """
+        parse user-defined kwargs and get back stackstorm config info
+        """
+        if "smtp_account_name" in kwargs:
+            kwargs["smtp_account"] = SMTPAccount.from_pack_config(
+                self.config, kwargs["smtp_account_name"]
+            )
+            del kwargs["smtp_account_name"]
+        return kwargs

--- a/tests/actions/test_workflow_actions.py
+++ b/tests/actions/test_workflow_actions.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch, NonCallableMock
+import pytest
+
+from src.workflow_actions import WorkflowActions
+from tests.actions.openstack_action_test_base import OpenstackActionTestBase
+
+
+@pytest.mark.parametrize(
+    "submodule_name, action_name", [("email", "send_decom_flavor_email")]
+)
+def test_submodules_exist(submodule_name, action_name):
+    """
+    Test that each submodule and action entry-points exist for each workflow action
+    """
+    workflow_module = __import__(f"workflows.{submodule_name}.{action_name}")
+    assert hasattr(workflow_module, f"{submodule_name}")
+    submodule = getattr(workflow_module, f"{submodule_name}")
+
+    assert hasattr(submodule, action_name)
+    action_module = getattr(submodule, action_name)
+
+    assert hasattr(action_module, action_name)
+
+
+class TestWorkflowActions(OpenstackActionTestBase):
+    """
+    Unit tests for actions that use workflow modules
+    """
+
+    action_cls = WorkflowActions
+    # pylint: disable=invalid-name
+
+    def setUp(self):
+        """setup for tests"""
+        super().setUp()
+        self.action: WorkflowActions = self.get_action_instance()
+        self.mock_kwargs = {
+            "kwarg1": NonCallableMock(),
+            "kwarg2": NonCallableMock(),
+        }
+
+    @patch("builtins.__import__")
+    def test_run(self, mock_import):
+        """
+        Tests that run method can dispatch to workflow methods
+        """
+
+        mock_submodule_name = "submodule"
+        mock_action_module_name = "action"
+
+        with patch.object(self.action, "parse_configs") as mock_parse_configs:
+            self.action.run(
+                submodule_name=mock_submodule_name,
+                action_name=mock_action_module_name,
+                **self.mock_kwargs,
+            )
+
+        mock_parse_configs.assert_called_once_with(**self.mock_kwargs)
+        mock_import.return_value.submodule.action.action.assert_called_once_with(
+            **mock_parse_configs.return_value
+        )
+
+    @patch("src.workflow_actions.SMTPAccount")
+    def parse_configs_with_smtp_account(self, mock_smtp_account):
+        """
+        tests that parse_configs parses smtp_account_name properly if provided
+        """
+        mock_smtp_account_name = NonCallableMock()
+        res = self.action.parse_configs({"smtp_account_name": mock_smtp_account_name})
+        mock_smtp_account.from_pack_config.assert_called_once_with(
+            self.config, mock_smtp_account_name
+        )
+        assert res == {"smtp_account": mock_smtp_account.from_pack_config.return_value}
+
+    def parse_configs_with_no_accounts(self):
+        """
+        tests that parse_configs doesn't do anything if no stackstorm config names given
+        """
+        mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+        res = self.action.parse_configs(mock_kwargs)
+        assert res == mock_kwargs


### PR DESCRIPTION
adds workflow_actions.py in actions layer and tests for it - which will become our default actions layer runner

added stackstorm action which uses workflow_actions and can be used to interact with workflow/email/send_decom_flavor_email.py