### PR TITLE
Add parent_id for project creation actions

### DIFF
--- a/actions/project.create.yaml
+++ b/actions/project.create.yaml
@@ -38,5 +38,5 @@ parameters:
   parent_id:
     default: ""
     description: Set the ID of the parent Domain/project. Leave as blank and it will use the "Default Domain"
-    type: str
+    type: string
 runner_type: python-script

--- a/actions/project.create.yaml
+++ b/actions/project.create.yaml
@@ -35,4 +35,8 @@ parameters:
     default: false
     description: Project is immutable or not
     type: boolean
+  parent_id:
+    default: ""
+    description: Set the ID of the parent Domain/project. Leave as blank and it will use the "Default Domain"
+    type: str
 runner_type: python-script

--- a/actions/src/project_actions.py
+++ b/actions/src/project_actions.py
@@ -92,6 +92,7 @@ class ProjectAction(Action):
         description: str,
         is_enabled: bool,
         immutable: bool,
+        parent_id: str,
     ) -> Tuple[bool, Optional[Project]]:
         """
         Find and return a given project's properties. Expected
@@ -102,6 +103,7 @@ class ProjectAction(Action):
         :param description: Description for new project
         :param is_enabled: Set if new project enabled or disabled
         :param immutable: Set if new project is immutable or not
+        :param parent_id: Set if new project has a parent id other than Default
         :return: status, optional project
         """
         details = ProjectDetails(
@@ -110,6 +112,7 @@ class ProjectAction(Action):
             description=description,
             is_enabled=is_enabled,
             immutable=immutable,
+            parent_id=parent_id or None,
         )
         project = self._identity_api.create_project(
             cloud_account=cloud_account, project_details=details

--- a/actions/workflow.project.create.external.yaml
+++ b/actions/workflow.project.create.external.yaml
@@ -31,7 +31,7 @@ parameters:
   parent_id:
     default: ""
     description: Set the ID of the parent Domain/project. Leave as blank and it will use the "Default Domain"
-    type: str
+    type: string
   admin_user_list:
     required: false
     default: null

--- a/actions/workflow.project.create.external.yaml
+++ b/actions/workflow.project.create.external.yaml
@@ -28,6 +28,10 @@ parameters:
     default: false
     description: Project is immutable or not
     type: boolean
+  parent_id:
+    default: ""
+    description: Set the ID of the parent Domain/project. Leave as blank and it will use the "Default Domain"
+    type: str
   admin_user_list:
     required: false
     default: null

--- a/actions/workflow.project.create.internal.yaml
+++ b/actions/workflow.project.create.internal.yaml
@@ -28,6 +28,10 @@ parameters:
     default: false
     description: Project is immutable or not
     type: boolean
+  parent_id:
+    default: ""
+    description: Set the ID of the parent Domain/project. Leave as blank and it will use the "Default Domain"
+    type: str
   admin_user_list:
     required: false
     default: []

--- a/actions/workflow.project.create.internal.yaml
+++ b/actions/workflow.project.create.internal.yaml
@@ -31,7 +31,7 @@ parameters:
   parent_id:
     default: ""
     description: Set the ID of the parent Domain/project. Leave as blank and it will use the "Default Domain"
-    type: str
+    type: string
   admin_user_list:
     required: false
     default: []

--- a/actions/workflows/project.create.external.yaml
+++ b/actions/workflows/project.create.external.yaml
@@ -9,6 +9,7 @@ input:
   - project_email
   - project_description
   - project_immutable
+  - parent_id
   - admin_user_list
   - stfc_user_list
 
@@ -46,6 +47,7 @@ tasks:
       project_email=<% ctx().project_email %>
       project_description=<% ctx().project_description %>
       project_immutable=<% ctx().project_immutable %>
+      parent_id=<% ctx().parent_id %>
       admin_user_list=<% ctx().admin_user_list %>
       stfc_user_list=<% ctx().stfc_user_list %>
       network_name="External"

--- a/actions/workflows/project.create.internal.yaml
+++ b/actions/workflows/project.create.internal.yaml
@@ -8,6 +8,7 @@ input:
   - project_email
   - project_description
   - project_immutable
+  - parent_id
   - admin_user_list
   - stfc_user_list
   - network_name: "Internal"
@@ -24,6 +25,7 @@ tasks:
       email=<% ctx().project_email %>
       description=<% ctx().project_description %>
       immutable=<% ctx().project_immutable %>
+      parent_id=<% ctx().parent_id %>
     next:
       - when: <% succeeded() %>
         publish:

--- a/lib/openstack_api/openstack_identity.py
+++ b/lib/openstack_api/openstack_identity.py
@@ -29,18 +29,22 @@ class OpenstackIdentity(OpenstackWrapperBase):
         if "@" not in project_details.email:
             raise ValueError("The project contact email is invalid")
 
+        create_project_kwargs = {
+            "name": project_details.name,
+            "description": project_details.description,
+            "is_enabled": project_details.is_enabled,
+        }
+        if project_details.parent_id:
+            create_project_kwargs["parent_id"] = project_details.parent_id
+
         tags = [project_details.email]
         if project_details.immutable:
             tags.append("immutable")
+        create_project_kwargs["tags"] = tags
 
         with self._connection_cls(cloud_account) as conn:
             try:
-                return conn.identity.create_project(
-                    name=project_details.name,
-                    description=project_details.description,
-                    is_enabled=project_details.is_enabled,
-                    tags=tags,
-                )
+                return conn.identity.create_project(**create_project_kwargs)
             except ConflictException as err:
                 # Strip out frames that are noise by rethrowing
                 raise ConflictException(err.message) from err

--- a/lib/structs/project_details.py
+++ b/lib/structs/project_details.py
@@ -10,3 +10,4 @@ class ProjectDetails:
     is_enabled: Optional[bool] = None
     openstack_id: Optional[str] = None
     immutable: Optional[bool] = None
+    parent_id: Optional[str] = None

--- a/tests/actions/test_project_actions.py
+++ b/tests/actions/test_project_actions.py
@@ -50,7 +50,7 @@ class TestProjectAction(OpenstackActionTestBase):
         """
         expected_proj_params = {
             i: NonCallableMock()
-            for i in ["name", "description", "is_enabled", "immutable"]
+            for i in ["name", "description", "is_enabled", "immutable", "parent_id"]
         }
         expected_proj_params.update({"email": "Test@Test.com"})
 
@@ -67,15 +67,54 @@ class TestProjectAction(OpenstackActionTestBase):
         assert returned_values[0] is True
         assert returned_values[1] == self.identity_mock.create_project.return_value
 
+    def test_create_project_when_parent_id_blank(self):
+        """
+        Tests that create project forwards the result when successful
+        - when parent_id is blank, it passes parent_id = None
+        """
+        expected_proj_params = {
+            i: NonCallableMock()
+            for i in ["name", "description", "is_enabled", "immutable"]
+        }
+        expected_proj_params["parent_id"] = ""
+
+        expected_proj_params.update({"email": "Test@Test.com"})
+
+        # Check that default gets hard-coded in too
+        packaged_proj = ProjectDetails(
+            name=expected_proj_params["name"],
+            description=expected_proj_params["description"],
+            is_enabled=expected_proj_params["is_enabled"],
+            immutable=expected_proj_params["immutable"],
+            email="Test@Test.com",
+            parent_id=None,
+        )
+
+        returned_values = self.action.project_create(
+            cloud_account="foo",
+            name=expected_proj_params["name"],
+            description=expected_proj_params["description"],
+            is_enabled=expected_proj_params["is_enabled"],
+            immutable=expected_proj_params["immutable"],
+            email="Test@Test.com",
+            parent_id=None,
+        )
+        self.identity_mock.create_project.assert_called_once_with(
+            cloud_account="foo", project_details=packaged_proj
+        )
+
+        assert returned_values[0] is True
+        assert returned_values[1] == self.identity_mock.create_project.return_value
+
     def test_project_create_when_failed(self):
         """
         Tests that create project returns None and an error
-        when the domain is not found
+        when the cloud domain is not found
         """
         self.identity_mock.create_project.return_value = None
 
         returned_values = self.action.project_create(
-            *{NonCallableMock() for _ in range(6)}
+            *{NonCallableMock() for _ in range(7)}
         )
         assert returned_values[0] is False
         assert returned_values[1] is None


### PR DESCRIPTION
parent_id allows setting a projects parent domain
This can be the id of a domain or another project