### PR TITLE
ENH: add ability to enter string aliases instead of enums

### DIFF
--- a/lib/enums/query/enum_with_aliases.py
+++ b/lib/enums/query/enum_with_aliases.py
@@ -27,7 +27,9 @@ class EnumWithAliases(Enum):
             valid_aliases = cls._get_aliases().get(prop_enum, [])
 
             # if val matches prop_enum.name, then directly return without looking at mappings
-            if val.upper() == prop_enum.name or val.lower() in valid_aliases:
+            if val.casefold() == prop_enum.name.casefold() or any(
+                val.casefold() == i.casefold() for i in valid_aliases
+            ):
                 return prop_enum
         raise ParseQueryError(
             f"Could not parse string alias {val}. "

--- a/lib/enums/query/enum_with_aliases.py
+++ b/lib/enums/query/enum_with_aliases.py
@@ -1,0 +1,36 @@
+from abc import abstractmethod
+from enum import Enum
+from typing import Dict
+
+from exceptions.parse_query_error import ParseQueryError
+
+
+class EnumWithAliases(Enum):
+    """
+    Enum class which stores aliases which can be mapped onto stored enums
+    """
+
+    @staticmethod
+    @abstractmethod
+    def _get_aliases() -> Dict:
+        """
+        A method that returns all valid string aliases for a given property enum
+        """
+
+    @classmethod
+    def from_string(cls, val: str):
+        """
+        A class method that converts string alias to enum
+        :param val: string value that is to be converted to an enum
+        """
+        for prop_enum in cls:
+            valid_aliases = cls._get_aliases().get(prop_enum, [])
+
+            # if val matches prop_enum.name, then directly return without looking at mappings
+            if val.upper() == prop_enum.name or val.lower() in valid_aliases:
+                return prop_enum
+        else:
+            raise ParseQueryError(
+                f"Could not parse string alias {val}. "
+                f"The string alias not valid for any of the following Enums {','.join([prop.name for prop in cls])}"
+            )

--- a/lib/enums/query/enum_with_aliases.py
+++ b/lib/enums/query/enum_with_aliases.py
@@ -29,8 +29,7 @@ class EnumWithAliases(Enum):
             # if val matches prop_enum.name, then directly return without looking at mappings
             if val.upper() == prop_enum.name or val.lower() in valid_aliases:
                 return prop_enum
-        else:
-            raise ParseQueryError(
-                f"Could not parse string alias {val}. "
-                f"The string alias not valid for any of the following Enums {','.join([prop.name for prop in cls])}"
-            )
+        raise ParseQueryError(
+            f"Could not parse string alias {val}. "
+            f"The string alias not valid for any of the following Enums {','.join([prop.name for prop in cls])}"
+        )

--- a/lib/enums/query/props/flavor_properties.py
+++ b/lib/enums/query/props/flavor_properties.py
@@ -38,7 +38,7 @@ class FlavorProperties(PropEnum):
             FlavorProperties.FLAVOR_NAME: ["name"],
             FlavorProperties.FLAVOR_RAM: ["ram", "ram_size"],
             FlavorProperties.FLAVOR_SWAP: ["swap", "swap_size"],
-            FlavorProperties.FLAVOR_VCPU: ["vcpu", "vcpus", "vcpu_num"],
+            FlavorProperties.FLAVOR_VCPU: ["vcpu", "vcpus"],
         }
 
     @staticmethod

--- a/lib/enums/query/props/flavor_properties.py
+++ b/lib/enums/query/props/flavor_properties.py
@@ -1,6 +1,5 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
 
@@ -21,17 +20,26 @@ class FlavorProperties(PropEnum):
     FLAVOR_VCPU = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return FlavorProperties[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find Flavor Property {val}. "
-                f"Available properties are {','.join([prop.name for prop in FlavorProperties])}"
-            ) from err
+        return {
+            FlavorProperties.FLAVOR_DESCRIPTION: ["description", "desc"],
+            FlavorProperties.FLAVOR_DISK: ["disk", "disk_size"],
+            FlavorProperties.FLAVOR_EPHEMERAL: [
+                "ephemeral",
+                "ephemeral_disk",
+                "ephemeral_disk_size",
+            ],
+            FlavorProperties.FLAVOR_ID: ["id", "uuid"],
+            FlavorProperties.FLAVOR_IS_DISABLED: ["is_disabled"],
+            FlavorProperties.FLAVOR_IS_PUBLIC: ["is_public"],
+            FlavorProperties.FLAVOR_NAME: ["name"],
+            FlavorProperties.FLAVOR_RAM: ["ram", "ram_size"],
+            FlavorProperties.FLAVOR_SWAP: ["swap", "swap_size"],
+            FlavorProperties.FLAVOR_VCPU: ["vcpu", "vcpus", "vcpu_num"],
+        }
 
     @staticmethod
     def get_prop_mapping(prop):

--- a/lib/enums/query/props/project_properties.py
+++ b/lib/enums/query/props/project_properties.py
@@ -1,6 +1,5 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
 
@@ -18,17 +17,19 @@ class ProjectProperties(PropEnum):
     PROJECT_PARENT_ID = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return ProjectProperties[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find Server Property {val}. "
-                f"Available properties are {','.join([prop.name for prop in ProjectProperties])}"
-            ) from err
+        return {
+            ProjectProperties.PROJECT_DESCRIPTION: ["description", "desc"],
+            ProjectProperties.PROJECT_DOMAIN_ID: ["domain_id"],
+            ProjectProperties.PROJECT_ID: ["id", "uuid"],
+            ProjectProperties.PROJECT_IS_DOMAIN: ["is_domain"],
+            ProjectProperties.PROJECT_IS_ENABLED: ["is_enabled"],
+            ProjectProperties.PROJECT_NAME: ["name"],
+            ProjectProperties.PROJECT_PARENT_ID: ["parent_id"],
+        }
 
     @staticmethod
     def get_prop_mapping(prop):

--- a/lib/enums/query/props/prop_enum.py
+++ b/lib/enums/query/props/prop_enum.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
-from enum import Enum
 from typing import Callable, Any, Optional
+
+from enums.query.enum_with_aliases import EnumWithAliases
 
 PropFunc = Callable[[Any], Any]
 
 
-class PropEnum(Enum):
+class PropEnum(EnumWithAliases):
     """
     An enum base class for all openstack resource properties - for type annotation purposes
     """
@@ -23,11 +24,4 @@ class PropEnum(Enum):
     def get_marker_prop_func():
         """
         A getter method to return marker property function for pagination
-        """
-
-    @staticmethod
-    @abstractmethod
-    def from_string(val: str):
-        """
-        A method that converts string alias to enum
         """

--- a/lib/enums/query/props/prop_enum.py
+++ b/lib/enums/query/props/prop_enum.py
@@ -24,3 +24,10 @@ class PropEnum(Enum):
         """
         A getter method to return marker property function for pagination
         """
+
+    @staticmethod
+    @abstractmethod
+    def from_string(val: str):
+        """
+        A method that converts string alias to enum
+        """

--- a/lib/enums/query/props/server_properties.py
+++ b/lib/enums/query/props/server_properties.py
@@ -1,6 +1,5 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
 
@@ -23,17 +22,24 @@ class ServerProperties(PropEnum):
     ADDRESSES = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return ServerProperties[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find Server Property {val}. "
-                f"Available properties are {','.join([prop.name for prop in ServerProperties])}"
-            ) from err
+        return {
+            ServerProperties.HYPERVISOR_ID: ["host_id", "hv_id"],
+            ServerProperties.SERVER_CREATION_DATE: ["created_at"],
+            ServerProperties.SERVER_DESCRIPTION: [
+                "description",
+                "desc",
+                "vm_description",
+            ],
+            ServerProperties.SERVER_ID: ["vm_id", "id", "uuid"],
+            ServerProperties.SERVER_LAST_UPDATED_DATE: ["updated_at"],
+            ServerProperties.SERVER_NAME: ["vm_name", "name"],
+            ServerProperties.SERVER_STATUS: ["status", "vm_status"],
+            ServerProperties.ADDRESSES: ["ips", "vm_ips", "server_ips"],
+        }
 
     @staticmethod
     def get_prop_mapping(prop):

--- a/lib/enums/query/props/user_properties.py
+++ b/lib/enums/query/props/user_properties.py
@@ -1,6 +1,5 @@
 from enum import auto
 from enums.query.props.prop_enum import PropEnum
-from exceptions.parse_query_error import ParseQueryError
 from exceptions.query_property_mapping_error import QueryPropertyMappingError
 
 
@@ -16,17 +15,22 @@ class UserProperties(PropEnum):
     USER_NAME = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return UserProperties[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find User Property {val}. "
-                f"Available properties are {','.join([prop.name for prop in UserProperties])}"
-            ) from err
+        return {
+            UserProperties.USER_DOMAIN_ID: ["domain_id"],
+            UserProperties.USER_DESCRIPTION: ["description", "desc"],
+            UserProperties.USER_EMAIL: [
+                "email",
+                "email_addr",
+                "email_address",
+                "user_email_address",
+            ],
+            UserProperties.USER_ID: ["id", "uuid"],
+            UserProperties.USER_NAME: ["name", "username"],
+        }
 
     @staticmethod
     def get_prop_mapping(prop):

--- a/lib/enums/query/query_presets.py
+++ b/lib/enums/query/query_presets.py
@@ -2,6 +2,8 @@ from enum import auto
 from enums.query.enum_with_aliases import EnumWithAliases
 from exceptions.parse_query_error import ParseQueryError
 
+# pylint: disable=too-few-public-methods
+
 
 class QueryPresets(EnumWithAliases):
     @staticmethod

--- a/lib/enums/query/query_presets.py
+++ b/lib/enums/query/query_presets.py
@@ -97,3 +97,21 @@ class QueryPresetsString(QueryPresets):
                 f"Could not find preset type {val}. "
                 f"Available preset types are {','.join([prop.name for prop in QueryPresetsString])}"
             ) from err
+
+
+def get_preset_from_string(val: str):
+    """
+    function that takes a string and returns a preset Enum if that string is an alias for that preset
+    :param val: a string alias to convert
+    """
+    for preset_cls in [
+        QueryPresetsGeneric,
+        QueryPresetsString,
+        QueryPresetsDateTime,
+        QueryPresetsInteger,
+    ]:
+        try:
+            return preset_cls.from_string(val)
+        except ParseQueryError:
+            continue
+    raise ParseQueryError(f"Could not find preset that matches alias {val}.")

--- a/lib/enums/query/query_presets.py
+++ b/lib/enums/query/query_presets.py
@@ -1,9 +1,12 @@
-from enum import Enum, auto
+from enum import auto
+from enums.query.enum_with_aliases import EnumWithAliases
 from exceptions.parse_query_error import ParseQueryError
 
 
-class QueryPresets(Enum):
-    pass
+class QueryPresets(EnumWithAliases):
+    @staticmethod
+    def _get_aliases():
+        pass
 
 
 class QueryPresetsGeneric(QueryPresets):
@@ -17,17 +20,16 @@ class QueryPresetsGeneric(QueryPresets):
     NOT_ANY_IN = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return QueryPresetsGeneric[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find preset type {val}. "
-                f"Available preset types are {','.join([prop.name for prop in QueryPresetsGeneric])}"
-            ) from err
+        return {
+            QueryPresetsGeneric.EQUAL_TO: ["equal", "=="],
+            QueryPresetsGeneric.NOT_EQUAL_TO: ["not_equal", "!="],
+            QueryPresetsGeneric.ANY_IN: ["in"],
+            QueryPresetsGeneric.NOT_ANY_IN: ["not_in"],
+        }
 
 
 class QueryPresetsInteger(QueryPresets):
@@ -41,17 +43,11 @@ class QueryPresetsInteger(QueryPresets):
     LESS_THAN_OR_EQUAL_TO = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return QueryPresetsInteger[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find preset type {val}. "
-                f"Available preset types are {','.join([prop.name for prop in QueryPresetsInteger])}"
-            ) from err
+        return {}
 
 
 class QueryPresetsDateTime(QueryPresets):
@@ -65,17 +61,11 @@ class QueryPresetsDateTime(QueryPresets):
     YOUNGER_THAN_OR_EQUAL_TO = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return QueryPresetsDateTime[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find preset type {val}. "
-                f"Available preset types are {','.join([prop.name for prop in QueryPresetsDateTime])}"
-            ) from err
+        return {}
 
 
 class QueryPresetsString(QueryPresets):
@@ -86,17 +76,11 @@ class QueryPresetsString(QueryPresets):
     MATCHES_REGEX = auto()
 
     @staticmethod
-    def from_string(val: str):
+    def _get_aliases():
         """
-        Converts a given string in a case-insensitive way to the enum values
+        A method that returns all valid string alias mappings
         """
-        try:
-            return QueryPresetsString[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find preset type {val}. "
-                f"Available preset types are {','.join([prop.name for prop in QueryPresetsString])}"
-            ) from err
+        return {QueryPresetsString.MATCHES_REGEX: ["regex", "match_regex"]}
 
 
 def get_preset_from_string(val: str):

--- a/lib/enums/query/query_presets.py
+++ b/lib/enums/query/query_presets.py
@@ -1,3 +1,4 @@
+from typing import Union
 from enum import auto
 from enums.query.enum_with_aliases import EnumWithAliases
 from exceptions.parse_query_error import ParseQueryError
@@ -5,13 +6,7 @@ from exceptions.parse_query_error import ParseQueryError
 # pylint: disable=too-few-public-methods
 
 
-class QueryPresets(EnumWithAliases):
-    @staticmethod
-    def _get_aliases():
-        pass
-
-
-class QueryPresetsGeneric(QueryPresets):
+class QueryPresetsGeneric(EnumWithAliases):
     """
     Enum class which holds generic query comparison operators
     """
@@ -34,7 +29,7 @@ class QueryPresetsGeneric(QueryPresets):
         }
 
 
-class QueryPresetsInteger(QueryPresets):
+class QueryPresetsInteger(EnumWithAliases):
     """
     Enum class which holds integer/float comparison operators
     """
@@ -52,7 +47,7 @@ class QueryPresetsInteger(QueryPresets):
         return {}
 
 
-class QueryPresetsDateTime(QueryPresets):
+class QueryPresetsDateTime(EnumWithAliases):
     """
     Enum class which holds datetime comparison operators
     """
@@ -70,7 +65,7 @@ class QueryPresetsDateTime(QueryPresets):
         return {}
 
 
-class QueryPresetsString(QueryPresets):
+class QueryPresetsString(EnumWithAliases):
     """
     Enum class which holds string comparison operators
     """
@@ -101,3 +96,8 @@ def get_preset_from_string(val: str):
         except ParseQueryError:
             continue
     raise ParseQueryError(f"Could not find preset that matches alias {val}.")
+
+
+QueryPresets = Union[
+    QueryPresetsGeneric, QueryPresetsDateTime, QueryPresetsString, QueryPresetsInteger
+]

--- a/lib/enums/query/query_types.py
+++ b/lib/enums/query/query_types.py
@@ -7,6 +7,8 @@ from openstack_query.mappings.project_mapping import ProjectMapping
 from openstack_query.mappings.server_mapping import ServerMapping
 from openstack_query.mappings.user_mapping import UserMapping
 
+# pylint: disable=too-few-public-methods
+
 
 class QueryTypes(EnumWithAliases):
     """

--- a/lib/enums/query/query_types.py
+++ b/lib/enums/query/query_types.py
@@ -1,5 +1,6 @@
-from enum import Enum
-from exceptions.parse_query_error import ParseQueryError
+from typing import Dict
+
+from enums.query.enum_with_aliases import EnumWithAliases
 
 from openstack_query.mappings.flavor_mapping import FlavorMapping
 from openstack_query.mappings.project_mapping import ProjectMapping
@@ -7,7 +8,7 @@ from openstack_query.mappings.server_mapping import ServerMapping
 from openstack_query.mappings.user_mapping import UserMapping
 
 
-class QueryTypes(Enum):
+class QueryTypes(EnumWithAliases):
     """
     Enum class which holds enums for different query objects. Used when
     specifying queries to chain to
@@ -19,14 +20,25 @@ class QueryTypes(Enum):
     USER_QUERY = UserMapping
 
     @staticmethod
-    def from_string(val: str):
-        """
-        Converts a given string in a case-insensitive way to the enum values
-        """
-        try:
-            return QueryTypes[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find query type {val}. "
-                f"Available query types are {','.join([prop.name for prop in QueryTypes])}"
-            ) from err
+    def _get_aliases() -> Dict:
+        return {
+            QueryTypes.FLAVOR_QUERY: [
+                "flavor",
+                "flavors",
+                "query_flavors",
+                "to_flavor_query",
+            ],
+            QueryTypes.PROJECT_QUERY: [
+                "project",
+                "projects",
+                "query_projects",
+                "to_project_query",
+            ],
+            QueryTypes.SERVER_QUERY: [
+                "server",
+                "servers",
+                "query_servers",
+                "to_server_query",
+            ],
+            QueryTypes.USER_QUERY: ["user", "users", "query_users", "to_user_query"],
+        }

--- a/lib/enums/query/query_types.py
+++ b/lib/enums/query/query_types.py
@@ -27,20 +27,14 @@ class QueryTypes(EnumWithAliases):
             QueryTypes.FLAVOR_QUERY: [
                 "flavor",
                 "flavors",
-                "query_flavors",
-                "to_flavor_query",
             ],
             QueryTypes.PROJECT_QUERY: [
                 "project",
                 "projects",
-                "query_projects",
-                "to_project_query",
             ],
             QueryTypes.SERVER_QUERY: [
                 "server",
                 "servers",
-                "query_servers",
-                "to_server_query",
             ],
-            QueryTypes.USER_QUERY: ["user", "users", "query_users", "to_user_query"],
+            QueryTypes.USER_QUERY: ["user", "users"],
         }

--- a/lib/enums/query/sort_order.py
+++ b/lib/enums/query/sort_order.py
@@ -1,6 +1,8 @@
 from typing import Dict
 from enums.query.enum_with_aliases import EnumWithAliases
 
+# pylint: disable=too-few-public-methods
+
 
 class SortOrder(EnumWithAliases):
     """

--- a/lib/enums/query/sort_order.py
+++ b/lib/enums/query/sort_order.py
@@ -1,8 +1,8 @@
-from enum import Enum
-from exceptions.parse_query_error import ParseQueryError
+from typing import Dict
+from enums.query.enum_with_aliases import EnumWithAliases
 
 
-class SortOrder(Enum):
+class SortOrder(EnumWithAliases):
     """
     Enum class which holds enums for sort order. Used to specify sort order when
     querying and parsing query using sort_by
@@ -12,16 +12,8 @@ class SortOrder(Enum):
     DESC = True
 
     @staticmethod
-    def from_string(val: str):
-        """
-        Converts a given string in a case-insensitive way to the enum values
-        """
-        if val.upper() in ["ASC", "ASCENDING"]:
-            return SortOrder["ASC"]
-        if val.upper() in ["DESCENDING", "DESC"]:
-            return SortOrder["DESC"]
-
-        raise ParseQueryError(
-            f"Could not find convert {val} into a sort order enum. "
-            f"Available orders are {','.join([order.name for order in SortOrder])}"
-        )
+    def _get_aliases() -> Dict:
+        return {
+            SortOrder.ASC: ["ascending"],
+            SortOrder.DESC: ["descending"],
+        }

--- a/lib/enums/query/sort_order.py
+++ b/lib/enums/query/sort_order.py
@@ -16,10 +16,12 @@ class SortOrder(Enum):
         """
         Converts a given string in a case-insensitive way to the enum values
         """
-        try:
-            return SortOrder[val.upper()]
-        except KeyError as err:
-            raise ParseQueryError(
-                f"Could not find convert {val} into a sort order enum. "
-                f"Available orders are {','.join([order.name for order in SortOrder])}"
-            ) from err
+        if val.upper() in ["ASC", "ASCENDING"]:
+            return SortOrder["ASC"]
+        if val.upper() in ["DESCENDING", "DESC"]:
+            return SortOrder["DESC"]
+
+        raise ParseQueryError(
+            f"Could not find convert {val} into a sort order enum. "
+            f"Available orders are {','.join([order.name for order in SortOrder])}"
+        )

--- a/lib/enums/query/sort_order.py
+++ b/lib/enums/query/sort_order.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from exceptions.parse_query_error import ParseQueryError
 
 
 class SortOrder(Enum):
@@ -9,3 +10,16 @@ class SortOrder(Enum):
 
     ASC = False
     DESC = True
+
+    @staticmethod
+    def from_string(val: str):
+        """
+        Converts a given string in a case-insensitive way to the enum values
+        """
+        try:
+            return SortOrder[val.upper()]
+        except KeyError as err:
+            raise ParseQueryError(
+                f"Could not find convert {val} into a sort order enum. "
+                f"Available orders are {','.join([order.name for order in SortOrder])}"
+            ) from err

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -27,16 +27,15 @@ class QueryAPI:
         self.chainer = query_components.chainer
         self.results_container = None
 
-    def select(self, *props: PropEnum):
+    def select(self, *props: Union[str, PropEnum]):
         """
         Public method used to 'select' properties that the query will return the value of.
         Mutually exclusive to returning objects using select_all()
-        :param props: one or more properties to collect described as enum
+        :param props: one or more properties to collect described as enum or a string that can convert to enum
         """
 
         # is an idempotent function
-        # an be called multiple times with should aggregate properties to select
-        logger.debug("select() called, with props: %s", [prop.name for prop in props])
+        # can be called multiple times with should aggregate properties to select
         if not props:
             raise ParseQueryError("provide at least one property to select")
 
@@ -55,7 +54,6 @@ class QueryAPI:
         Overrides all currently selected properties
         returns list of properties currently selected
         """
-        logger.debug("select_all() called - getting all properties")
         self.output.parse_select(select_all=True)
         logger.debug(
             "selected props are now: %s",
@@ -63,30 +61,16 @@ class QueryAPI:
         )
         return self
 
-    def where(self, preset: QueryPresets, prop: PropEnum, **kwargs):
+    def where(
+        self, preset: Union[str, QueryPresets], prop: Union[str, PropEnum], **kwargs
+    ):
         """
         Public method used to set the conditions for the query.
-        :param preset: QueryPreset Enum to use
-        :param prop: Property Enum that the query preset will be used on
+        :param preset: QueryPreset Enum or string alias to use
+        :param prop: Property Enum or string alias that the query preset will be used on
         :param kwargs: a set of optional arguments to pass along with the preset - property pair
             - these kwargs are dependent on the preset given
         """
-        kwargs_log_str = "<none>"
-        if kwargs:
-            kwargs_log_str = "\n\t\t".join(
-                [f"{key}: '{arg}'" for key, arg in kwargs.items()]
-            )
-
-        logger.debug(
-            "where() called, with args:"
-            "\n\t preset: %s"
-            "\n\t prop: %s"
-            "\n\t preset-args:\n\t\t%s",
-            preset.name,
-            prop.name,
-            kwargs_log_str,
-        )
-
         self.builder.parse_where(preset, prop, kwargs)
         return self
 
@@ -101,13 +85,13 @@ class QueryAPI:
 
     def group_by(
         self,
-        group_by: PropEnum,
+        group_by: Union[PropEnum, str],
         group_ranges: Optional[Dict[str, List[PropValue]]] = None,
         include_ungrouped_results: bool = False,
     ):
         """
         Public method used to configure how to group results.
-        :param group_by: name of the property to group by
+        :param group_by: Enum or string alias of the property to group by
         :param group_ranges: a set of optional group mappings - group name to list of values of
         selected group by property to be included in each group
         :param include_ungrouped_results: an optional flag to include a "ungrouped" group to the

--- a/lib/openstack_query/docs/developer_docs/ADDING_ALIASES.md
+++ b/lib/openstack_query/docs/developer_docs/ADDING_ALIASES.md
@@ -1,0 +1,42 @@
+# Aliases
+
+There are several Enums that represent different values that the user can provide as input.
+
+These include:
+
+1. Property Enums
+   - which define the properties that can be extracted from an Openstack item
+2. Preset Enums
+   - which defines the query logic to use when calling `where`
+3. Query Enum
+   - which map to the different queries the library supports. Used when mapping one query to another like
+   when calling `then` or `append_from`
+
+## Adding an Alias
+
+Aliases are optional, We don't need to include an alias for every Enum value, only where it makes sense to do so.
+
+To add an alias, first find the specific Enum that contains the value you want to add an alias for.
+
+This class should have a method called `_get_aliases`.
+
+Edit this class to add a case for your alias. e.g:
+```python
+class ServerProperties(PropEnum):
+    ...
+    @staticmethod
+    def _get_aliases():
+        return {
+            ...
+            # adding "new_alias" as an alias which maps to server name
+            ServerProperties.SERVER_NAME: ["vm_name", "name", "new_alias"]
+        }
+```
+
+Your alias must be:
+1. Unique - no other enum for that class must share that enum
+2. Lowercase - so that we can compare in case-insensitive way
+3. Intuitive - so it's easy to use
+
+**NOTE:** You don't need to include the alias that matches the enum name exactly (case-insensitive) - in such cases
+they will automatically be mapped over.

--- a/lib/openstack_query/docs/developer_docs/ADDING_NEW_PRESETS.md
+++ b/lib/openstack_query/docs/developer_docs/ADDING_NEW_PRESETS.md
@@ -144,3 +144,6 @@ group - you can add one like so:
 
 
 4. Follow steps mentioned above to add new presets to the new preset group class you've created
+
+5. Edit `QueryPresets` type declaration at the bottom of the file `/lib/enums/query/query_presets.py` and add your new
+preset ffclass to it

--- a/lib/openstack_query/docs/developer_docs/ADDING_NEW_PRESETS.md
+++ b/lib/openstack_query/docs/developer_docs/ADDING_NEW_PRESETS.md
@@ -14,6 +14,8 @@ class QueryPresetsGeneric(QueryPresets):
     NEW_PRESET = auto() # <- we add this line to repesent a new preset enum belonging to the 'Generic' group
 ```
 
+(Optional) Add alias mappings for the preset - see [Adding Aliases](ADDING_ALIASES.md)
+
 ## **2. Edit the corresponding handler class in `/lib/openstack_query/handlers/client_side_handler_<preset-group>.py`.**
 
 Here you must:

--- a/lib/openstack_query/docs/developer_docs/ADDING_NEW_QUERIES.md
+++ b/lib/openstack_query/docs/developer_docs/ADDING_NEW_QUERIES.md
@@ -42,6 +42,8 @@ class ResourceProperties(PropEnum):
         return ResourceProperties.get_prop_mapping(ResourceProperties.PROP_1)
 ```
 
+(Optional) Add alias mappings for each property - see [Adding Aliases](ADDING_ALIASES.md)
+
 ## 2. Create a Runner Class
 A new subclass of the `RunnerWrapper` class is required to store how to actually run the query using openstacksdk. It
 will also be the place where we can define extra parameters that can be used to fine-tune the query.
@@ -117,6 +119,8 @@ To add a Mapping Class:
 1. Create a new file under `/openstack_query/mappings/` called `<resource>_mapping.py` replace `<resource>` with openstack resource name you want to query
 2.  Create the `<resource>Mapping` class definition
    - class must inherit from `MappingInterface` abstract base class and implement abstract methods.
+3. Update the enum holding query types `/enums/query/query_types.py` and add a Enum mapping to this Mapping class.
+4. (Optional) Add alias mappings for the query type - see [Adding Aliases](ADDING_ALIASES.md)
 
 ### 3a. Set the Prop Enum class
 

--- a/lib/openstack_query/docs/developer_docs/OVERVIEW.md
+++ b/lib/openstack_query/docs/developer_docs/OVERVIEW.md
@@ -3,6 +3,7 @@
 ## Workflow Links
 - #### [Adding a new Query Feature](ADDING_NEW_QUERIES.md)
 - #### [Adding a new Preset](ADDING_NEW_PRESETS.md)
+- #### [Adding an Alias](ADDING_ALIASES.md)
 - #### [Other smaller workflows](OTHER_WORKFLOWS.md)
 
 ## Other Links

--- a/lib/openstack_query/docs/user_docs/PRESETS.md
+++ b/lib/openstack_query/docs/user_docs/PRESETS.md
@@ -38,42 +38,42 @@ Alternatively, you can also pass string aliases instead of a preset Enum (see re
 ## QueryPresetsGeneric
 QueryPresetsGeneric has the following presets:
 
-| Preset       | Aliases        | Description                                                                          | Extra Parameters                                              |
-|--------------|----------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| ANY_IN       | "ANY_IN"       | Finds objects which have a property matching any of a given set of values            | `values: List` - a list of property values to compare against |
-| NOT_ANY_IN   | "NOT_ANY_IN"   | Finds objects which have a property that does not match any of a given set of values | `values: List` - a list of property values to compare against |
-| EQUAL_TO     | "EQUAL_TO"     | Finds objects which have a property matching a given value                           | `value` - a single value to compare against                   |
-| NOT_EQUAL_TO | "NOT_EQUAL_TO" | Finds objects which have a property that does not match a given value                | `value` - a single value to compare against                   |
+| Preset       | Aliases           | Description                                                                          | Extra Parameters                                              |
+|--------------|-------------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| ANY_IN       | "in"              | Finds objects which have a property matching any of a given set of values            | `values: List` - a list of property values to compare against |
+| NOT_ANY_IN   | "not in"          | Finds objects which have a property that does not match any of a given set of values | `values: List` - a list of property values to compare against |
+| EQUAL_TO     | "equal", "=="     | Finds objects which have a property matching a given value                           | `value` - a single value to compare against                   |
+| NOT_EQUAL_TO | "not equal", "!=" | Finds objects which have a property that does not match a given value                | `value` - a single value to compare against                   |
 
 
 ## QueryPresetsString
 QueryPresetsString has the following presets:
 
-| Preset        | Aliases         | Description                                                      | Extra Parameters                                                    |
-|---------------|-----------------|------------------------------------------------------------------|---------------------------------------------------------------------|
-| MATCHES_REGEX | "MATCHES_REGEX" | Finds objects which have a property that matches a regex pattern | `value: str` - a string which can be converted into a regex pattern |
+| Preset        | Aliases                | Description                                                      | Extra Parameters                                                    |
+|---------------|------------------------|------------------------------------------------------------------|---------------------------------------------------------------------|
+| MATCHES_REGEX | "regex", "match_regex" | Finds objects which have a property that matches a regex pattern | `value: str` - a string which can be converted into a regex pattern |
 
 
 ## QueryPresetsInteger
 QueryPresetsInteger has the following presets:
 
-| Preset                   | Aliases                    | Description                                                                             | Extra Parameters                                                              |
-|--------------------------|----------------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| GREATER_THAN             | "GREATER_THAN"             | Finds objects which have an integer/float property greater than a threshold             | `value: Union[int, float]` - an integer or float threshold to compare against |
-| LESS_THAN                | "LESS_THAN"                | Finds objects which have an integer/float property less than a threshold                | `value: Union[int, float]` - an integer or float threshold to compare against |
-| GREATER_THAN_OR_EQUAL_TO | "GREATER_THAN_OR_EQUAL_TO" | Finds objects which have an integer/float property greater than or equal to a threshold | `value: Union[int, float]` - an integer or float threshold to compare against |
-| LESS_THAN_OR_EQUAL_TO    | "LESS_THAN_OR_EQUAL_TO"    | Finds objects which have an integer/float property less than or equal to a threshold    | `value: Union[int, float]` - an integer or float threshold to compare against |
+| Preset                   | Aliases | Description                                                                             | Extra Parameters                                                              |
+|--------------------------|---------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| GREATER_THAN             | `None`  | Finds objects which have an integer/float property greater than a threshold             | `value: Union[int, float]` - an integer or float threshold to compare against |
+| LESS_THAN                | `None`  | Finds objects which have an integer/float property less than a threshold                | `value: Union[int, float]` - an integer or float threshold to compare against |
+| GREATER_THAN_OR_EQUAL_TO | `None`  | Finds objects which have an integer/float property greater than or equal to a threshold | `value: Union[int, float]` - an integer or float threshold to compare against |
+| LESS_THAN_OR_EQUAL_TO    | `None`   | Finds objects which have an integer/float property less than or equal to a threshold    | `value: Union[int, float]` - an integer or float threshold to compare against |
 
 
 ## QueryPresetsDateTime
 QueryPresetsDateTime has the following presets:
 
-| Preset                   | Aliases                    | Description                                                                                            | Extra Parameters |
-|--------------------------|----------------------------|--------------------------------------------------------------------------------------------------------|------------------|
-| OLDER_THAN               | "OLDER_THAN"               | Finds objects which have an datetime property older than a given relative time threshold               | see below        |
-| YOUNGER_THAN             | "YOUNGER_THAN"             | Finds objects which have an datetime property younger than a given relative time threshold             | see below        |
-| OLDER_THAN_OR_EQUAL_TO   | "OLDER_THAN_OR_EQUAL_TO"   | Finds objects which have an datetime property older than or equal to a given relative time threshold   | see below        |
-| YOUNGER_THAN_OR_EQUAL_TO | "YOUNGER_THAN_OR_EQUAL_TO" | Finds objects which have an datetime property younger than or equal to a given relative time threshold | see below        |
+| Preset                   | Aliases | Description                                                                                            | Extra Parameters |
+|--------------------------|---------|--------------------------------------------------------------------------------------------------------|------------------|
+| OLDER_THAN               | `None`  | Finds objects which have an datetime property older than a given relative time threshold               | see below        |
+| YOUNGER_THAN             | `None`  | Finds objects which have an datetime property younger than a given relative time threshold             | see below        |
+| OLDER_THAN_OR_EQUAL_TO   | `None`  | Finds objects which have an datetime property older than or equal to a given relative time threshold   | see below        |
+| YOUNGER_THAN_OR_EQUAL_TO | `None`  | Finds objects which have an datetime property younger than or equal to a given relative time threshold | see below        |
 
 ### Extra Parameters
 - `days: int` - (Optional) relative number of days since current time to compare against

--- a/lib/openstack_query/docs/user_docs/USAGE.md
+++ b/lib/openstack_query/docs/user_docs/USAGE.md
@@ -180,3 +180,32 @@ group_keys = {
 #   - all other VMs will be ignored
 query.group_by(ServerProperties.PROJECT_ID, group_keys=group_keys)
 ```
+
+### Note About Aliases
+
+All these examples use Enums as inputs to various API methods.
+
+Any API methods that take Enums as input can also accept strings that are known as string aliases.
+These aliases will be converted to a specific Enum implicitly.
+
+The point of aliases is to be intuitive, and won't require you to learn the specific syntax of the query library.
+To see which aliases are available:
+
+1. For Preset aliases for use with `where()` see [Presets.md](PRESETS.md)
+2. For Property aliases for use with `select()`, `where()` and others, see the specific page in [query_docs](query_docs)
+3. For Query aliases for use with `then()`, append_from()`, see the specific page in [query_docs](query_docs)
+4. For other aliases, see API method reference in [API.md](API.md)
+
+**NOTE**: passing a string alias that exactly matches the enum will always be accepted. E.g:
+
+```python
+query.select(ServerProperties.SERVER_ID)
+
+# is equivalent to
+query.select("server_id")
+
+# both are equivalent to using aliases like:
+query.select("id")
+# or
+query.select("uuid")
+```

--- a/lib/openstack_query/docs/user_docs/query_docs/FLAVORS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/FLAVORS.md
@@ -47,9 +47,9 @@ This applies to API calls `then` and `append_from` - see [API.md](../API.md) for
 ## Query Alias
 The aliases that can be used for the query when chaining are listed below:
 
-| Query Enum              | Aliases (case-insensitive                               |
-|-------------------------|---------------------------------------------------------|
-| QueryTypes.FLAVOR_QUERY | "flavor", "flavors", "query_flavors", "to_flavor_query" |
+| Query Enum              | Aliases (case-insensitive |
+|-------------------------|---------------------------|
+| QueryTypes.FLAVOR_QUERY | "flavor", "flavors"       |
 
 
 

--- a/lib/openstack_query/docs/user_docs/query_docs/FLAVORS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/FLAVORS.md
@@ -24,18 +24,18 @@ from enums.query.props.flavor_properties import FlavorProperties
 
 `FlavorProperties` exposes the following properties:
 
-| Property Enum      | Type     | Aliases | Description                                                                                     |
-|--------------------|----------|---------|-------------------------------------------------------------------------------------------------|
-| FLAVOR_DESCRIPTION | `string` | `None`  | The description of the flavor                                                                   |
-| FLAVOR_DISK        | `int`    | `None`  | Size of the disk this flavor offers. Type: int                                                  |
-| FLAVOR_EPHEMERAL   | `int`    | `None`  | Size of the ephemeral data disk attached to this server. Type: int                              |
-| FLAVOR_ID          | `string` | `None`  | Unique ID Openstack has assigned the flavor.                                                    |
-| FLAVOR_IS_DISABLED | `bool`   | `None`  | Indicates whether flavor is disabled. <br/>True if disabled, False if not                       |
-| FLAVOR_IS_PUBLIC   | `bool`   | `None`  | Indicates if flavor is available to all projects. <br/>True if publicly available, False if not |
-| FLAVOR_NAME        | `string` | `None`  | Name of the flavor                                                                              |
-| FLAVOR_RAM         | `int`    | `None`  | The amount of RAM (in MB) this flavor offers. Type: int                                         |
-| FLAVOR_SWAP        | `int`    | `None`  | Size of the swap partitions.                                                                    |
-| FLAVOR_VCPU        | `int`    | `None`  | The number of virtual CPUs this flavor offers. Type: int                                        |
+| Property Enum      | Type     | Aliases (case-insensitive)                           | Description                                                                                     |
+|--------------------|----------|------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| FLAVOR_DESCRIPTION | `string` | "description", "desc"                                | The description of the flavor                                                                   |
+| FLAVOR_DISK        | `int`    | "disk", "disk_size"                                  | Size of the disk this flavor offers. Type: int                                                  |
+| FLAVOR_EPHEMERAL   | `int`    | "ephemeral", "ephemeral_disk", "ephemeral_disk_size" | Size of the ephemeral data disk attached to this server. Type: int                              |
+| FLAVOR_ID          | `string` | "id", "uuid"                                         | Unique ID Openstack has assigned the flavor.                                                    |
+| FLAVOR_IS_DISABLED | `bool`   | "is_disabled"                                        | Indicates whether flavor is disabled. <br/>True if disabled, False if not                       |
+| FLAVOR_IS_PUBLIC   | `bool`   | "is_public"                                          | Indicates if flavor is available to all projects. <br/>True if publicly available, False if not |
+| FLAVOR_NAME        | `string` | "name"                                               | Name of the flavor                                                                              |
+| FLAVOR_RAM         | `int`    | "ram", "ram_size                                     | The amount of RAM (in MB) this flavor offers. Type: int                                         |
+| FLAVOR_SWAP        | `int`    | "swap", "swap_size"                                  | Size of the swap partitions.                                                                    |
+| FLAVOR_VCPU        | `int`    | "vcpu", "vcpus", "vcpu_num"                          | The number of virtual CPUs this flavor offers. Type: int                                        |
 
 Any of these properties can be used for any of the API methods that takes a property - like `select`, `where`, `sort_by` etc
 Alternatively, you can pass property aliases (passed as string) instead (currently WIP)
@@ -43,6 +43,14 @@ Alternatively, you can pass property aliases (passed as string) instead (current
 ## Chaining
 This section details valid mappings you can use to chain onto other queries or from other queries to chain into a `FlavorQuery` object.
 This applies to API calls `then` and `append_from` - see [API.md](../API.md) for details
+
+## Query Alias
+The aliases that can be used for the query when chaining are listed below:
+
+| Query Enum              | Aliases (case-insensitive                               |
+|-------------------------|---------------------------------------------------------|
+| QueryTypes.FLAVOR_QUERY | "flavor", "flavors", "query_flavors", "to_flavor_query" |
+
 
 
 ## Chaining from

--- a/lib/openstack_query/docs/user_docs/query_docs/FLAVORS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/FLAVORS.md
@@ -35,7 +35,7 @@ from enums.query.props.flavor_properties import FlavorProperties
 | FLAVOR_NAME        | `string` | "name"                                               | Name of the flavor                                                                              |
 | FLAVOR_RAM         | `int`    | "ram", "ram_size                                     | The amount of RAM (in MB) this flavor offers. Type: int                                         |
 | FLAVOR_SWAP        | `int`    | "swap", "swap_size"                                  | Size of the swap partitions.                                                                    |
-| FLAVOR_VCPU        | `int`    | "vcpu", "vcpus", "vcpu_num"                          | The number of virtual CPUs this flavor offers. Type: int                                        |
+| FLAVOR_VCPU        | `int`    | "vcpu", "vcpus"                                      | The number of virtual CPUs this flavor offers. Type: int                                        |
 
 Any of these properties can be used for any of the API methods that takes a property - like `select`, `where`, `sort_by` etc
 Alternatively, you can pass property aliases (passed as string) instead (currently WIP)

--- a/lib/openstack_query/docs/user_docs/query_docs/PROJECTS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/PROJECTS.md
@@ -45,9 +45,9 @@ This applies to API calls `then` and `append_from` - see [API.md](../API.md) for
 ## Query Alias
 The aliases that can be used for the query when chaining are listed below:
 
-| Query Enum               | Aliases (case-insensitive                                   |
-|--------------------------|-------------------------------------------------------------|
-| QueryTypes.PROJECT_QUERY | "project", "projects", "query_projects", "to_project_query" |
+| Query Enum               | Aliases (case-insensitive |
+|--------------------------|---------------------------|
+| QueryTypes.PROJECT_QUERY | "project", "projects"     |
 
 
 

--- a/lib/openstack_query/docs/user_docs/query_docs/PROJECTS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/PROJECTS.md
@@ -25,15 +25,15 @@ from enums.query.props.project_properties import ProjectProperties
 `ProjectProperties` exposes the following properties:
 
 
-| Property Enum       | Type     | Aliases | Description                                                                                                                                                        |
-|---------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| PROJECT_DESCRIPTION | `string` | `None`  | The description of the project.                                                                                                                                    |
-| PROJECT_DOMAIN_ID   | `string` | `None`  | The ID of the domain which owns the project.                                                                                                                       |
-| PROJECT_ID          | `string` | `None`  | Unique ID Openstack has assigned the project.                                                                                                                      |
-| PROJECT_IS_DOMAIN   | `bool`   | `None`  | Indicates whether the project also acts as a domain. <br/>If set to True, the project acts as both a project and a domain.                                         |
-| PROJECT_IS_ENABLED  | `bool`   | `None`  | Indicates whether users can authorize against this project. <br/>if set to False, users cannot access project, additionally all authorized tokens are invalidated. |
-| PROJECT_NAME        | `string` | `None`  | Name of the project.                                                                                                                                               |
-| PROJECT_PARENT_ID   | `string` | `None`  | The ID of the parent of the project.                                                                                                                               |
+| Property Enum       | Type     | Aliases               | Description                                                                                                                                                        |
+|---------------------|----------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PROJECT_DESCRIPTION | `string` | "description", "desc" | The description of the project.                                                                                                                                    |
+| PROJECT_DOMAIN_ID   | `string` | "domain_id"           | The ID of the domain which owns the project.                                                                                                                       |
+| PROJECT_ID          | `string` | "project_id"          | Unique ID Openstack has assigned the project.                                                                                                                      |
+| PROJECT_IS_DOMAIN   | `bool`   | "is_domain"           | Indicates whether the project also acts as a domain. <br/>If set to True, the project acts as both a project and a domain.                                         |
+| PROJECT_IS_ENABLED  | `bool`   | "is_enabled"          | Indicates whether users can authorize against this project. <br/>if set to False, users cannot access project, additionally all authorized tokens are invalidated. |
+| PROJECT_NAME        | `string` | "name"                | Name of the project.                                                                                                                                               |
+| PROJECT_PARENT_ID   | `string` | "parent_id"           | The ID of the parent of the project.                                                                                                                               |
 
 Any of these properties can be used for any of the API methods that takes a property - like `select`, `where`, `sort_by` etc
 Alternatively, you can pass property aliases (passed as string) instead (currently WIP)
@@ -41,6 +41,14 @@ Alternatively, you can pass property aliases (passed as string) instead (current
 ## Chaining
 This section details valid mappings you can use to chain onto other queries or from other queries to chain into a `ProjectQuery` object.
 This applies to API calls `then` and `append_from` - see [API.md](../API.md) for details
+
+## Query Alias
+The aliases that can be used for the query when chaining are listed below:
+
+| Query Enum               | Aliases (case-insensitive                                   |
+|--------------------------|-------------------------------------------------------------|
+| QueryTypes.PROJECT_QUERY | "project", "projects", "query_projects", "to_project_query" |
+
 
 
 ## Chaining from

--- a/lib/openstack_query/docs/user_docs/query_docs/SERVERS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/SERVERS.md
@@ -54,9 +54,9 @@ This applies to API calls `then` and `append_from` - see [API.md](../API.md) for
 ## Query Alias
 The aliases that can be used for the query when chaining are listed below:
 
-| Query Enum              | Aliases (case-insensitive                               |
-|-------------------------|---------------------------------------------------------|
-| QueryTypes.SERVER_QUERY | "server", "servers", "query_servers", "to_server_query" |
+| Query Enum              | Aliases (case-insensitive |
+|-------------------------|---------------------------|
+| QueryTypes.SERVER_QUERY | "server", "servers"       |
 
 
 ## Chaining from

--- a/lib/openstack_query/docs/user_docs/query_docs/SERVERS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/SERVERS.md
@@ -27,20 +27,20 @@ from enums.query.props.server_properties import ServerProperties
 
 `ServerProperties` exposes the following properties:
 
-| Property Enum            | Type         | Aliases | Description                                                                                                                                                                                                                                          |
-|--------------------------|--------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| FLAVOR_ID                | `string`     | `None`  | The ID of the Flavor the Server is using                                                                                                                                                                                                             |
-| HYPERVISOR_ID            | `string`     | `None`  | The ID of the Hypervisor the Server is being hosted on                                                                                                                                                                                               |
-| IMAGE_ID                 | `string`     | `None`  | The ID of the Image the Server is using                                                                                                                                                                                                              |
-| PROJECT_ID               | `string`     | `None`  | The ID of the Project the Server is associated with                                                                                                                                                                                                  |
-| SERVER_CREATION_DATE     | `string` (x) | `None`  | Timestamp of when the server was created.                                                                                                                                                                                                            |
-| SERVER_DESCRIPTION       | `string`     | `None`  | User provided description of the server.                                                                                                                                                                                                             |
-| SERVER_ID                | `string`     | `None`  | Unique ID Openstack has assigned the server.                                                                                                                                                                                                         |
-| SERVER_LAST_UPDATED_DATE | `string` (x) | `None`  | Timestamp of when this server was last updated.                                                                                                                                                                                                      |
-| SERVER_NAME              | `string`     | `None`  | User provided name for server                                                                                                                                                                                                                        |
-| SERVER_STATUS            | `string`     | `None`  | The state this server is in. Valid values include <br/>ACTIVE, BUILDING, DELETED, ERROR, HARD_REBOOT, PASSWORD, PAUSED, <br/>REBOOT, REBUILD, RESCUED, RESIZED, REVERT_RESIZE, SHUTOFF, SOFT_DELETED, STOPPED, SUSPENDED, UNKNOWN, or VERIFY_RESIZE. |
-| USER_ID                  | `string`     | `None`  | The ID of the User that owns the server                                                                                                                                                                                                              |
-| ADDRESSES                | `string`     | `None`  | Comma-separated list of IP addresses this server can be accessed through                                                                                                                                                                             |
+| Property Enum            | Type         | Aliases                       | Description                                                                                                                                                                                                                                          |
+|--------------------------|--------------|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| FLAVOR_ID                | `string`     | `None`                        | The ID of the Flavor the Server is using                                                                                                                                                                                                             |
+| HYPERVISOR_ID            | `string`     | `None`                        | The ID of the Hypervisor the Server is being hosted on                                                                                                                                                                                               |
+| IMAGE_ID                 | `string`     | `None`                        | The ID of the Image the Server is using                                                                                                                                                                                                              |
+| PROJECT_ID               | `string`     | `None`                        | The ID of the Project the Server is associated with                                                                                                                                                                                                  |
+| SERVER_CREATION_DATE     | `string` (x) | "created_at"                  | Timestamp of when the server was created.                                                                                                                                                                                                            |
+| SERVER_DESCRIPTION       | `string`     | "description", "desc"         | User provided description of the server.                                                                                                                                                                                                             |
+| SERVER_ID                | `string`     | "id", "uuid"                  | Unique ID Openstack has assigned the server.                                                                                                                                                                                                         |
+| SERVER_LAST_UPDATED_DATE | `string` (x) | "updated_at"                  | Timestamp of when this server was last updated.                                                                                                                                                                                                      |
+| SERVER_NAME              | `string`     | "vm_name", name"              | User provided name for server                                                                                                                                                                                                                        |
+| SERVER_STATUS            | `string`     | "vm_status", "status"         | The state this server is in. Valid values include <br/>ACTIVE, BUILDING, DELETED, ERROR, HARD_REBOOT, PASSWORD, PAUSED, <br/>REBOOT, REBUILD, RESCUED, RESIZED, REVERT_RESIZE, SHUTOFF, SOFT_DELETED, STOPPED, SUSPENDED, UNKNOWN, or VERIFY_RESIZE. |
+| USER_ID                  | `string`     | `None`                        | The ID of the User that owns the server                                                                                                                                                                                                              |
+| ADDRESSES                | `string`     | "ips", "vm_ips", "server_ips" | Comma-separated list of IP addresses this server can be accessed through                                                                                                                                                                             |
 
 (x) - These are UTC timestamps in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format
 
@@ -50,6 +50,13 @@ Alternatively, you can pass property aliases (passed as string) instead (current
 ## Chaining
 This section details valid mappings you can use to chain onto other queries or from other queries to chain into a `ProjectQuery` object.
 This applies to API calls `then` and `append_from` - see [API.md](../API.md) for details
+
+## Query Alias
+The aliases that can be used for the query when chaining are listed below:
+
+| Query Enum              | Aliases (case-insensitive                               |
+|-------------------------|---------------------------------------------------------|
+| QueryTypes.SERVER_QUERY | "server", "servers", "query_servers", "to_server_query" |
 
 
 ## Chaining from

--- a/lib/openstack_query/docs/user_docs/query_docs/USERS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/USERS.md
@@ -25,13 +25,13 @@ from enums.query.props.user_properties import UserProperties
 
 `UserProperties` exposes the following properties:
 
-| Property Enum    | Type     | Aliases | Description                               |
-|------------------|----------|---------|-------------------------------------------|
-| USER_DOMAIN_ID   | `string` | `None`  | The ID for the domain which owns the user |
-| USER_DESCRIPTION | `string` | `None`  | The description of this user.             |
-| USER_EMAIL       | `string` | `None`  | The email address of this user.           |
-| USER_ID          | `string` | `None`  | Unique ID Openstack has assigned the user |
-| USER_NAME        | `string` | `None`  | Unique user name (within the domain)      |
+| Property Enum    | Type     | Aliases                                                      | Description                               |
+|------------------|----------|--------------------------------------------------------------|-------------------------------------------|
+| USER_DOMAIN_ID   | `string` | "domain_id"                                                  | The ID for the domain which owns the user |
+| USER_DESCRIPTION | `string` | "description", "desc"                                        | The description of this user.             |
+| USER_EMAIL       | `string` | "email", "email_addr", "email_address", "user_email_address" | The email address of this user.           |
+| USER_ID          | `string` | "id", "uuid"                                                 | Unique ID Openstack has assigned the user |
+| USER_NAME        | `string` | "name", "username                                            | Unique user name (within the domain)      |
 
 
 Any of these properties can be used for any of the API methods that takes a property - like `select`, `where`, `sort_by` etc
@@ -40,6 +40,15 @@ Alternatively, you can pass property aliases (passed as string) instead (current
 ## Chaining
 This section details valid mappings you can use to chain onto other queries or from other queries to chain into a `ProjectQuery` object.
 This applies to API calls `then` and `append_from` - see [API.md](../API.md) for details
+
+
+## Query Alias
+The aliases that can be used for the query when chaining are listed below:
+
+| Query Enum            | Aliases (case-insensitive                       |
+|-----------------------|-------------------------------------------------|
+| QueryTypes.USER_QUERY | "user", "users", "query_users", "to_user_query" |
+
 
 
 ## Chaining from

--- a/lib/openstack_query/docs/user_docs/query_docs/USERS.md
+++ b/lib/openstack_query/docs/user_docs/query_docs/USERS.md
@@ -45,9 +45,9 @@ This applies to API calls `then` and `append_from` - see [API.md](../API.md) for
 ## Query Alias
 The aliases that can be used for the query when chaining are listed below:
 
-| Query Enum            | Aliases (case-insensitive                       |
-|-----------------------|-------------------------------------------------|
-| QueryTypes.USER_QUERY | "user", "users", "query_users", "to_user_query" |
+| Query Enum            | Aliases (case-insensitive |
+|-----------------------|---------------------------|
+| QueryTypes.USER_QUERY | "user", "users"           |
 
 
 

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -162,17 +162,30 @@ class QueryOutput:
             )
         return output
 
-    def parse_select(self, *props: PropEnum, select_all=False) -> None:
+    def _parse_select_inputs(self, props):
+        """
+        Converts list of select() 'prop' user inputs into Enums, any string aliases will be converted into Enums
+        :param props: one or more Enums/string aliases representing properties to show
+        """
+        parsed_props = []
+        for prop in props:
+            if isinstance(prop, str):
+                prop = self._prop_enum_cls.from_string(prop)
+            parsed_props.append(prop)
+        return parsed_props
+
+    def parse_select(self, *props: Union[str, PropEnum], select_all=False) -> None:
         """
         Method which is used to set which properties to output once results are gathered
         This method checks that each Enum provided is valid and populates internal attribute which holds selected props
         :param select_all: boolean flag to select all valid properties
-        :param props: any number of Enums representing properties to show
+        :param props: one or more Enums/string aliases representing properties to show
         """
         if select_all:
             self.selected_props = set(self._prop_enum_cls)
             return
 
+        props = self._parse_select_inputs(props)
         all_props = set()
         for prop in props:
             if prop not in self._prop_enum_cls:

--- a/tests/enums/props/test_flavor_properties.py
+++ b/tests/enums/props/test_flavor_properties.py
@@ -34,7 +34,14 @@ def test_get_marker_prop_func(mock_get_prop_mapping):
 
 
 @pytest.mark.parametrize(
-    "val", ["flavor_description", "Flavor_Description", "FlAvOr_DeScRiPtIoN"]
+    "val",
+    [
+        "flavor_description",
+        "Flavor_Description",
+        "FlAvOr_DeScRiPtIoN",
+        "description",
+        "desc",
+    ],
 )
 def test_flavor_description_serialization(val):
     """
@@ -43,7 +50,9 @@ def test_flavor_description_serialization(val):
     assert FlavorProperties.from_string(val) is FlavorProperties.FLAVOR_DESCRIPTION
 
 
-@pytest.mark.parametrize("val", ["flavor_disk", "Flavor_Disk", "FlAvOr_DiSk"])
+@pytest.mark.parametrize(
+    "val", ["flavor_disk", "Flavor_Disk", "FlAvOr_DiSk", "disk", "disk_size"]
+)
 def test_flavor_disk_serialization(val):
     """
     Tests that variants of FLAVOR_DISK can be serialized
@@ -52,7 +61,15 @@ def test_flavor_disk_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["flavor_ephemeral", "Flavor_Ephemeral", "FlAvOr_EpHeMeRaL"]
+    "val",
+    [
+        "flavor_ephemeral",
+        "Flavor_Ephemeral",
+        "FlAvOr_EpHeMeRaL",
+        "ephemeral",
+        "ephemeral_disk",
+        "ephemeral_disk_size",
+    ],
 )
 def test_flavor_ephemeral_serialization(val):
     """
@@ -61,7 +78,7 @@ def test_flavor_ephemeral_serialization(val):
     assert FlavorProperties.from_string(val) is FlavorProperties.FLAVOR_EPHEMERAL
 
 
-@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id"])
+@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id", "id", "uuid"])
 def test_flavor_id_serialization(val):
     """
     Tests that variants of FLAVOR_ID can be serialized
@@ -70,7 +87,8 @@ def test_flavor_id_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["flavor_is_disabled", "Flavor_Is_Disabled", "Flavor_Is_DiSaBlEd"]
+    "val",
+    ["flavor_is_disabled", "Flavor_Is_Disabled", "Flavor_Is_DiSaBlEd", "is_disabled"],
 )
 def test_flavor_is_disabled_serialization(val):
     """
@@ -80,7 +98,7 @@ def test_flavor_is_disabled_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["flavor_is_public", "Flavor_Is_Public", "FlAvOr_Is_PuBlIc"]
+    "val", ["flavor_is_public", "Flavor_Is_Public", "FlAvOr_Is_PuBlIc", "is_public"]
 )
 def test_flavor_is_public_serialization(val):
     """
@@ -89,7 +107,7 @@ def test_flavor_is_public_serialization(val):
     assert FlavorProperties.from_string(val) is FlavorProperties.FLAVOR_IS_PUBLIC
 
 
-@pytest.mark.parametrize("val", ["flavor_name", "Flavor_Name", "FlAvOr_NaMe"])
+@pytest.mark.parametrize("val", ["flavor_name", "Flavor_Name", "FlAvOr_NaMe", "name"])
 def test_flavor_name_serialization(val):
     """
     Tests that variants of FLAVOR_NAME can be serialized
@@ -97,7 +115,9 @@ def test_flavor_name_serialization(val):
     assert FlavorProperties.from_string(val) is FlavorProperties.FLAVOR_NAME
 
 
-@pytest.mark.parametrize("val", ["flavor_ram", "Flavor_RAM", "FlAvOr_RaM"])
+@pytest.mark.parametrize(
+    "val", ["flavor_ram", "Flavor_RAM", "FlAvOr_RaM", "ram", "ram_size"]
+)
 def test_flavor_ram_serialization(val):
     """
     Tests that variants of FLAVOR_RAM can be serialized
@@ -113,7 +133,9 @@ def test_flavor_swap_serialization(val):
     assert FlavorProperties.from_string(val) is FlavorProperties.FLAVOR_SWAP
 
 
-@pytest.mark.parametrize("val", ["flavor_vcpu", "Flavor_VCPU", "FlAvOr_VcPu"])
+@pytest.mark.parametrize(
+    "val", ["flavor_vcpu", "Flavor_VCPU", "FlAvOr_VcPu", "vcpu", "vcpus", "vcup_num"]
+)
 def test_flavor_vcpu_serialization(val):
     """
     Tests that variants of FLAVOR_VCPU can be serialized

--- a/tests/enums/props/test_flavor_properties.py
+++ b/tests/enums/props/test_flavor_properties.py
@@ -134,7 +134,7 @@ def test_flavor_swap_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["flavor_vcpu", "Flavor_VCPU", "FlAvOr_VcPu", "vcpu", "vcpus", "vcup_num"]
+    "val", ["flavor_vcpu", "Flavor_VCPU", "FlAvOr_VcPu", "vcpu", "vcpus", "vcpu_num"]
 )
 def test_flavor_vcpu_serialization(val):
     """

--- a/tests/enums/props/test_flavor_properties.py
+++ b/tests/enums/props/test_flavor_properties.py
@@ -134,7 +134,7 @@ def test_flavor_swap_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["flavor_vcpu", "Flavor_VCPU", "FlAvOr_VcPu", "vcpu", "vcpus", "vcpu_num"]
+    "val", ["flavor_vcpu", "Flavor_VCPU", "FlAvOr_VcPu", "vcpu", "vcpus"]
 )
 def test_flavor_vcpu_serialization(val):
     """

--- a/tests/enums/props/test_project_properties.py
+++ b/tests/enums/props/test_project_properties.py
@@ -34,7 +34,14 @@ def test_get_marker_prop_func(mock_get_prop_mapping):
 
 
 @pytest.mark.parametrize(
-    "val", ["project_description", "Project_Description", "PrOjEcT_DeScRiPtIoN"]
+    "val",
+    [
+        "project_description",
+        "Project_Description",
+        "PrOjEcT_DeScRiPtIoN",
+        "description",
+        "desc",
+    ],
 )
 def test_project_description_serialization(val):
     """
@@ -44,7 +51,7 @@ def test_project_description_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["project_domain_id", "Project_Domain_Id", "PrOjEcT_DoMaIn_Id"]
+    "val", ["project_domain_id", "Project_Domain_Id", "PrOjEcT_DoMaIn_Id", "domain_id"]
 )
 def test_project_domain_id_serialization(val):
     """
@@ -53,7 +60,9 @@ def test_project_domain_id_serialization(val):
     assert ProjectProperties.from_string(val) is ProjectProperties.PROJECT_DOMAIN_ID
 
 
-@pytest.mark.parametrize("val", ["project_id", "Project_Id", "PrOjEcT_Id"])
+@pytest.mark.parametrize(
+    "val", ["project_id", "Project_Id", "PrOjEcT_Id", "id", "uuid"]
+)
 def test_project_id_serialization(val):
     """
     Tests that variants of PROJECT_ID can be serialized
@@ -62,7 +71,7 @@ def test_project_id_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["project_is_domain", "Project_Is_Domain", "PrOjEcT_Is_DoMaIn"]
+    "val", ["project_is_domain", "Project_Is_Domain", "PrOjEcT_Is_DoMaIn", "is_domain"]
 )
 def test_project_is_domain_serialization(val):
     """
@@ -72,7 +81,8 @@ def test_project_is_domain_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["project_is_enabled", "Project_Is_Enabled", "PrOjEcT_Is_EnAbLeD"]
+    "val",
+    ["project_is_enabled", "Project_Is_Enabled", "PrOjEcT_Is_EnAbLeD", "is_enabled"],
 )
 def test_project_is_enabled_serialization(val):
     """
@@ -81,7 +91,9 @@ def test_project_is_enabled_serialization(val):
     assert ProjectProperties.from_string(val) is ProjectProperties.PROJECT_IS_ENABLED
 
 
-@pytest.mark.parametrize("val", ["project_name", "Project_Name", "PrOjEcT_NaMe"])
+@pytest.mark.parametrize(
+    "val", ["project_name", "Project_Name", "PrOjEcT_NaMe", "name"]
+)
 def test_project_name_serialization(val):
     """
     Tests that variants of PROJECT_NAME can be serialized
@@ -90,7 +102,7 @@ def test_project_name_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["project_parent_id", "Project_Parent_Id", "PrOjEcT_PaReNt_Id"]
+    "val", ["project_parent_id", "Project_Parent_Id", "PrOjEcT_PaReNt_Id", "parent_id"]
 )
 def test_project_parent_id_serialization(val):
     """

--- a/tests/enums/props/test_server_properties.py
+++ b/tests/enums/props/test_server_properties.py
@@ -34,7 +34,7 @@ def test_get_marker_prop_func(mock_get_prop_mapping):
     assert val == mock_get_prop_mapping.return_value
 
 
-@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id", "id", "uuid"])
+@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id"])
 def test_flavor_id_serialization(val):
     """
     Tests that variants of FLAVOR_ID can be serialized

--- a/tests/enums/props/test_server_properties.py
+++ b/tests/enums/props/test_server_properties.py
@@ -34,7 +34,7 @@ def test_get_marker_prop_func(mock_get_prop_mapping):
     assert val == mock_get_prop_mapping.return_value
 
 
-@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id"])
+@pytest.mark.parametrize("val", ["flavor_id", "Flavor_ID", "FlAvOr_Id", "id", "uuid"])
 def test_flavor_id_serialization(val):
     """
     Tests that variants of FLAVOR_ID can be serialized
@@ -42,7 +42,9 @@ def test_flavor_id_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.FLAVOR_ID
 
 
-@pytest.mark.parametrize("val", ["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID"])
+@pytest.mark.parametrize(
+    "val", ["hypervisor_id", "Hypervisor_ID", "HyPerVisor_ID", "host_id", "hv_id"]
+)
 def test_hypervisor_id_serialization(val):
     """
     Tests that variants of HYPERVISOR_ID can be serialized
@@ -67,7 +69,13 @@ def test_project_id_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["server_creation_date", "Server_Creation_Date", "SeRvEr_CrEaTiOn_DAte"]
+    "val",
+    [
+        "server_creation_date",
+        "Server_Creation_Date",
+        "SeRvEr_CrEaTiOn_DAte",
+        "created_at",
+    ],
 )
 def test_server_creation_date_serialization(val):
     """
@@ -77,7 +85,8 @@ def test_server_creation_date_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["server_description", "Server_Description", "SeRvEr_DeScrIpTion"]
+    "val",
+    ["server_description", "Server_Description", "SeRvEr_DeScrIpTion", "description"],
 )
 def test_server_description_serialization(val):
     """
@@ -86,7 +95,9 @@ def test_server_description_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_DESCRIPTION
 
 
-@pytest.mark.parametrize("val", ["server_id", "Server_Id", "SeRvEr_iD"])
+@pytest.mark.parametrize(
+    "val", ["server_id", "Server_Id", "SeRvEr_iD", "vm_id", "id", "uuid"]
+)
 def test_server_id_serialization(val):
     """
     Tests that variants of SERVER_ID can be serialized
@@ -100,6 +111,7 @@ def test_server_id_serialization(val):
         "server_last_updated_date",
         "Server_Last_Updated_Date",
         "SerVer_LasT_UpDatED_DaTe",
+        "updated_at",
     ],
 )
 def test_server_last_updated_date_serialization(val):
@@ -111,7 +123,9 @@ def test_server_last_updated_date_serialization(val):
     )
 
 
-@pytest.mark.parametrize("val", ["server_name", "Server_NaMe", "Server_Name"])
+@pytest.mark.parametrize(
+    "val", ["server_name", "Server_NaMe", "Server_Name", "vm_name", "name"]
+)
 def test_server_name_serialization(val):
     """
     Tests that variants of SERVER_NAME can be serialized
@@ -119,7 +133,9 @@ def test_server_name_serialization(val):
     assert ServerProperties.from_string(val) is ServerProperties.SERVER_NAME
 
 
-@pytest.mark.parametrize("val", ["server_status", "Server_Status", "SerVer_StAtUs"])
+@pytest.mark.parametrize(
+    "val", ["server_status", "Server_Status", "SerVer_StAtUs", "status", "vm_status"]
+)
 def test_server_status_serialization(val):
     """
     Tests that variants of SERVER_STATUS can be serialized
@@ -133,6 +149,16 @@ def test_user_id_serialization(val):
     Tests that variants of USER_ID can be serialized
     """
     assert ServerProperties.from_string(val) is ServerProperties.USER_ID
+
+
+@pytest.mark.parametrize(
+    "val", ["addresses", "Addresses", "AdDreSSeS", "ips", "vm_ips", "server_ips"]
+)
+def test_addresses_serialization(val):
+    """
+    Tests that variants of ADDRESSES can be serialized
+    """
+    assert ServerProperties.from_string(val) is ServerProperties.ADDRESSES
 
 
 def test_invalid_serialization():

--- a/tests/enums/props/test_user_properties.py
+++ b/tests/enums/props/test_user_properties.py
@@ -33,7 +33,9 @@ def test_get_marker_prop_func(mock_get_prop_mapping):
     assert val == mock_get_prop_mapping.return_value
 
 
-@pytest.mark.parametrize("val", ["user_domain_id", "User_Domain_ID", "UsEr_DoMaIn_iD"])
+@pytest.mark.parametrize(
+    "val", ["user_domain_id", "User_Domain_ID", "UsEr_DoMaIn_iD", "domain_id"]
+)
 def test_user_domain_id_serialization(val):
     """
     Tests that variants of USER_DOMAIN_ID can be serialized
@@ -41,7 +43,18 @@ def test_user_domain_id_serialization(val):
     assert UserProperties.from_string(val) is UserProperties.USER_DOMAIN_ID
 
 
-@pytest.mark.parametrize("val", ["USER_EMAIL", "User_Email", "UsEr_EmAiL"])
+@pytest.mark.parametrize(
+    "val",
+    [
+        "USER_EMAIL",
+        "User_Email",
+        "UsEr_EmAiL",
+        "email",
+        "email_addr",
+        "email_address",
+        "user_email_address",
+    ],
+)
 def test_user_email_serialization(val):
     """
     Tests that variants of USER_EMAIL can be serialized
@@ -50,7 +63,8 @@ def test_user_email_serialization(val):
 
 
 @pytest.mark.parametrize(
-    "val", ["USER_DESCRIPTION", "User_Description", "UsEr_DeScRiPtIoN"]
+    "val",
+    ["USER_DESCRIPTION", "User_Description", "UsEr_DeScRiPtIoN" "description", "desc"],
 )
 def test_user_description_serialization(val):
     """
@@ -59,7 +73,17 @@ def test_user_description_serialization(val):
     assert UserProperties.from_string(val) is UserProperties.USER_DESCRIPTION
 
 
-@pytest.mark.parametrize("val", ["USER_NAME", "User_Name", "UsEr_NaMe"])
+@pytest.mark.parametrize("val", ["USER_ID", "User_Id", "UsEr_Id", "id", "uuid"])
+def test_user_id_serialization(val):
+    """
+    Tests that variants of USER_ID can be serialized
+    """
+    assert UserProperties.from_string(val) is UserProperties.USER_ID
+
+
+@pytest.mark.parametrize(
+    "val", ["USER_NAME", "User_Name", "UsEr_NaMe", "name", "username"]
+)
 def test_user_name_serialization(val):
     """
     Tests that variants of USER_NAME can be serialized

--- a/tests/enums/props/test_user_properties.py
+++ b/tests/enums/props/test_user_properties.py
@@ -64,7 +64,7 @@ def test_user_email_serialization(val):
 
 @pytest.mark.parametrize(
     "val",
-    ["USER_DESCRIPTION", "User_Description", "UsEr_DeScRiPtIoN" "description", "desc"],
+    ["USER_DESCRIPTION", "User_Description", "UsEr_DeScRiPtIoN", "description", "desc"],
 )
 def test_user_description_serialization(val):
     """

--- a/tests/enums/test_query_presets.py
+++ b/tests/enums/test_query_presets.py
@@ -5,6 +5,7 @@ from enums.query.query_presets import (
     QueryPresetsInteger,
     QueryPresetsString,
     QueryPresetsDateTime,
+    get_preset_from_string,
 )
 from exceptions.parse_query_error import ParseQueryError
 
@@ -186,3 +187,27 @@ def test_invalid_serialization():
     ]:
         with pytest.raises(ParseQueryError):
             enum_cls.from_string("some-invalid-string")
+
+
+@pytest.mark.parametrize(
+    "alias, expected_preset",
+    [
+        ("equal_to", QueryPresetsGeneric.EQUAL_TO),
+        ("matches_regex", QueryPresetsString.MATCHES_REGEX),
+        ("older_than", QueryPresetsDateTime.OLDER_THAN),
+        ("greater_than", QueryPresetsInteger.GREATER_THAN),
+    ],
+)
+def test_get_preset_from_string_valid(alias, expected_preset):
+    """
+    Tests that get_preset_from_string works for a valid preset alias from each preset type
+    """
+    assert get_preset_from_string(alias) == expected_preset
+
+
+def test_get_preset_from_string_invalid():
+    """
+    Tests that get_preset_from_string returns error if given an invalid alias
+    """
+    with pytest.raises(ParseQueryError):
+        get_preset_from_string("invalid-alias")

--- a/tests/enums/test_query_presets.py
+++ b/tests/enums/test_query_presets.py
@@ -10,7 +10,9 @@ from enums.query.query_presets import (
 from exceptions.parse_query_error import ParseQueryError
 
 
-@pytest.mark.parametrize("preset_string", ["equal_to", "Equal_To", "EqUaL_tO"])
+@pytest.mark.parametrize(
+    "preset_string", ["equal_to", "Equal_To", "EqUaL_tO", "equal", "=="]
+)
 def test_equal_to_serialization(preset_string):
     """
     Tests that variants of EQUAL_TO can be serialized
@@ -21,7 +23,7 @@ def test_equal_to_serialization(preset_string):
 
 
 @pytest.mark.parametrize(
-    "preset_string", ["not_equal_to", "Not_Equal_To", "NoT_EqUaL_tO"]
+    "preset_string", ["not_equal_to", "Not_Equal_To", "NoT_EqUaL_tO", "not_equal", "!="]
 )
 def test_not_equal_to_serialization(preset_string):
     """
@@ -144,7 +146,7 @@ def test_younger_than_or_equal_to_serialization(preset_string):
     )
 
 
-@pytest.mark.parametrize("preset_string", ["any_in", "Any_In", "AnY_In"])
+@pytest.mark.parametrize("preset_string", ["any_in", "Any_In", "AnY_In", "in"])
 def test_any_in_serialization(preset_string):
     """
     Tests that variants of ANY_IN can be serialized
@@ -152,7 +154,9 @@ def test_any_in_serialization(preset_string):
     assert QueryPresetsGeneric.from_string(preset_string) is QueryPresetsGeneric.ANY_IN
 
 
-@pytest.mark.parametrize("preset_string", ["not_any_in", "Not_Any_In", "NoT_AnY_In"])
+@pytest.mark.parametrize(
+    "preset_string", ["not_any_in", "Not_Any_In", "NoT_AnY_In", "not_in"]
+)
 def test_not_any_in_serialization(preset_string):
     """
     Tests that variants of NOT_ANY_IN can be serialized
@@ -163,7 +167,8 @@ def test_not_any_in_serialization(preset_string):
 
 
 @pytest.mark.parametrize(
-    "preset_string", ["matches_regex", "Matches_Regex", "MaTcHeS_ReGeX"]
+    "preset_string",
+    ["matches_regex", "Matches_Regex", "MaTcHeS_ReGeX", "regex", "match_regex"],
 )
 def test_matches_regex_serialization(preset_string):
     """

--- a/tests/enums/test_query_types.py
+++ b/tests/enums/test_query_types.py
@@ -4,7 +4,18 @@ from enums.query.query_types import QueryTypes
 from exceptions.parse_query_error import ParseQueryError
 
 
-@pytest.mark.parametrize("query_type", ["Flavor_Query", "FlAvOr_Query", "flavor_query"])
+@pytest.mark.parametrize(
+    "query_type",
+    [
+        "Flavor_Query",
+        "FlAvOr_Query",
+        "flavor_query",
+        "flavor",
+        "flavors",
+        "query_flavors",
+        "to_flavor_query",
+    ],
+)
 def test_flavor_query_serialization(query_type):
     """
     Tests that variants of FLAVOR_QUERY can be serialized
@@ -12,7 +23,17 @@ def test_flavor_query_serialization(query_type):
     assert QueryTypes.from_string(query_type) is QueryTypes.FLAVOR_QUERY
 
 
-@pytest.mark.parametrize("query_type", ["Server_Query", "SeRvEr_QuErY", "server_query"])
+@pytest.mark.parametrize(
+    "query_type",
+    [
+        "Server_Query",
+        "SeRvEr_QuErY",
+        "server_query" "server",
+        "servers",
+        "query_servers",
+        "to_server_query",
+    ],
+)
 def test_server_query_serialization(query_type):
     """
     Tests that variants of SERVER_QUERY can be serialized
@@ -21,7 +42,16 @@ def test_server_query_serialization(query_type):
 
 
 @pytest.mark.parametrize(
-    "query_type", ["Project_Query", "PrOjEcT_Query", "project_query"]
+    "query_type",
+    [
+        "Project_Query",
+        "PrOjEcT_Query",
+        "project_query",
+        "project",
+        "projects",
+        "query_projects",
+        "to_project_query",
+    ],
 )
 def test_project_query_serialization(query_type):
     """
@@ -30,7 +60,17 @@ def test_project_query_serialization(query_type):
     assert QueryTypes.from_string(query_type) is QueryTypes.PROJECT_QUERY
 
 
-@pytest.mark.parametrize("query_type", ["User_Query", "UsEr_QuEry", "user_query"])
+@pytest.mark.parametrize(
+    "query_type",
+    [
+        "User_Query",
+        "UsEr_QuEry",
+        "user_query" "user",
+        "users",
+        "query_users",
+        "to_user_query",
+    ],
+)
 def test_user_query_serialization(query_type):
     """
     Tests that variants of USER_QUERY can be serialized

--- a/tests/enums/test_query_types.py
+++ b/tests/enums/test_query_types.py
@@ -12,8 +12,6 @@ from exceptions.parse_query_error import ParseQueryError
         "flavor_query",
         "flavor",
         "flavors",
-        "query_flavors",
-        "to_flavor_query",
     ],
 )
 def test_flavor_query_serialization(query_type):
@@ -31,8 +29,6 @@ def test_flavor_query_serialization(query_type):
         "server_query",
         "server",
         "servers",
-        "query_servers",
-        "to_server_query",
     ],
 )
 def test_server_query_serialization(query_type):
@@ -50,8 +46,6 @@ def test_server_query_serialization(query_type):
         "project_query",
         "project",
         "projects",
-        "query_projects",
-        "to_project_query",
     ],
 )
 def test_project_query_serialization(query_type):
@@ -69,8 +63,6 @@ def test_project_query_serialization(query_type):
         "user_query",
         "user",
         "users",
-        "query_users",
-        "to_user_query",
     ],
 )
 def test_user_query_serialization(query_type):

--- a/tests/enums/test_query_types.py
+++ b/tests/enums/test_query_types.py
@@ -28,7 +28,8 @@ def test_flavor_query_serialization(query_type):
     [
         "Server_Query",
         "SeRvEr_QuErY",
-        "server_query" "server",
+        "server_query",
+        "server",
         "servers",
         "query_servers",
         "to_server_query",
@@ -65,7 +66,8 @@ def test_project_query_serialization(query_type):
     [
         "User_Query",
         "UsEr_QuEry",
-        "user_query" "user",
+        "user_query",
+        "user",
         "users",
         "query_users",
         "to_user_query",

--- a/tests/enums/test_sort_order.py
+++ b/tests/enums/test_sort_order.py
@@ -1,0 +1,28 @@
+import pytest
+
+from enums.query.sort_order import SortOrder
+from exceptions.parse_query_error import ParseQueryError
+
+
+@pytest.mark.parametrize("sort_order_type", ["asc", "Asc", "Ascending"])
+def test_asc_serialization(sort_order_type):
+    """
+    Tests that variants of ASC can be serialized
+    """
+    assert SortOrder.from_string(sort_order_type) is SortOrder.ASC
+
+
+@pytest.mark.parametrize("sort_order_type", ["desc", "Desc", "Descending"])
+def test_desc_serialization(sort_order_type):
+    """
+    Tests that variants of DESC can be serialized
+    """
+    assert SortOrder.from_string(sort_order_type) is SortOrder.DESC
+
+
+def test_get_preset_from_string_invalid():
+    """
+    Tests that error is raised when passed invalid string
+    """
+    with pytest.raises(ParseQueryError):
+        SortOrder.from_string("some-invalid-string")

--- a/tests/lib/openstack_query/mocks/mocked_query_presets.py
+++ b/tests/lib/openstack_query/mocks/mocked_query_presets.py
@@ -1,12 +1,18 @@
-from enums.query.query_presets import QueryPresets
+from typing import Dict
+from enums.query.enum_with_aliases import EnumWithAliases
 
 # pylint:disable=too-few-public-methods
 
 
-class MockQueryPresets(QueryPresets):
+class MockQueryPresets(EnumWithAliases):
     """
     An Enum class to mock query presets for various unit tests
     """
+
+    @staticmethod
+    def _get_aliases() -> Dict:
+        # No mock aliases
+        return {}
 
     ITEM_1 = 1
     ITEM_2 = 2

--- a/tests/lib/openstack_query/query_blocks/test_query_output.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_output.py
@@ -516,6 +516,21 @@ def test_parse_select_given_args(instance):
     assert instance.selected_props, [MockProperties.PROP_1, MockProperties.PROP_2]
 
 
+def test_parse_select_with_string_aliases():
+    """
+    tests that parse select works with string aliases. They should get converted to Enums automatically
+    """
+    # we create a new local instance since MockProperties doesn't implement the from_string method
+    mock_prop_enum_cls = ServerProperties
+    instance = QueryOutput(prop_enum_cls=mock_prop_enum_cls)
+
+    instance.parse_select("server_id", "server_name")
+    assert instance.selected_props, [
+        ServerProperties.SERVER_ID,
+        ServerProperties.SERVER_NAME,
+    ]
+
+
 def test_parse_select_given_invalid(instance):
     """
     Tests that parse_select works expectedly

--- a/tests/lib/openstack_query/query_blocks/test_query_parser.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_parser.py
@@ -137,9 +137,7 @@ def test_parse_sort_by_with_string_aliases():
     mock_prop_enum_cls = ServerProperties
     instance = QueryParser(prop_enum_cls=mock_prop_enum_cls)
 
-    instance.parse_sort_by(
-        ("server_id", SortOrder.ASC), ("server_name", SortOrder.DESC)
-    )
+    instance.parse_sort_by(("server_id", "asc"), ("server_name", "descending"))
     assert instance.sort_by == {
         ServerProperties.SERVER_ID: False,
         ServerProperties.SERVER_NAME: True,

--- a/tests/lib/openstack_query/query_blocks/test_query_parser.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_parser.py
@@ -129,6 +129,23 @@ def test_parse_sort_by_invalid(instance):
         instance.parse_sort_by((ServerProperties.SERVER_ID, True))
 
 
+def test_parse_sort_by_with_string_aliases():
+    """
+    Tests that parse_sort_by method can handle string aliases as well as enums
+    """
+    # we create a new local instance since MockProperties doesn't implement the from_string method
+    mock_prop_enum_cls = ServerProperties
+    instance = QueryParser(prop_enum_cls=mock_prop_enum_cls)
+
+    instance.parse_sort_by(
+        ("server_id", SortOrder.ASC), ("server_name", SortOrder.DESC)
+    )
+    assert instance.sort_by == {
+        ServerProperties.SERVER_ID: False,
+        ServerProperties.SERVER_NAME: True,
+    }
+
+
 def test_parse_group_by_invalid(instance):
     """
     Tests parse_group_by - when given an invalid group by prop
@@ -177,6 +194,18 @@ def test_parse_group_by_with_group_ranges_and_include_missing(
     assert instance.group_by == MockProperties.PROP_1
     mock_parse_group_ranges.assert_called_once_with(mock_group_ranges)
     mock_add_include_missing_group.assert_called_once_with(mock_group_ranges)
+
+
+def test_parse_group_by_with_string_aliases():
+    """
+    Tests that parse_group_by method can handle string aliases as well as enums
+    """
+    # we create a new local instance since MockProperties doesn't implement the from_string method
+    mock_prop_enum_cls = ServerProperties
+    instance = QueryParser(prop_enum_cls=mock_prop_enum_cls)
+
+    instance.parse_group_by("server_id")
+    assert instance.group_by == ServerProperties.SERVER_ID
 
 
 def test_run_parse_group_ranges(instance, mock_get_prop_mapping):


### PR DESCRIPTION
various methods for query api now accept string aliases as well as Enums - see #88 
Added Alias support and reworked how aliases can be added