### PR TITLE
MAINT: Use Results and ResultsContainer Classes

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from typing import Union, List, Optional, Dict, Tuple
 
 from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
@@ -24,7 +25,7 @@ class QueryAPI:
         self.parser = query_components.parser
         self.output = query_components.output
         self.chainer = query_components.chainer
-        self._query_run = False
+        self.results_container = None
 
     def select(self, *props: PropEnum):
         """
@@ -147,7 +148,15 @@ class QueryAPI:
             from_subset=from_subset,
             **kwargs,
         )
-        self._query_run = True
+
+        link_prop, forwarded_vals = self.chainer.forwarded_info
+        if forwarded_vals:
+            self.executer.apply_forwarded_results(
+                link_prop,
+                deepcopy(forwarded_vals),
+            )
+
+        self.results_container = self.executer.results_container
         return self
 
     def to_objects(
@@ -158,26 +167,14 @@ class QueryAPI:
         This is either returned as a list if no groups are specified, or as a dict if they grouping was requested
         :param groups: a list of group keys to limit output by
         """
-        if self.output.forwarded_outputs:
+        if self.executer.has_forwarded_results:
             logger.warning(
                 "This Query has properties from previous queries. Running to_objects WILL IGNORE THIS "
                 "Use to_props() instead if you want to include these properties"
             )
 
-        results, _ = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-        if groups:
-            if not isinstance(results, dict):
-                raise ParseQueryError(
-                    f"Result is not grouped - cannot filter by given group(s) {groups}"
-                )
-            if not all(group in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"Group(s) given are invalid - valid groups {list(results.keys())}"
-                )
-            return {group_key: results[group_key] for group_key in groups}
-        return results
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_objects(self.results_container, groups)
 
     def to_props(
         self, flatten: bool = False, groups: Optional[List[str]] = None
@@ -188,23 +185,8 @@ class QueryAPI:
         :param flatten: boolean which will flatten results if true
         :param groups: a list of group keys to limit output by
         """
-        _, results = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-        if groups:
-            if not isinstance(results, dict):
-                raise ParseQueryError(
-                    f"Result is not grouped - cannot filter by given group(s) {groups}"
-                )
-            if not all(group in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"Group(s) given are invalid - valid groups {list(results.keys())}"
-                )
-            return {group_key: results[group_key] for group_key in groups}
-
-        if flatten:
-            return self.output.flatten(results)
-        return results
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_props(self.results_container, flatten, groups)
 
     def to_string(
         self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
@@ -215,11 +197,8 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        _, selected_results = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-
-        return self.output.to_string(selected_results, title, groups, **kwargs)
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_string(self.results_container, title, groups, **kwargs)
 
     def to_html(
         self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
@@ -230,10 +209,8 @@ class QueryAPI:
         :param groups: a list group to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        _, selected_results = self.executer.parse_results(
-            parse_func=self.parser.run_parser, output_func=self.output.generate_output
-        )
-        return self.output.to_html(selected_results, title, groups, **kwargs)
+        self.results_container.parse_results(self.parser.run_parser)
+        return self.output.to_html(self.results_container, title, groups, **kwargs)
 
     def then(
         self, query_type: Union[str, QueryTypes], keep_previous_results: bool = True
@@ -273,15 +250,8 @@ class QueryAPI:
         :param cloud_account: A String or a CloudDomains Enum for the clouds configuration to use
         :param props: list of props from new queries to get
         """
-        if isinstance(query_type, str):
-            query_type = QueryTypes.from_string(query_type)
-
-        new_query = self.then(query_type, keep_previous_results=False)
-        new_query.select(*props)
-        new_query.run(cloud_account)
-
-        link_props = self.chainer.get_link_props(query_type)
-        new_query.group_by(link_props[1])
-
-        self.output.update_forwarded_outputs(link_props[0], new_query.to_props())
+        link_prop, results = self.chainer.run_append_from_query(
+            self, query_type, cloud_account, *props
+        )
+        self.results_container.apply_forwarded_results(link_prop, results)
         return self

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -1,14 +1,9 @@
-from copy import deepcopy
 from typing import List, Dict, Union, Type, Set, Optional
 from tabulate import tabulate
 from enums.query.props.prop_enum import PropEnum
-from custom_types.openstack_query.aliases import (
-    OpenstackResourceObj,
-    PropValue,
-    GroupedReturn,
-)
-from exceptions.query_chaining_error import QueryChainingError
+from custom_types.openstack_query.aliases import PropValue
 from exceptions.parse_query_error import ParseQueryError
+from openstack_query.query_blocks.results_container import ResultsContainer
 
 
 class QueryOutput:
@@ -25,22 +20,6 @@ class QueryOutput:
     def __init__(self, prop_enum_cls: Type[PropEnum]):
         self._prop_enum_cls = prop_enum_cls
         self._props = set()
-        self._forwarded_outputs: Dict[PropEnum, GroupedReturn] = {}
-
-    def update_forwarded_outputs(self, link_prop: PropEnum, values: Dict[str, List]):
-        """
-        method to set outputs to forward from other queries
-        :param link_prop: the property that the results are grouped by
-        :param values: grouped properties to forward
-        """
-        self._forwarded_outputs[link_prop] = values
-
-    @property
-    def forwarded_outputs(self) -> Dict[PropEnum, GroupedReturn]:
-        """
-        A getter for forwarded properties
-        """
-        return self._forwarded_outputs
 
     @property
     def selected_props(self) -> List[PropEnum]:
@@ -59,43 +38,80 @@ class QueryOutput:
         """
         self._props = props
 
+    @staticmethod
+    def _validate_groups(
+        results: Union[List, Dict], groups: Optional[List[str]] = None
+    ):
+        if not groups:
+            return results
+
+        if not isinstance(results, dict):
+            raise ParseQueryError(
+                f"Result is not grouped - cannot filter by given group(s) {groups}"
+            )
+        if not all(group in results.keys() for group in groups):
+            raise ParseQueryError(
+                f"Group(s) given are invalid - valid groups {list(results.keys())}"
+            )
+        return {group_key: results[group_key] for group_key in groups}
+
+    def to_objects(
+        self, results_container: ResultsContainer, groups: Optional[List[str]] = None
+    ) -> Union[Dict[str, List], List]:
+        """
+        return results as openstack objects
+        :param results_container: container object which stores results
+        :param groups: a list of group keys to limit output by
+
+        """
+        results = results_container.to_objects()
+        return self._validate_groups(results, groups)
+
+    def to_props(
+        self,
+        results_container: ResultsContainer,
+        flatten: bool = False,
+        groups: Optional[List[str]] = None,
+    ) -> Union[Dict[str, List], List]:
+        """
+        return results as selected props
+        :param results_container: container object which stores results
+        :param flatten: boolean which will flatten results if true
+        :param groups: a list of group keys to limit output by
+        """
+        results = results_container.to_props(*self.selected_props)
+        results = self._validate_groups(results, groups)
+        if flatten:
+            results = self.flatten(results)
+        return results
+
     def to_string(
         self,
-        results: Union[List, Dict],
+        results_container: ResultsContainer,
         title: str = None,
         groups: Optional[List[str]] = None,
         **kwargs,
     ):
         """
-        method to return results as a table
-        :param results: a list of parsed query results - either a list or a dict of grouped results
-        :param title: a title for the table(s) when it gets outputted
-        :param groups: a list group to limit output by
+        return results as a table of selected properties
+        :param results_container: container object which stores results
+        :param title: an optional title for the table when it gets outputted
+        :param groups: a list of groups to limit output by
         :param kwargs: kwargs to pass to _generate_table method
         """
-        output = ""
-        if title:
-            output += f"{title}:\n"
+        results = results_container.to_props(*self.selected_props)
+        results = self._validate_groups(results, groups)
+
+        output = "" if not title else f"{title}:\n"
 
         if isinstance(results, dict):
-            if groups and any(group not in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"given group(s) {groups} not found - available groups {list(results.keys())}"
-                )
-
-            if not groups:
-                groups = list(results.keys())
-
-            for group_title in groups:
-                group_list = results[group_title]
+            for group_title in list(results.keys()):
                 output += self._generate_table(
-                    group_list, return_html=False, title=f"{group_title}:\n", **kwargs
+                    results[group_title],
+                    return_html=False,
+                    title=f"{group_title}:\n",
+                    **kwargs,
                 )
-        elif groups:
-            raise ParseQueryError(
-                f"Result is not grouped - cannot filter by given group(s) {groups}"
-            )
-
         else:
             output += self._generate_table(
                 results, return_html=False, title=None, **kwargs
@@ -104,44 +120,30 @@ class QueryOutput:
 
     def to_html(
         self,
-        results: Union[List, Dict],
+        results_container: ResultsContainer,
         title: str = None,
         groups: Optional[List[str]] = None,
         **kwargs,
     ) -> str:
         """
         method to return results as html table
-        :param results: a list of parsed query results - either a list or a dict of grouped results
+        :param results_container: container object which stores results
         :param title: a title for the table(s) when it gets outputted
-        :param groups: a list group to limit output by
+        :param groups: a list of groups to limit output by
         :param kwargs: kwargs to pass to generate table
         """
-        output = ""
-        if title:
-            output += f"<b> {title} </b><br/> "
+        results = results_container.to_props(*self.selected_props)
+        results = self._validate_groups(results, groups)
+        output = "" if not title else f"<b> {title}: </b><br/> "
 
         if isinstance(results, dict):
-            if groups and any(group not in results.keys() for group in groups):
-                raise ParseQueryError(
-                    f"given group(s) {groups} not found - available groups {list(results.keys())}"
-                )
-
-            if not groups:
-                groups = list(results.keys())
-
-            for group_title in groups:
-                group_list = results[group_title]
+            for group_title in list(results.keys()):
                 output += self._generate_table(
-                    group_list,
+                    results[group_title],
                     return_html=True,
                     title=f"<b> {group_title}: </b><br/> ",
                     **kwargs,
                 )
-        elif groups:
-            raise ParseQueryError(
-                f"Result is not grouped - cannot filter by given group(s) {groups}"
-            )
-
         else:
             output += self._generate_table(
                 results, return_html=True, title=None, **kwargs
@@ -169,102 +171,18 @@ class QueryOutput:
 
         self.selected_props = set(all_props)
 
-    def generate_output(
-        self, openstack_resources: List[OpenstackResourceObj]
-    ) -> List[Dict[str, PropValue]]:
-        """
-        Generates a dictionary of queried properties from a list of openstack objects e.g. servers
-        e.g. {['server_name': 'server1', 'server_id': 'server1_id'],
-              ['server_name': 'server2', 'server_id': 'server2_id']} etc.
-        (if we selected 'server_name' and 'server_id' as properties
-        :param openstack_resources: List of openstack objects to obtain properties from - e.g. [Server1, Server2]
-        :return: List containing dictionaries of the requested properties obtained from the items
-        """
-        output = []
-        forwarded_outputs = deepcopy(self.forwarded_outputs)
-        for item in openstack_resources:
-            prop_list = self._parse_properties(item)
-            prop_list.update(self._parse_forwarded_outputs(item, forwarded_outputs))
-            output.append(prop_list)
-        return output
-
-    def _parse_forwarded_outputs(
-        self, openstack_resource: OpenstackResourceObj, forwarded_outputs: Dict
-    ) -> Dict[str, str]:
-        """
-        Generates a dictionary of forwarded outputs for the item given
-        :param openstack_resource: openstack resource item to parse forwarded outputs for
-        """
-        forwarded_output_dict = {}
-        for grouped_property, outputs in forwarded_outputs.items():
-            prop_val = self._parse_property(grouped_property, openstack_resource)
-
-            # this "should not" error because forwarded outputs should always be a super-set
-            # but sometimes resolving the property fails for whatever reason - fail noisily
-            try:
-                output_list = outputs[prop_val]
-                # we update with first result in grouped list and delete it
-
-                # forwarded properties might contain more than one value
-                # then() will keep duplicates so each one in the list will be shunted into an output
-                forwarded_output_dict.update(output_list[0])
-
-                # a hacky way to prevent one-to-many chaining erroring - keep at least one value
-                # one-to-many/one-to-one will only ever contain one value per grouped_value
-                # many-to-one will contain multiple values per grouped values
-                if len(output_list) > 1:
-                    del output_list[0]
-            except KeyError as exp:
-                raise QueryChainingError(
-                    "Error: Chaining failed. Could not attach forwarded outputs.\n"
-                    f"Property {grouped_property} extracted from has value {prop_val} which"
-                    "does not match any values from forwarded outputs. "
-                    "This is due to a mismatch in property mappings - likely an Openstack issue"
-                ) from exp
-        return forwarded_output_dict
-
-    def _parse_properties(
-        self, openstack_resource: OpenstackResourceObj
-    ) -> Dict[str, PropValue]:
-        """
-        Generates a dictionary of queried properties from a single openstack object
-        :param openstack_resource: openstack resource item to obtain properties from
-        """
-        obj_dict = {}
-        for prop in self.selected_props:
-            val = self._parse_property(prop, openstack_resource)
-            obj_dict[prop.name.lower()] = val
-        return obj_dict
-
-    def _parse_property(
-        self, prop: PropEnum, openstack_resource: OpenstackResourceObj
-    ) -> PropValue:
-        """
-        Parse single property from an openstack_object and return result
-        :param prop: property to parse
-        :param openstack_resource: openstack resource item to obtain property from
-        """
-        prop_func = self._prop_enum_cls.get_prop_mapping(prop)
-        try:
-            val = str(prop_func(openstack_resource))
-        except AttributeError:
-            val = self.DEFAULT_OUT
-        return val
-
     @staticmethod
     def _generate_table(
         results: List[Dict[str, PropValue]], return_html: bool, title=None, **kwargs
     ) -> str:
         """
-        Returns a table from the result of 'self._parse_properties'
+        Returns a table from the result of 'self.parse_properties'
         :param results: dict of query results
         :param return_html: True if output required in html table format else output plain text table
         :param kwargs: kwargs to pass to tabulate
         :return: String (html or plaintext table of results)
         """
-        output = ""
-        if title:
-            output += f"{title}\n"
+        output = "" if not title else f"{title}"
 
         if results:
             headers = list(results[0].keys())

--- a/lib/openstack_query/query_factory.py
+++ b/lib/openstack_query/query_factory.py
@@ -1,7 +1,5 @@
-from typing import Tuple, Type, Optional
+from typing import Type
 
-from enums.query.props.prop_enum import PropEnum
-from custom_types.openstack_query.aliases import GroupedReturn
 from openstack_query.mappings.mapping_interface import MappingInterface
 from openstack_query.query_blocks.query_builder import QueryBuilder
 from openstack_query.query_blocks.query_chainer import QueryChainer
@@ -21,21 +19,15 @@ class QueryFactory:
     """
 
     @staticmethod
-    def build_query_deps(
-        mapping_cls: Type[MappingInterface],
-        forwarded_outputs: Optional[Tuple[PropEnum, GroupedReturn]] = None,
-    ) -> QueryComponents:
+    def build_query_deps(mapping_cls: Type[MappingInterface]) -> QueryComponents:
         """
         Composes objects that make up the query - to allow dependency injection
         :param mapping_cls: A mapping class which is used to configure query objects
-        :param forwarded_outputs: A tuple containing grouped outputs to forward from another query
         and the enum they are grouped by
         """
         prop_mapping = mapping_cls.get_prop_mapping()
 
         output = QueryOutput(prop_mapping)
-        if forwarded_outputs:
-            output.update_forwarded_outputs(forwarded_outputs[0], forwarded_outputs[1])
         parser = QueryParser(prop_mapping)
         builder = QueryBuilder(
             prop_enum_cls=prop_mapping,

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -15,46 +15,10 @@ def instance_fixture():
     """
     Returns an instance to run tests with
     """
-    return QueryAPI(query_components=MagicMock())
-
-
-@pytest.fixture(name="run_with_test_case_with_subset")
-def run_with_test_case_with_subset_fixture(instance):
-    """
-    Fixture for running run() with a subset
-    """
-
-    def _run_with_test_case(mock_kwargs):
-        """
-        Runs a test case for the run() method
-        """
-        mock_query_results = ("object-list", "property-list")
-        instance.executer.run_query.return_value = mock_query_results
-        instance.builder.client_side_filters = ["client-filters"]
-        instance.builder.server_filter_fallback = ["fallback-client-filters"]
-        instance.builder.server_side_filters = ["server-filters"]
-
-        if not mock_kwargs:
-            mock_kwargs = {}
-
-        res = instance.run("test-account", ["item1", "item2"], **mock_kwargs)
-        instance.executer.run_query.assert_called_once_with(
-            cloud_account="test-account", from_subset=["item1", "item2"], **mock_kwargs
-        )
-
-        # test that data is marshalled correctly to executer
-        # - this differs based on if from_subset is given
-        client_filters = (
-            instance.builder.client_side_filters
-            + instance.builder.server_filter_fallback
-        )
-        server_filters = None
-
-        assert instance.executer.client_side_filters == client_filters
-        assert instance.executer.server_side_filters == server_filters
-        assert res == instance
-
-    return _run_with_test_case
+    res = QueryAPI(query_components=MagicMock())
+    # pylint: disable=protected-access
+    res.results_container = MagicMock()
+    return res
 
 
 @pytest.fixture(name="run_with_test_case")
@@ -63,12 +27,20 @@ def run_with_test_case_fixture(instance):
     Fixture for running run() with various test arguments
     """
 
-    def _run_with_test_case(data_subset, mock_kwargs):
+    @patch("openstack_query.api.query_api.deepcopy")
+    def _run_with_test_case(
+        mock_deepcopy,
+        mock_forwarded_info=(None, None),
+        data_subset=None,
+        mock_kwargs=None,
+    ):
         """
         Runs a test case for the run() method
         """
         mock_query_results = ("object-list", "property-list")
         instance.executer.run_query.return_value = mock_query_results
+        instance.chainer.forwarded_info = mock_forwarded_info
+
         instance.builder.client_side_filters = ["client-filters"]
         instance.builder.server_filter_fallback = ["fallback-client-filters"]
         instance.builder.server_side_filters = ["server-filters"]
@@ -81,10 +53,20 @@ def run_with_test_case_fixture(instance):
             cloud_account="test-account", from_subset=data_subset, **mock_kwargs
         )
 
-        # test that data is marshalled correctly to executer
-        # - this differs based on if from_subset is given
-        client_filters = instance.builder.client_side_filters
-        server_filters = instance.builder.server_side_filters
+        if data_subset:
+            client_filters = (
+                instance.builder.client_side_filters
+                + instance.builder.server_filter_fallback
+            )
+            server_filters = None
+        else:
+            client_filters = instance.builder.client_side_filters
+            server_filters = instance.builder.server_side_filters
+
+        # test if forwarded vals provided
+        if mock_forwarded_info[1]:
+            instance.executer.apply_forwarded_results.assert_called_once()
+            mock_deepcopy.assert_called_once_with(mock_forwarded_info[1])
 
         assert instance.executer.client_side_filters == client_filters
         assert instance.executer.server_side_filters == server_filters
@@ -177,13 +159,13 @@ def test_where_with_kwargs(instance):
     assert res == instance
 
 
-def test_run_with_optional_params(run_with_test_case_with_subset):
+def test_run_with_optional_params(run_with_test_case):
     """
     Tests that run method works expectedly - with subset meta_params kwargs
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case_with_subset(mock_kwargs=None)
+    run_with_test_case(data_subset=NonCallableMock(), mock_kwargs=None)
 
 
 def test_run_with_kwargs(run_with_test_case):
@@ -201,17 +183,29 @@ def test_run_with_nothing(run_with_test_case):
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case(None, None)
+    run_with_test_case(data_subset=None, mock_kwargs=None)
 
 
-def test_run_with_kwargs_and_subset(run_with_test_case_with_subset):
+def test_run_with_kwargs_and_subset(run_with_test_case):
     """
     Tests that run method works expectedly - with subset kwargs
     method should get client_side and server_side filters and forward them to query runner object
 
     """
-    run_with_test_case_with_subset(
+    run_with_test_case(
+        data_subset=NonCallableMock(),
         mock_kwargs={"arg1": "val1", "arg2": "val2"},
+    )
+
+
+def test_run_with_forwarded_vals(run_with_test_case):
+    """
+    Tests that run method works - with forwarded vals
+    method run query as normal, then run executer.apply_forwarded_results
+    """
+    run_with_test_case(
+        data_subset=NonCallableMock(),
+        mock_forwarded_info=(NonCallableMock(), NonCallableMock()),
     )
 
 
@@ -220,8 +214,17 @@ def test_to_props(instance):
     Tests that to_props method functions expectedly - with no extra params
     method should just return _query_results attribute when groups is None and flatten is false
     """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_props() == "parsed-list"
+    mock_groups = NonCallableMock()
+    mock_flatten = NonCallableMock()
+
+    res = instance.to_props(mock_flatten, mock_groups)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_props.assert_called_once_with(
+        instance.results_container, mock_flatten, mock_groups
+    )
+    assert res == instance.output.to_props.return_value
 
 
 def test_to_objects(instance):
@@ -229,113 +232,39 @@ def test_to_objects(instance):
     Tests that to_objects method functions expectedly - with no extra params
     method should just return _query_results_as_objects attribute when groups is None
     """
-    # pylint: disable=protected-access
-    instance.output.forwarded_outputs = {}
-    instance.executer.parse_results.return_value = "object-list", ""
-    assert instance.to_objects() == "object-list"
+    mock_flatten = NonCallableMock()
+
+    instance.executer.has_forwarded_results = False
+
+    res = instance.to_objects(mock_flatten)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_objects.assert_called_once_with(
+        instance.results_container,
+        mock_flatten,
+    )
+    assert res == instance.output.to_objects.return_value
 
 
-def test_to_objects_forwarded_outputs_warning(instance):
+def test_to_objects_with_forwarded_results(instance):
     """
-    Tests that to_objects method functions expectedly
-    prints warning when forwarded_outputs is not empty
+    Tests that to_objects method - but where forwarded_results are given
+    method should output a warning but continue as normal
     """
-    # pylint: disable=protected-access
-    instance.output.forwarded_outputs = {"out1": "val1"}
+    mock_flatten = NonCallableMock()
 
-    # should just continue running as normal after printing warning
-    instance.executer.parse_results.return_value = "object-list", ""
-    assert instance.to_objects() == "object-list"
+    instance.executer.has_forwarded_results = True
 
-
-def test_to_props_flatten_true(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should call output.flatten() with query_results
-    """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    res = instance.to_props(flatten=True)
-    instance.output.flatten.assert_called_once_with("parsed-list")
-    assert res == instance.output.flatten.return_value
-
-
-def test_to_props_with_groups_not_dict(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should raise error when given group and results are not dict
-    """
-    instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
-    with pytest.raises(ParseQueryError):
-        instance.to_props(groups=["group1", "group2"])
-
-
-def test_to_objects_with_groups_not_dict(instance):
-    """
-    Tests that to_objects method functions expectedly
-    method should raise error when given group and results are not dict
-    """
-    instance.output.forwarded_outputs = {}
-    instance.executer.parse_results.return_value = "", ["obj1", "obj2"]
-    with pytest.raises(ParseQueryError):
-        instance.to_objects(groups=["group1", "group2"])
-
-
-def test_to_props_groups_dict(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should return subset of results which match keys (groups) given
-    """
-    mock_query_results = {
-        "group1": ["result1", "result2"],
-        "group2": ["result3", "result4"],
-    }
-    instance.executer.parse_results.return_value = "", mock_query_results
-    res = instance.to_props(groups=["group1"])
-    assert res == {"group1": mock_query_results["group1"]}
-
-
-def test_to_objects_groups_dict(instance):
-    """
-    Tests that to_objects method functions expectedly
-    method should return subset of results which match keys (groups) given
-    """
-    instance.output.forwarded_outputs = {}
-    mock_query_results = {
-        "group1": ["obj1", "obj2"],
-        "group2": ["obj3", "obj4"],
-    }
-    instance.executer.parse_results.return_value = mock_query_results, ""
-    res = instance.to_objects(groups=["group1"])
-    assert res == {"group1": mock_query_results["group1"]}
-
-
-def test_to_props_group_not_valid(instance):
-    """
-    Tests that to_props method functions expectedly
-    method should raise error if group specified is not a key in results
-    """
-    mock_query_results = {
-        "group1": ["result1", "result2"],
-        "group2": ["result3", "result4"],
-    }
-    instance.executer.parse_results.return_value = "", mock_query_results
-    with pytest.raises(ParseQueryError):
-        instance.to_props(groups=["group3"])
-
-
-def test_to_objects_group_not_valid(instance):
-    """
-    Tests that to_objects method functions expectedly
-    method should raise error if group specified is not a key in results
-    """
-    instance.output.forwarded_outputs = {}
-    mock_query_results = {
-        "group1": ["result1", "result2"],
-        "group2": ["result3", "result4"],
-    }
-    instance.executer.parse_results.return_value = mock_query_results, ""
-    with pytest.raises(ParseQueryError):
-        instance.to_objects(groups=["group3"])
+    res = instance.to_objects(mock_flatten)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_objects.assert_called_once_with(
+        instance.results_container,
+        mock_flatten,
+    )
+    assert res == instance.output.to_objects.return_value
 
 
 def test_to_string(instance):
@@ -343,9 +272,21 @@ def test_to_string(instance):
     Tests that to_string method functions expectedly
     method should call QueryOutput object to_string() and return results
     """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_string() == instance.output.to_string.return_value
-    instance.output.to_string.assert_called_once_with("parsed-list", None, None)
+    mock_groups = NonCallableMock()
+    mock_title = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    # pylint: disable=protected-access
+    instance.results_container = MagicMock()
+
+    res = instance.to_string(mock_title, mock_groups, **mock_kwargs)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_string.assert_called_once_with(
+        instance.results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    assert res == instance.output.to_string.return_value
 
 
 def test_to_html(instance):
@@ -353,9 +294,18 @@ def test_to_html(instance):
     Tests that to_html method functions expectedly
     method should call QueryOutput object to_html() and return results
     """
-    instance.executer.parse_results.return_value = "", "parsed-list"
-    assert instance.to_html() == instance.output.to_html.return_value
-    instance.output.to_html.assert_called_once_with("parsed-list", None, None)
+    mock_groups = NonCallableMock()
+    mock_title = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    res = instance.to_html(mock_title, mock_groups, **mock_kwargs)
+    instance.results_container.parse_results.assert_called_once_with(
+        instance.parser.run_parser
+    )
+    instance.output.to_html.assert_called_once_with(
+        instance.results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    assert res == instance.output.to_html.return_value
 
 
 def test_sort_by(instance):
@@ -401,34 +351,32 @@ def test_then(instance):
     assert res == instance.chainer.parse_then.return_value
 
 
-@patch("openstack_query.api.query_api.QueryAPI.then")
-@patch("openstack_query.api.query_api.QueryTypes")
-def test_append_from(mock_query_types_cls, mock_then, instance):
+def test_append_from(instance):
     """
-    Tests that append_from method creates new query
+    Tests that append_from method - should call run_append_from_query
+    and martial results into results_container.apply_forwarded_results
     """
-    mock_new_query = MagicMock()
+    mock_query_type = NonCallableMock()
     mock_cloud_account = NonCallableMock()
-    mock_query_type = "query-type"
+    mock_prop1 = NonCallableMock()
+    mock_prop2 = NonCallableMock()
 
-    mock_props = ["prop1", "prop2", "prop3"]
-    instance.chainer.get_link_props.return_value = ("current-prop", "link-prop")
-    mock_then.return_value = mock_new_query
+    mock_link_prop = NonCallableMock()
+    mock_new_query_results = NonCallableMock()
 
-    res = instance.append_from(mock_query_type, mock_cloud_account, *mock_props)
-    mock_query_types_cls.from_string.assert_called_once_with(mock_query_type)
-    mock_then.assert_called_once_with(
-        mock_query_types_cls.from_string.return_value, keep_previous_results=False
+    instance.chainer.run_append_from_query.return_value = (
+        mock_link_prop,
+        mock_new_query_results,
     )
 
-    mock_new_query.select.assert_called_once_with(*mock_props)
-    mock_new_query.run.assert_called_once_with(mock_cloud_account)
-    instance.chainer.get_link_props.assert_called_once_with(
-        mock_query_types_cls.from_string.return_value
+    res = instance.append_from(
+        mock_query_type, mock_cloud_account, mock_prop1, mock_prop2
     )
-    mock_new_query.group_by.assert_called_once_with("link-prop")
-    mock_new_query.to_props.assert_called_once()
-    instance.output.update_forwarded_outputs.assert_called_once_with(
-        "current-prop", mock_new_query.to_props.return_value
+    instance.chainer.run_append_from_query.assert_called_once_with(
+        instance, mock_query_type, mock_cloud_account, mock_prop1, mock_prop2
     )
+    instance.results_container.apply_forwarded_results(
+        mock_link_prop, mock_new_query_results
+    )
+
     assert res == instance

--- a/tests/lib/openstack_query/query_blocks/test_query_chainer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_chainer.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call, NonCallableMock
 
 import pytest
 
@@ -52,13 +52,6 @@ def run_parse_then_query_valid_fixture(instance):
             "prop_1": ["val1", "val2", "val3"]
         }
 
-        to_forward = None
-        if mock_keep_previous_results:
-            to_forward = (
-                MockProperties.PROP_2,
-                mock_current_query.group_by.return_value.to_props.return_value,
-            )
-
         res = instance.parse_then(
             current_query=mock_current_query,
             query_type="query-type",
@@ -73,6 +66,10 @@ def run_parse_then_query_valid_fixture(instance):
         mock_current_query.select.return_value.to_props.assert_any_call(flatten=True)
 
         if mock_keep_previous_results:
+            mock_query_api.return_value.chainer.set_forwarded_vals.assert_called_once_with(
+                MockProperties.PROP_2,
+                mock_current_query.group_by.return_value.to_props.return_value,
+            )
             mock_group_by = mock_current_query.group_by
             mock_group_by.assert_has_calls(
                 [
@@ -82,7 +79,7 @@ def run_parse_then_query_valid_fixture(instance):
             )
 
         mock_query_factory.build_query_deps.assert_called_once_with(
-            mock_query_types_cls.from_string.return_value.value, to_forward
+            mock_query_types_cls.from_string.return_value.value
         )
 
         mock_query_api.assert_called_once_with(
@@ -97,6 +94,17 @@ def run_parse_then_query_valid_fixture(instance):
         assert res == mock_query_api.return_value.where.return_value
 
     return _run_parse_then_query_valid
+
+
+def test_forwarded_info(instance):
+    """
+    Tests forwarded info property outputs a tuple of link_prop and
+    forwarded_values attributes. Uses set_forwarded_vals to set the properties
+    """
+    mock_forwarded_values = NonCallableMock()
+    mock_link_prop = NonCallableMock()
+    instance.set_forwarded_vals(mock_link_prop, mock_forwarded_values)
+    assert instance.forwarded_info == (mock_link_prop, mock_forwarded_values)
 
 
 def test_get_chaining_props(instance):
@@ -210,3 +218,39 @@ def test_parse_then_no_results(instance):
         )
     mock_current_query.chainer.get_link_props.assert_called_once_with(mock_query_type)
     mock_current_query.to_props.assert_called_once()
+
+
+@patch("openstack_query.query_blocks.query_chainer.QueryTypes")
+def test_run_append_from_query(mock_query_types, instance):
+    """
+    tests run_append_from_query method - calls then() to get a new query and runs it, selecting
+    given props and return grouped values
+    """
+    mock_current_query = NonCallableMock()
+    mock_cloud_account = NonCallableMock()
+    query_type = "query_type"
+    mock_props = ["prop1", "prop2"]
+
+    mock_current_query.chainer.get_link_props.return_value = (
+        "current_link_prop",
+        "new_link_prop",
+    )
+    mock_new_query = mock_current_query.then.return_value
+
+    res = instance.run_append_from_query(
+        mock_current_query, query_type, mock_cloud_account, *mock_props
+    )
+
+    mock_query_types.from_string.assert_called_once_with(query_type)
+    mock_current_query.then.assert_called_once_with(
+        mock_query_types.from_string.return_value, keep_previous_results=False
+    )
+    mock_new_query.select.assert_called_once_with(*mock_props)
+    mock_new_query.run.assert_called_once_with(mock_cloud_account)
+    mock_current_query.chainer.get_link_props.assert_called_once_with(
+        mock_query_types.from_string.return_value
+    )
+    assert res == (
+        "current_link_prop",
+        mock_new_query.group_by.return_value.to_props.return_value,
+    )

--- a/tests/lib/openstack_query/query_blocks/test_query_executer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_executer.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, NonCallableMock
 import pytest
 
 from enums.cloud_domains import CloudDomains
@@ -15,7 +15,17 @@ def instance_fixture():
     """
     mock_prop_enum_cls = MockProperties
     mock_runner_cls = MagicMock()
-    return QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
+    query_executer = QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
+    query_executer._results_container = MagicMock()
+    return query_executer
+
+
+def test_results_container(instance):
+    """
+    Tests that results container property works as expected
+    """
+    mock_results_container = instance._results_container
+    assert instance.results_container == mock_results_container
 
 
 def test_client_side_filter_func(instance):
@@ -36,75 +46,11 @@ def test_server_side_filters(instance):
     assert instance.server_side_filters == mock_client_filter
 
 
-def test_parse_func(instance):
-    """
-    Tests that parse_func property works as expected
-    """
-    mock_parse_func = MagicMock()
-    instance.parse_func = mock_parse_func
-    assert instance.parse_func == mock_parse_func
-
-
-def test_output_func(instance):
-    """
-    Tests that output_func property method works as expected
-    """
-    mock_output_func = MagicMock()
-    instance.output_func = mock_output_func
-    assert instance.output_func == mock_output_func
-
-
-def test_raw_results(instance):
-    """
-    Tests that raw_results property method works as expected
-    """
-    mock_raw_results = MagicMock()
-    instance.raw_results = mock_raw_results
-    assert instance.raw_results == mock_raw_results
-
-
-def test_get_output_list_input(instance):
-    """
-    Tests that get_output method works as expected - when given a list
-    Should output the results of calling function stored in output_func attribute with given list
-    """
-    mock_out = [1, 2, 3]
-
-    def output_func(_):
-        return mock_out
-
-    output = instance.get_output(output_func, ["mock-result1"])
-    assert output == mock_out
-
-
-def test_get_output_dict_input(instance):
-    """
-    Tests that get_output method works as expected - when given a grouped output (dictionary)
-    Should output a dictionary, with values being the output of calling output_func with each group
-    """
-    mock_out = [1, 2, 3]
-    expected_out = {"group1": mock_out, "group2": mock_out}
-
-    def output_func(_):
-        return mock_out
-
-    output = instance.get_output(
-        output_func, {"group1": ["mock-results"], "group2": ["mock-results2"]}
-    )
-    assert output == expected_out
-
-
-def test_get_output_no_output_func(instance):
-    """
-    Tests that get_output method works as expected - when given no ouptut_func
-    Should output an empty list
-    """
-    instance._output_func = None
-    output = instance.get_output(None, ["mock-results1"])
-    assert output == []
-
-
-def test_run_query(instance):
+@pytest.mark.parametrize(
+    "mock_cloud_account, expected_cloud_account_str",
+    [(CloudDomains.PROD, "prod"), ("domain", "domain")],
+)
+def test_run_query(mock_cloud_account, expected_cloud_account_str, instance):
     """
     Tests that run_query method works as expected
     simply calls runner.run() and saves result in raw_results
@@ -113,13 +59,17 @@ def test_run_query(instance):
     instance.server_side_filters = MagicMock()
 
     instance.run_query(
-        cloud_account=CloudDomains.PROD,
+        cloud_account=mock_cloud_account,
         from_subset="some-subset",
         **{"arg1": "val1", "arg2": "val2"}
     )
 
+    instance.results_container.store_query_results.assert_called_once_with(
+        instance.runner.run.return_value
+    )
+
     instance.runner.run.assert_called_once_with(
-        cloud_account="prod",
+        cloud_account=expected_cloud_account_str,
         client_side_filters=instance.client_side_filters,
         server_side_filters=instance.server_side_filters,
         from_subset="some-subset",
@@ -127,61 +77,15 @@ def test_run_query(instance):
     )
 
 
-def test_run_query_with_string_domain(instance):
+def test_apply_forwarded_results(instance):
     """
-    Tests that run_query method works as expected
-    simply calls runner.run() and saves result in raw_results
+    Test apply_forwarded_results method - should forward to results_container
+    and set has_forwarded_results flag to True
     """
-    instance.client_side_filters = MagicMock()
-    instance.server_side_filters = MagicMock()
-
-    instance.run_query(
-        cloud_account="domain",
-        from_subset="some-subset",
-        **{"arg1": "val1", "arg2": "val2"}
+    mock_link_prop = NonCallableMock()
+    mock_results = NonCallableMock()
+    instance.apply_forwarded_results(mock_link_prop, mock_results)
+    instance.results_container.apply_forwarded_results.assert_called_once_with(
+        mock_link_prop, mock_results
     )
-
-    instance.runner.run.assert_called_once_with(
-        cloud_account="domain",
-        client_side_filters=instance.client_side_filters,
-        server_side_filters=instance.server_side_filters,
-        from_subset="some-subset",
-        **{"arg1": "val1", "arg2": "val2"}
-    )
-
-
-def test_parse_results_no_parse_func(instance):
-    """
-    Tests that parse_results method works as expected
-    should return raw_results, and get_output(raw_results) tuple
-    """
-    instance.raw_results = MagicMock()
-    with patch(
-        "openstack_query.query_blocks.query_executer.QueryExecuter.get_output"
-    ) as mock_get_output:
-        res1, res2 = instance.parse_results(None, "output_func")
-
-    assert res1 == instance.raw_results
-    mock_get_output.assert_called_once_with("output_func", instance.raw_results)
-    assert res2 == mock_get_output.return_value
-
-
-def test_parse_results_with_parse_func(instance):
-    """
-    Tests that parse_results method works as expected
-    should return raw_results, and get_output(raw_results) tuple
-    """
-    instance.raw_results = MagicMock()
-    parse_func = MagicMock()
-    output_func = "output_func"
-
-    with patch(
-        "openstack_query.query_blocks.query_executer.QueryExecuter.get_output"
-    ) as mock_get_output:
-        res1, res2 = instance.parse_results(parse_func, output_func)
-
-    parse_func.assert_called_once_with(instance.raw_results)
-    assert res1 == parse_func.return_value
-
-    mock_get_output.assert_called_once_with("output_func", parse_func.return_value)
-    assert res2 == mock_get_output.return_value
+    assert instance.has_forwarded_results

--- a/tests/lib/openstack_query/query_blocks/test_query_output.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_output.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch, call, NonCallableMock
 import pytest
 
-from exceptions.query_chaining_error import QueryChainingError
 from exceptions.parse_query_error import ParseQueryError
 from openstack_query.query_blocks.query_output import QueryOutput
 from enums.query.props.server_properties import ServerProperties
@@ -32,146 +31,308 @@ def test_selected_props(instance):
     assert instance.selected_props == list(val)
 
 
-@patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
-def test_to_html_with_list_results(mock_generate_table, instance):
+def test_selected_props_empty(instance):
     """
-    Tests that to_html function works expectedly - when given list as results and no title
-    method should call generate_table with return_html once
+    Tests selected property method returns empty list when no props selected
     """
+    assert instance.selected_props == []
 
-    mocked_results = ["obj1", "obj2"]
-    mock_generate_table.return_value = "mock out"
-    res = instance.to_html(results=mocked_results, title="mock title")
-    mock_generate_table.assert_called_once_with(
-        mocked_results, return_html=True, title=None
+
+def test_validate_groups_empty(instance):
+    """
+    Tests validate groups returns result if groups empty
+    """
+    mock_results = {"group1": "val1", "group2": "val2", "group3": "val3"}
+    mock_groups = None
+    # pylint:disable=protected-access
+    assert instance._validate_groups(mock_results, mock_groups) == mock_results
+
+
+def test_validate_groups_valid(instance):
+    """
+    Tests validate groups returns subset of results that match given set of groups
+    """
+    mock_results = {"group1": "val1", "group2": "val2", "group3": "val3"}
+    mock_groups = ["group1", "group2"]
+
+    # pylint:disable=protected-access
+    assert instance._validate_groups(mock_results, mock_groups) == {
+        "group1": "val1",
+        "group2": "val2",
+    }
+
+
+def test_validate_groups_invalid_keys(instance):
+    """
+    Tests validate groups returns error if value given in groups does not exist
+    as a key in results
+    """
+    mock_results = {"group1": "val1", "group2": "val2", "group3": "val3"}
+    mock_groups = ["invalid_group"]
+    with pytest.raises(ParseQueryError):
+        # pylint:disable=protected-access
+        instance._validate_groups(mock_results, mock_groups)
+
+
+def test_validate_groups_results_not_dict(instance):
+    """
+    Tests validate groups returns error if results given is not a dictionary
+    """
+    mock_results = ["val1", "val2"]
+    with pytest.raises(ParseQueryError):
+        # pylint:disable=protected-access
+        instance._validate_groups(mock_results, NonCallableMock())
+
+
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
+def test_to_objects(mock_validate_groups, instance):
+    """
+    Tests that to_objects method calls results_container.to_objects and martials
+    results into _validate_groups() then outputs the result
+    """
+    mock_results_container = MagicMock()
+    mock_groups = NonCallableMock()
+
+    res = instance.to_objects(mock_results_container, mock_groups)
+    mock_results_container.to_objects.assert_called_once_with()
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_objects.return_value, mock_groups
     )
-    assert res == "<b> mock title </b><br/> mock out"
+    assert res == mock_validate_groups.return_value
 
 
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.flatten")
+def test_to_props_no_flatten(mock_flatten, mock_validate_groups, instance):
+    """
+    Tests that to_props method calls results_container.to_props and martials
+    results into _validate_groups() then outputs the result. Does not call flatten
+    """
+    mock_results_container = MagicMock()
+    mock_groups = NonCallableMock()
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+
+    res = instance.to_props(mock_results_container, False, mock_groups)
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+    mock_flatten.assert_not_called()
+    assert res == mock_validate_groups.return_value
+
+
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
+@patch("openstack_query.query_blocks.query_output.QueryOutput.flatten")
+def test_to_props_with_flatten(mock_flatten, mock_validate_groups, instance):
+    """
+    Tests that to_props method calls results_container.to_props, martials
+    results into _validate_groups(), then flatten() and returns results
+    """
+    mock_results_container = MagicMock()
+    mock_groups = NonCallableMock()
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+
+    res = instance.to_props(mock_results_container, True, mock_groups)
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+    mock_flatten.assert_called_once_with(mock_validate_groups.return_value)
+    assert res == mock_flatten.return_value
+
+
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
-def test_to_html_with_no_title(mock_generate_table, instance):
+def test_to_html_with_list_results(mock_generate_table, mock_validate_groups, instance):
+    """
+    Tests that to_html function - when results are outputted as a list
+    method should call generate_table with return_html = True once
+    """
+    mock_results_container = MagicMock()
+    mock_title = "mock title"
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+    mock_generate_table.return_value = "mock out"
+
+    res = instance.to_html(
+        mock_results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+
+    mock_generate_table.assert_called_once_with(
+        mock_validate_groups.return_value, return_html=True, title=None, **mock_kwargs
+    )
+    assert res == "<b> mock title: </b><br/> mock out"
+
+
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
+@patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
+def test_to_html_with_no_title(mock_generate_table, mock_validate_groups, instance):
     """
     Tests that to_html function works expectedly - when given list as results and no title
     method should call generate_table with return_html once
     """
-
-    mocked_results = ["obj1", "obj2"]
+    mock_results_container = MagicMock()
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
     mock_generate_table.return_value = "mock out"
-    res = instance.to_html(results=mocked_results, title=None)
+
+    res = instance.to_html(mock_results_container, groups=mock_groups, **mock_kwargs)
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+
     mock_generate_table.assert_called_once_with(
-        mocked_results, return_html=True, title=None
+        mock_validate_groups.return_value, return_html=True, title=None, **mock_kwargs
     )
     assert res == "mock out"
 
 
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
-def test_to_html_with_grouped_results(mock_generate_table, instance):
+def test_to_html_with_grouped_results(
+    mock_generate_table, mock_validate_groups, instance
+):
     """
-    Tests that to_html function works expectedly - when given grouped results
+    Tests that to_html function works expectedly - when results are grouped - outputted as a dict
     method should call generate_table with return_html for each group
     """
-    mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
 
+    mock_results_container = MagicMock()
+    mock_title = "mock title"
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+
+    mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
+    mock_validate_groups.return_value = mocked_results
     mock_generate_table.side_effect = ["1 out, ", "2 out"]
-    res = instance.to_html(results=mocked_results, title="mock title")
+
+    res = instance.to_html(
+        mock_results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
 
     mock_generate_table.assert_has_calls(
         [
-            call(["obj1", "obj2"], return_html=True, title="<b> group1: </b><br/> "),
-            call(["obj3", "obj4"], return_html=True, title="<b> group2: </b><br/> "),
+            call(
+                ["obj1", "obj2"],
+                return_html=True,
+                title="<b> group1: </b><br/> ",
+                **mock_kwargs
+            ),
+            call(
+                ["obj3", "obj4"],
+                return_html=True,
+                title="<b> group2: </b><br/> ",
+                **mock_kwargs
+            ),
         ]
     )
-    assert res == "<b> mock title </b><br/> 1 out, 2 out"
+    assert res == "<b> mock title: </b><br/> 1 out, 2 out"
 
 
-def test_to_html_incorrect_groups(instance):
-    """
-    Tests that to_html function raises error when given a group that doesn't appear in results
-    """
-    mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
-    with pytest.raises(ParseQueryError):
-        instance.to_html(results=mocked_results, groups=["group3"])
-
-
-def test_to_html_errors_when_not_grouped(instance):
-    """
-    Tests that to_html function raises error when given a group and results are not grouped
-    """
-    mocked_results = ["obj1", "obj2"]
-    with pytest.raises(ParseQueryError):
-        instance.to_html(results=mocked_results, groups=["group3"])
-
-
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
-def test_to_string_with_list_results(mock_generate_table, instance):
+def test_to_string_with_list_results(
+    mock_generate_table, mock_validate_groups, instance
+):
     """
-    Tests that to_string function works expectedly - when given list as results
-    method should call generate_table with return_html set to false once
+    Tests that to_string function - when results are outputted as a list
+    method should call generate_table with return_html = False once
     """
+    mock_results_container = MagicMock()
+    mock_title = "mock title"
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
 
-    mocked_results = ["obj1", "obj2"]
+    instance.selected_props = ["prop1", "prop2", "prop3"]
     mock_generate_table.return_value = "mock out"
 
-    res = instance.to_string(results=mocked_results, title="mock title")
-    mock_generate_table.assert_called_once_with(
-        mocked_results, return_html=False, title=None
+    res = instance.to_string(
+        mock_results_container, mock_title, mock_groups, **mock_kwargs
     )
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+
+    mock_generate_table.assert_called_once_with(
+        mock_validate_groups.return_value, return_html=False, title=None, **mock_kwargs
+    )
+
     assert "mock title:\nmock out" == res
 
 
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
-def test_to_string_with_no_title(mock_generate_table, instance):
+def test_to_string_with_no_title(mock_generate_table, mock_validate_groups, instance):
     """
-    Tests that to_string function works expectedly - when given list as results and no title
-    method should call generate_table with return_html set to false once
+    Tests that to_string - when given list as results and no title
+    method should call generate_table with return_html once
     """
-
-    mocked_results = ["obj1", "obj2"]
+    mock_results_container = MagicMock()
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
     mock_generate_table.return_value = "mock out"
 
-    res = instance.to_string(results=mocked_results, title=None)
-    mock_generate_table.assert_called_once_with(
-        mocked_results, return_html=False, title=None
+    res = instance.to_string(mock_results_container, groups=mock_groups, **mock_kwargs)
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
     )
-    assert "mock out" == res
+
+    mock_generate_table.assert_called_once_with(
+        mock_validate_groups.return_value, return_html=False, title=None, **mock_kwargs
+    )
+    assert res == "mock out"
 
 
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
-def test_to_string_with_grouped_results(mock_generate_table, instance):
+def test_to_string_with_grouped_results(
+    mock_generate_table, mock_validate_groups, instance
+):
     """
-    Tests that to_string function works expectedly - when given grouped results
-    method should call generate_table with return_html set to false for each group
+    Tests that to_html function works expectedly - when results are grouped - outputted as a dict
+    method should call generate_table with return_html for each group
     """
+
+    mock_results_container = MagicMock()
+    mock_title = "mock title"
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+
     mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
+    mock_validate_groups.return_value = mocked_results
     mock_generate_table.side_effect = ["1 out, ", "2 out"]
 
-    res = instance.to_string(results=mocked_results, title="mock title")
+    res = instance.to_string(
+        mock_results_container, mock_title, mock_groups, **mock_kwargs
+    )
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
 
     mock_generate_table.assert_has_calls(
         [
-            call(["obj1", "obj2"], return_html=False, title="group1:\n"),
-            call(["obj3", "obj4"], return_html=False, title="group2:\n"),
+            call(["obj1", "obj2"], return_html=False, title="group1:\n", **mock_kwargs),
+            call(["obj3", "obj4"], return_html=False, title="group2:\n", **mock_kwargs),
         ]
     )
     assert "mock title:\n1 out, 2 out" == res
-
-
-def test_to_string_incorrect_groups(instance):
-    """
-    Tests that to_html function raises error when given a group that doesn't appear in results
-    """
-    mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
-    with pytest.raises(ParseQueryError):
-        instance.to_string(results=mocked_results, groups=["group3"])
-
-
-def test_to_string_errors_when_not_grouped(instance):
-    """
-    Tests that to_string function raises error when given a group and results are not grouped
-    """
-    mocked_results = ["obj1", "obj2"]
-    with pytest.raises(ParseQueryError):
-        instance.to_string(results=mocked_results, groups=["group3"])
 
 
 def test_generate_table_no_vals(instance):
@@ -185,7 +346,7 @@ def test_generate_table_no_vals(instance):
     res = instance._generate_table(
         results_dict_0, title="mock title", return_html=False
     )
-    assert "mock title\nNo results found" == res
+    assert "mock titleNo results found" == res
 
 
 @pytest.mark.parametrize(
@@ -323,168 +484,6 @@ def test_parse_select_overwrites_old(instance):
     assert instance.selected_props == [MockProperties.PROP_2]
 
 
-def test_generate_output_no_items(instance):
-    """
-    Tests that generate_output method works expectedly - no openstack items
-    method should return an empty list
-    """
-    assert instance.generate_output([]) == []
-
-
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_properties")
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_forwarded_outputs")
-@patch("openstack_query.query_blocks.query_output.deepcopy")
-def test_generate_output_one_item(
-    mock_deepcopy, mock_parse_forwarded_outputs, mock_parse_properties, instance
-):
-    """
-    Tests generate output method - with a list containing one item
-    """
-    instance.update_forwarded_outputs(NonCallableMock(), NonCallableMock())
-    mock_parse_properties.return_value = {"prop1": "val1", "prop2": "val2"}
-    mock_parse_forwarded_outputs.return_value = {
-        "output_prop3": "val3",
-        "output_prop4": "val4",
-    }
-
-    res = instance.generate_output(["obj1"])
-    mock_deepcopy.assert_called_once_with(instance.forwarded_outputs)
-    mock_parse_properties.assert_called_once_with("obj1")
-    mock_parse_forwarded_outputs.assert_called_once_with(
-        "obj1", mock_deepcopy.return_value
-    )
-    assert res == [
-        {
-            "prop1": "val1",
-            "prop2": "val2",
-            "output_prop3": "val3",
-            "output_prop4": "val4",
-        }
-    ]
-
-
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_properties")
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_forwarded_outputs")
-@patch("openstack_query.query_blocks.query_output.deepcopy")
-def test_generate_output_many_items(
-    mock_deepcopy, mock_parse_forwarded_outputs, mock_parse_properties, instance
-):
-    """
-    Tests generate output method - with a list containing one item
-    """
-    instance.update_forwarded_outputs(NonCallableMock(), NonCallableMock())
-
-    mock_parse_properties.side_effect = [
-        {"prop1": "val1", "prop2": "val2"},
-        {"prop1": "val3", "prop2": "val4"},
-    ]
-    mock_parse_forwarded_outputs.side_effect = [
-        {"output_prop1": "val1", "output_prop2": "val2"},
-        {"output_prop1": "val3", "output_prop2": "val4"},
-    ]
-
-    res = instance.generate_output(["obj1", "obj2"])
-    mock_deepcopy.assert_called_once_with(instance.forwarded_outputs)
-
-    mock_parse_properties.assert_has_calls([call("obj1"), call("obj2")])
-    mock_parse_forwarded_outputs.asssert_has_calls(
-        [
-            call("obj1", mock_deepcopy.return_value),
-            call("obj2", mock_deepcopy.return_value),
-        ]
-    )
-
-    expected_vals = [
-        {
-            "prop1": "val1",
-            "prop2": "val2",
-            "output_prop1": "val1",
-            "output_prop2": "val2",
-        },
-        {
-            "prop1": "val3",
-            "prop2": "val4",
-            "output_prop1": "val3",
-            "output_prop2": "val4",
-        },
-    ]
-    assert res == expected_vals
-
-
-@pytest.fixture(name="mock_get_prop_func")
-def get_prop_func_fixture():
-    """
-    Stubs out get_prop_func method to return a
-    stub callable based on prop enum
-    """
-    mock_prop_1_func = MagicMock()
-    mock_prop_1_func.return_value = "prop 1 out"
-
-    mock_prop_2_func = MagicMock()
-    mock_prop_2_func.side_effect = AttributeError
-
-    def _mock_get_prop_func(prop):
-        return {
-            MockProperties.PROP_1: mock_prop_1_func,
-            MockProperties.PROP_2: mock_prop_2_func,
-        }.get(prop, None)
-
-    return _mock_get_prop_func
-
-
-def test_parse_properties_no_props(instance):
-    """
-    Tests that parse_properties function works expectedly with 0 prop_funcs to apply
-    method should return an empty dict
-    """
-
-    # mock get_prop_mapping to return a func string appropriate for that prop
-    instance.selected_props = set()
-    # pylint:disable=protected-access
-    assert instance._parse_properties("openstack-item") == {}
-
-
-@patch.object(MockProperties, "get_prop_mapping")
-def test_parse_properties_one_prop(mock_get_prop_func, instance):
-    """
-    Tests that parse_properties function works expectedly with 0 prop_funcs to apply
-    method should return a dict with one key value pair (prop-name, prop-value)
-    """
-    mock_prop_func = MagicMock()
-    mock_prop_func.return_value = "prop 1 out"
-
-    mock_get_prop_func.return_value = mock_prop_func
-
-    instance.selected_props = {MockProperties.PROP_1}
-    # pylint:disable=protected-access
-    res = instance._parse_properties("openstack-item")
-
-    mock_get_prop_func.assert_called_once_with(MockProperties.PROP_1)
-    mock_prop_func.assert_called_once_with("openstack-item")
-
-    assert res == {"prop_1": "prop 1 out"}
-
-
-def test_parse_properties_many_props(mock_get_prop_func, instance):
-    """
-    Tests that parse_properties function works expectedly with 0 prop_funcs to apply
-    method should return a dict with many key value pairs (prop-name, prop-value)
-    """
-
-    instance.selected_props = {MockProperties.PROP_1, MockProperties.PROP_2}
-
-    with patch.object(
-        MockProperties, "get_prop_mapping", wraps=mock_get_prop_func
-    ) as mock_get_prop_mapping:
-        # pylint:disable=protected-access
-        res = instance._parse_properties("openstack-item")
-
-    assert res == {"prop_1": "prop 1 out", "prop_2": "Not Found"}
-    mock_get_prop_mapping.assert_has_calls(
-        [call(prop) for prop in instance.selected_props]
-    )
-
-
 def test_flatten_empty(instance):
     """
     Tests that flatten() function works expectedly - with empty list/dict
@@ -581,131 +580,3 @@ def test_flatten_with_duplicates(instance):
     assert instance._flatten_list(
         [{"prop1": "val1", "prop2": "val2"}, {"prop1": "val1", "prop2": "val2"}]
     ) == {"prop1": ["val1", "val1"], "prop2": ["val2", "val2"]}
-
-
-def test_update_forwarded_outputs(instance):
-    """
-    Tests update_forwarded_outputs() method
-    ensure various test cases when running update_forwarded_outputs succeeds
-    """
-
-    # test update with one output set when forwarded_outputs empty
-    instance.update_forwarded_outputs("prop1", "output")
-    assert instance.forwarded_outputs == {"prop1": "output"}
-
-    # test add another another output set - different group key
-    instance.update_forwarded_outputs("prop2", "output2")
-    assert instance.forwarded_outputs == {"prop1": "output", "prop2": "output2"}
-
-    # test update works - same group key
-    instance.update_forwarded_outputs("prop1", "output-new")
-    assert instance.forwarded_outputs == {"prop1": "output-new", "prop2": "output2"}
-
-
-def test_parse_forwarded_outputs_no_set(instance):
-    """
-    Tests parse_forwarded_outputs() method - with no forwarded_outputs set
-    should return empty dict
-    """
-    # pylint:disable=protected-access
-    assert instance._parse_forwarded_outputs("obj1", {}) == {}
-
-
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
-def test_parse_forwarded_outputs_one_to_many(mock_parse_property, instance):
-    """
-    Tests parse_forwarded_outputs() method - one set of forwarded_outputs
-    """
-    expected_out = {"forwarded-prop1": "val1", "forwarded-prop2": "val2"}
-    mock_forwarded_outputs = {"prop1": {"prop_val1": [expected_out]}}
-
-    mock_parse_property.side_effect = ["prop_val1", "prop_val1"]
-
-    # pylint:disable=protected-access
-
-    # first match
-    res = instance._parse_forwarded_outputs("obj1", mock_forwarded_outputs)
-    mock_parse_property.assert_has_calls([call("prop1", "obj1")])
-    assert res == expected_out
-
-    # second match
-    res = instance._parse_forwarded_outputs("obj2", mock_forwarded_outputs)
-    mock_parse_property.assert_has_calls([call("prop1", "obj2")])
-    assert res == expected_out
-
-
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
-def test_parse_forwarded_outputs_multiple_sets(mock_parse_property, instance):
-    """
-    Tests parse_forwarded_outputs() method - a set of many forwarded_outputs
-    first one-to-many (singleton list), second many-to-one (list containing many items)
-    """
-    one_to_many_out = {"forwarded-prop1": "val1", "forwarded-prop2": "val2"}
-
-    many_to_one_out1 = {"forwarded-prop3": "val3", "forwarded-prop4": "val4"}
-    many_to_one_out2 = {"forwarded-prop3": "new-val", "forwarded-prop4": "new-val2"}
-
-    mock_forwarded_outputs = {
-        "prop1": {"prop_val1": [one_to_many_out]},
-        "prop2": {"prop_val2": [many_to_one_out1, many_to_one_out2]},
-    }
-
-    mock_parse_property.side_effect = [
-        # first item calls
-        "prop_val1",
-        "prop_val2",
-        # second item calls
-        "prop_val1",
-        "prop_val2",
-    ]
-    # pylint:disable=protected-access
-
-    # first item
-    res = instance._parse_forwarded_outputs("obj1", mock_forwarded_outputs)
-    mock_parse_property.assert_has_calls([call("prop1", "obj1"), call("prop2", "obj1")])
-    assert res == {**one_to_many_out, **many_to_one_out1}
-
-    # second item
-    res = instance._parse_forwarded_outputs("obj1", mock_forwarded_outputs)
-    mock_parse_property.assert_has_calls([call("prop1", "obj1"), call("prop2", "obj1")])
-    assert res == {**one_to_many_out, **many_to_one_out2}
-
-
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
-def test_parse_forwarded_prop_value_not_found(mock_parse_property, instance):
-    """
-    Tests parse_forwarded_outputs() method
-    where a prop_value is not found - raise error
-    """
-    mock_forwarded_outputs = {"prop1": {"prop-val1": ["outputs"]}}
-
-    mock_parse_property.return_value = "invalid-prop"
-    with pytest.raises(QueryChainingError):
-        # pylint:disable=protected-access
-        instance._parse_forwarded_outputs("obj1", mock_forwarded_outputs)
-
-
-@patch("openstack_query.query_blocks.query_output.QueryOutput._parse_property")
-def test_parse_forwarded_outputs_many_to_one(mock_parse_property, instance):
-    """
-    Tests parse_forwarded_outputs() method - where forwarded outputs expects duplicates
-    cases where grouped results have a many-to-one relationship.
-    i.e. finding Users mapped to Servers - many servers can be mapped to one user - so duplicates of same user ids
-    are expected
-    """
-    expected_out1 = {"forwarded-prop1": "val1", "forwarded-prop2": "val2"}
-    expected_out2 = {"forwarded-prop3": "val3", "forwarded-prop4": "val4"}
-
-    mock_forwarded_outputs = {"prop1": {"prop_val1": [expected_out1, expected_out2]}}
-    mock_parse_property.side_effect = ["prop_val1", "prop_val1"]
-    # pylint:disable=protected-access
-
-    # first duplicate - takes first item in list
-    res = instance._parse_forwarded_outputs("obj1", mock_forwarded_outputs)
-    assert res == expected_out1
-
-    # second duplicate - takes second item in list
-    res = instance._parse_forwarded_outputs("obj2", mock_forwarded_outputs)
-    assert res == expected_out2
-
-    mock_parse_property.assert_has_calls([call("prop1", "obj1"), call("prop1", "obj2")])

--- a/tests/lib/openstack_query/query_blocks/test_query_parser.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_parser.py
@@ -9,6 +9,28 @@ from exceptions.parse_query_error import ParseQueryError
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
+@pytest.fixture(name="mock_results_container")
+def results_container_fixture():
+    """
+    Returns a list of mock results with each as_object return value set to
+    given values
+    """
+
+    def _setup_results_container(mock_as_objects):
+        """
+        function which sets up a list of mock Result objects each with
+        a different as_object return value - as specified by mock_as_objects input
+        :param mock_as_objects: a list of values that is to be assigned as the
+         return_value for each mock Result object
+        """
+        mock_results = [MagicMock() for _ in mock_as_objects]
+        for i, mock_result in enumerate(mock_results):
+            mock_result.as_object.return_value = mock_as_objects[i]
+        return mock_results
+
+    return _setup_results_container
+
+
 @pytest.fixture(name="instance")
 def instance_fixture():
     """
@@ -50,7 +72,8 @@ def run_sort_by_tests_fixture(instance, mock_get_prop_mapping):
         ) as mock_get_prop_func:
             # pylint:disable=protected-access
             res = instance._run_sort(obj_list)
-            assert res == expected_list
+            # test that res object list is sorted properly
+            assert [item.as_object() for item in res] == expected_list
             mock_get_prop_func.assert_has_calls(
                 [call(sort_key) for sort_key in reversed(sort_by_specs.keys())]
             )
@@ -104,6 +127,15 @@ def test_parse_sort_by_invalid(instance):
     """
     with pytest.raises(ParseQueryError):
         instance.parse_sort_by((ServerProperties.SERVER_ID, True))
+
+
+def test_parse_group_by_invalid(instance):
+    """
+    Tests parse_group_by - when given an invalid group by prop
+    """
+    with pytest.raises(ParseQueryError):
+        # we gave an unexpected enum value (sort-order) that's not supported
+        instance.parse_group_by(SortOrder.DESC)
 
 
 def test_parse_group_by_no_ranges(instance):
@@ -165,11 +197,16 @@ def test_run_parse_group_ranges(instance, mock_get_prop_mapping):
 
     assert instance.group_mappings
 
-    assert instance.group_mappings["group1"]({"prop_1": "val1"})
-    assert not instance.group_mappings["group2"]({"prop_1": "val1"})
+    prop_to_check = MagicMock()
+    prop_to_check.as_object.return_value = {"prop_1": "val1"}
+
+    assert instance.group_mappings["group1"](prop_to_check)
+    assert not instance.group_mappings["group2"](prop_to_check)
 
 
-def test_add_include_missing_group(instance, mock_get_prop_mapping):
+def test_add_include_missing_group(
+    instance, mock_get_prop_mapping, mock_results_container
+):
     """
     Tests add_include_missing_group functions expectedly
     Should create an extra "ungrouped results" group which includes values
@@ -186,9 +223,13 @@ def test_add_include_missing_group(instance, mock_get_prop_mapping):
         instance._add_include_missing_group(mock_group_ranges)
         mock_get_prop_func.assert_called_once_with(mock_group_by)
 
-    assert instance.group_mappings["ungrouped results"]({"prop_1": "val5"})
-    assert not instance.group_mappings["ungrouped results"]({"prop_1": "val1"})
-    assert not instance.group_mappings["ungrouped results"]({"prop_1": "val4"})
+    results_to_check = mock_results_container(
+        [{"prop_1": "val5"}, {"prop_1": "val1"}, {"prop_1": "val4"}]
+    )
+
+    assert instance.group_mappings["ungrouped results"](results_to_check[0])
+    assert not instance.group_mappings["ungrouped results"](results_to_check[1])
+    assert not instance.group_mappings["ungrouped results"](results_to_check[2])
 
 
 @patch("openstack_query.query_blocks.query_parser.QueryParser._run_sort")
@@ -197,9 +238,7 @@ def test_run_parser_with_sort_by(mock_run_sort, instance):
     Tests that run_parser functions expectedly - when giving only sort_by
     Should call run_sort method, and return result
     """
-    instance.sort_by = {MockProperties.PROP_1: False}
-    instance.group_by = None
-    instance.group_mappings = {}
+    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.DESC))
 
     mock_run_sort.return_value = "sort-out"
     mock_obj_list = ["obj1", "obj2", "obj3"]
@@ -215,9 +254,7 @@ def test_run_parser_no_sort_with_group_mappings(mock_run_group_by, instance):
     Tests that run_parser functions expectedly - when giving group_mappings
     Should call run_group_by with group mappings and return
     """
-    instance.sort_by = {}
-    instance.group_by = MockProperties.PROP_1
-    instance.group_mappings = {"group1": "some-mapping_func"}
+    instance.parse_group_by(MockProperties.PROP_1)
 
     mock_obj_list = ["obj1", "obj2", "obj3"]
     mock_run_group_by.return_value = "group-out"
@@ -235,11 +272,10 @@ def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instan
     Tests that run_parser functions expectedly - when giving both group_by and sort_by
     Should call run_sort method and then run_group_by on that output, then return
     """
-    instance.sort_by = {MockProperties.PROP_1: False}
-    instance.group_by = MockProperties.PROP_1
-    instance.group_mappings = {"group1": "some-mapping_func"}
-    mock_obj_list = ["obj1", "obj2", "obj3"]
+    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.DESC))
+    instance.parse_group_by(MockProperties.PROP_1)
 
+    mock_obj_list = ["obj1", "obj2", "obj3"]
     mock_run_group_by.return_value = "group-out"
     mock_run_sort.return_value = "sort-out"
 
@@ -247,6 +283,13 @@ def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instan
     assert res == "group-out"
     mock_run_sort.assert_called_once_with(mock_obj_list)
     mock_run_group_by.assert_called_once_with("sort-out")
+
+
+def test_run_parser_empty_list(instance):
+    """
+    Tests run_parser - when given empty list - output empty list
+    """
+    assert instance.run_parser([]) == []
 
 
 @pytest.mark.parametrize(
@@ -258,26 +301,29 @@ def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instan
         {MockProperties.PROP_2: True},
     ],
 )
-def test_run_sort_with_one_key(mock_sort_by_specs, run_sort_by_tests):
+def test_run_sort_with_one_key(
+    mock_sort_by_specs, run_sort_by_tests, mock_results_container
+):
     """
     Tests that run_sort functions expectedly - with one sorting key
     Should call run_sort method which should get the appropriate sorting
     key lambda function and sort dict accordingly
     """
-
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 2},
         {"prop_1": "c", "prop_2": 4},
         {"prop_1": "d", "prop_2": 3},
         {"prop_1": "b", "prop_2": 1},
     ]
 
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+
     # sorting by only one property so get first key in sort specs
     mock_enum = list(mock_sort_by_specs.keys())[0]
     reverse = mock_sort_by_specs[mock_enum]
     mock_prop_name = mock_enum.name.lower()
     expected_list = sorted(
-        mock_obj_list, key=lambda k: k[mock_prop_name], reverse=reverse
+        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
     )
     run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
 
@@ -324,20 +370,20 @@ def test_run_sort_with_one_key(mock_sort_by_specs, run_sort_by_tests):
     ],
 )
 def test_run_sort_with_multiple_key(
-    mock_sort_by_specs, expected_list, run_sort_by_tests
+    mock_sort_by_specs, expected_list, run_sort_by_tests, mock_results_container
 ):
     """
     Tests that run_sort functions expectedly - with one sorting key
     Should call run_sort method which should get the appropriate sorting
     key lambda function and sort dict accordingly
     """
-
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 1},
         {"prop_1": "b", "prop_2": 1},
         {"prop_1": "a", "prop_2": 2},
         {"prop_1": "b", "prop_2": 2},
     ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
     run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
 
 
@@ -345,23 +391,23 @@ def test_run_sort_with_multiple_key(
     "mock_sort_by_specs",
     [{MockProperties.PROP_1: False}, {MockProperties.PROP_1: True}],
 )
-def test_run_sort_with_boolean(mock_sort_by_specs, instance, run_sort_by_tests):
+def test_run_sort_with_boolean(
+    mock_sort_by_specs, instance, run_sort_by_tests, mock_results_container
+):
     """
     Tests that run_sort functions expectedly - sorting by boolean
     Should call run_sort method which should get the appropriate sorting
     key lambda function and sort dict accordingly
     """
-    mock_obj_list = [
-        {"prop_1": False},
-        {"prop_1": True},
-    ]
+    mock_as_object_vals = [{"prop_1": False}, {"prop_1": True}]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
     instance.sort_by = mock_sort_by_specs
     mock_enum = list(mock_sort_by_specs.keys())[0]
     reverse = mock_sort_by_specs[mock_enum]
     mock_prop_name = mock_enum.name.lower()
 
     expected_list = sorted(
-        mock_obj_list, key=lambda k: k[mock_prop_name], reverse=reverse
+        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
     )
     run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
 
@@ -422,7 +468,9 @@ def test_build_unique_val_groups(
 
 
 @patch("openstack_query.query_blocks.query_parser.QueryParser._build_unique_val_groups")
-def test_run_group_by_no_group_mappings(mock_build_unique_val_groups, instance):
+def test_run_group_by_no_group_mappings(
+    mock_build_unique_val_groups, instance, mock_results_container
+):
     """
     Tests run group_by method functions expectedly - when using no group mappings
     Should call build_unique_val_group and use the mappings returned to apply onto given object list
@@ -437,24 +485,33 @@ def test_run_group_by_no_group_mappings(mock_build_unique_val_groups, instance):
     }
     mock_build_unique_val_groups.return_value = mock_group_mappings
 
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 1},
         {"prop_1": "b", "prop_2": 2},
         {"prop_1": "c", "prop_2": 3},
     ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
     # pylint:disable=protected-access
     res = instance._run_group_by(mock_obj_list)
-    mock_build_unique_val_groups.assert_called_once_with(mock_obj_list)
+    mock_build_unique_val_groups.assert_called_once_with(
+        [item.as_object() for item in mock_obj_list]
+    )
 
-    assert res == {
-        "group1": [{"prop_1": "a", "prop_2": 1}],
-        "group2": [{"prop_1": "b", "prop_2": 2}],
-        "group3": [{"prop_1": "c", "prop_2": 3}],
-    }
+    assert [item.as_object() for item in res["group1"]] == [
+        {"prop_1": "a", "prop_2": 1}
+    ]
+    assert [item.as_object() for item in res["group2"]] == [
+        {"prop_1": "b", "prop_2": 2}
+    ]
+    assert [item.as_object() for item in res["group3"]] == [
+        {"prop_1": "c", "prop_2": 3}
+    ]
 
 
 @patch("openstack_query.query_blocks.query_parser.QueryParser._build_unique_val_groups")
-def test_run_group_by_with_group_mappings(mock_build_unique_val_groups, instance):
+def test_run_group_by_with_group_mappings(
+    mock_build_unique_val_groups, instance, mock_results_container
+):
     """
     Tests run group_by method functions expectedly - when using group mappings
     Should use the preset mappings and apply them onto given object list
@@ -467,17 +524,22 @@ def test_run_group_by_with_group_mappings(mock_build_unique_val_groups, instance
     }
     instance.group_mappings = mock_group_mappings
 
-    mock_obj_list = [
+    mock_as_object_vals = [
         {"prop_1": "a", "prop_2": 1},
         {"prop_1": "b", "prop_2": 2},
         {"prop_1": "c", "prop_2": 3},
     ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
 
     # pylint:disable=protected-access
     res = instance._run_group_by(mock_obj_list)
     mock_build_unique_val_groups.assert_not_called()
 
-    assert res == {
-        "group1": [{"prop_1": "a", "prop_2": 1}, {"prop_1": "b", "prop_2": 2}],
-        "group2": [{"prop_1": "c", "prop_2": 3}],
-    }
+    assert [item.as_object() for item in res["group1"]] == [
+        {"prop_1": "a", "prop_2": 1},
+        {"prop_1": "b", "prop_2": 2},
+    ]
+
+    assert [item.as_object() for item in res["group2"]] == [
+        {"prop_1": "c", "prop_2": 3}
+    ]

--- a/tests/lib/openstack_query/test_query_factory.py
+++ b/tests/lib/openstack_query/test_query_factory.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openstack_query.query_factory import QueryFactory
-from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
 @pytest.fixture(name="run_build_query_deps_test_case")
@@ -18,7 +17,6 @@ def run_build_query_deps_test_case_fixture():
     @patch("openstack_query.query_factory.QueryChainer")
     @patch("openstack_query.query_factory.QueryComponents")
     def _run_build_query_deps_test_case(
-        mock_forwarded_outputs,
         mock_query_components,
         mock_chainer,
         mock_executer,
@@ -31,14 +29,7 @@ def run_build_query_deps_test_case_fixture():
         if provided forwarded outputs or not
         """
         mock_mapping_cls = MagicMock()
-        res = QueryFactory.build_query_deps(
-            mock_mapping_cls, forwarded_outputs=mock_forwarded_outputs
-        )
-
-        if mock_forwarded_outputs:
-            mock_output.return_value.update_forwarded_outputs.assert_called_once_with(
-                MockProperties.PROP_1, {"val_1": ["output1", "output2"]}
-            )
+        res = QueryFactory.build_query_deps(mock_mapping_cls)
 
         mock_mapping_cls.get_prop_mapping.assert_called_once()
         mock_prop_mapping = mock_mapping_cls.get_prop_mapping.return_value
@@ -71,19 +62,9 @@ def run_build_query_deps_test_case_fixture():
     return _run_build_query_deps_test_case
 
 
-def test_build_query_deps_no_forwarded_outputs(run_build_query_deps_test_case):
+def test_build_query_deps(run_build_query_deps_test_case):
     """
     Test that function build_query_deps works - with no forwarded outputs
     should build all query blocks and return QueryComponent dataclass using them
     """
-    run_build_query_deps_test_case(None)
-
-
-def test_build_query_deps_with_forwarded_outputs(run_build_query_deps_test_case):
-    """
-    Test that function build_query_deps works - with forwarded outputs
-    should build all query blocks and return QueryComponent dataclass using them
-    """
-    run_build_query_deps_test_case(
-        (MockProperties.PROP_1, {"val_1": ["output1", "output2"]}),
-    )
+    run_build_query_deps_test_case()


### PR DESCRIPTION
refactor query blocks to use results classes

QueryParser now expects a list of Result classes instead when running run_sort_by/run_group_by

QueryOutput no longer handles parsing selected properties - instead calls the function in ResultsContainer to get selected properties - simplifies this block quite a bit

QueryExecuter now creates and manages a ResultsContainer object instead of holding raw results itself

QueryChainer stores forwarded_properties from previous queries