### PR TITLE
TST: rewriting QueryBuilder Tests

### DIFF
--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -240,7 +240,7 @@ class QueryBuilder:
                 return i
 
         logger.error(
-            "Error: if you are here as a developer"
+            "Error: if you are here as a developer "
             "you have likely forgotten to add client-side mappings for the preset '%s' and property '%s' "
             "under mappings/<resource>_mapping",
             preset.name,

--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -226,7 +226,7 @@ class QueryBuilder:
                 "with the resource you're querying.\n "
                 "i.e. using LESS_THAN for querying Users "
                 "(as users holds no query-able properties which are of an integer type).\n "
-                "However, if you believe it should please raise an issue with the repo maintainer",
+                "However, if you believe it should, please raise an issue with the repo maintainer.",
                 preset.name,
             )
 
@@ -252,7 +252,7 @@ class QueryBuilder:
             "with the preset '%s' \n"
             "i.e. using LESS_THAN with a string property like SERVER_NAME won't work "
             "(server_name holds strings, and preset LESS_THAN only works on integers.)\n "
-            "However, if you believe it preset and property should be used together please raise an "
+            "However, if you believe the preset and property should be used together please raise an "
             "issue with the repo maintainer",
             prop.name,
             preset.name,

--- a/lib/openstack_query/query_blocks/query_builder.py
+++ b/lib/openstack_query/query_blocks/query_builder.py
@@ -226,7 +226,8 @@ class QueryBuilder:
                 "with the resource you're querying.\n "
                 "i.e. using LESS_THAN for querying Users "
                 "(as users holds no query-able properties which are of an integer type).\n "
-                "However, if you believe it should please raise an issue with the repo maintainer"
+                "However, if you believe it should please raise an issue with the repo maintainer",
+                preset.name,
             )
 
             raise QueryPresetMappingError(
@@ -240,12 +241,23 @@ class QueryBuilder:
 
         logger.error(
             "Error: if you are here as a developer"
-            "you have likely forgotten to add client-side mappings for the preset '%s' "
-            "under queries/<resource>_query",
+            "you have likely forgotten to add client-side mappings for the preset '%s' and property '%s' "
+            "under mappings/<resource>_mapping",
+            preset.name,
+            prop.name,
+        )
+
+        logger.error(
+            "Error: If you are here as a user - double check whether the property '%s' can be used "
+            "with the preset '%s' \n"
+            "i.e. using LESS_THAN with a string property like SERVER_NAME won't work "
+            "(server_name holds strings, and preset LESS_THAN only works on integers.)\n "
+            "However, if you believe it preset and property should be used together please raise an "
+            "issue with the repo maintainer",
+            prop.name,
             preset.name,
         )
 
         raise QueryPresetMappingError(
-            f"No client-side handler found for preset '{preset.name}'"
-            "- this query is likely misconfigured/preset is not supported on resource"
+            f"No client-side handler found which supports preset '{preset.name}' and property '{prop.name}"
         )

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -67,19 +67,19 @@ def instance_fixture(
     )
 
 
-@pytest.fixture(name="run_parse_where_test")
-def run_parse_where_test_fixture(
+@pytest.fixture(name="parse_where_runner")
+def parse_where_runner_fixture(
     instance, mock_server_side_handler, mock_valid_client_handler
 ):
     """
-    This fixture runs test cases of parse_where, where we expect it to complete successfully,
+    This is a helper function that runs test cases of parse_where, where we expect it to complete successfully,
     In each test case we change what server_side_handler.get_filters and client_side_handler.get_filter_func returns
     This will change what is set in the client_side_filters and server_side_filters properties at the end
     """
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
 
     # pylint:disable=too-many-arguments
-    def _run_parse_where_test_case(
+    def _parse_where_runner(
         mock_get_filter_return,
         mock_get_filter_func_return,
         expected_server_side_filters,
@@ -123,15 +123,15 @@ def run_parse_where_test_fixture(
         assert test_instance.server_side_filters == expected_server_side_filters
         assert test_instance.server_filter_fallback == expected_fallback_filters
 
-    return _run_parse_where_test_case
+    return _parse_where_runner
 
 
-def test_parse_where_with_single_filter(run_parse_where_test):
+def test_parse_where_with_single_filter(parse_where_runner):
     """
-    Tests that parse_where where server-side-handler get_filters returns a single filter set
+    Tests parse_where where server-side-handler get_filters returns a single filter set
     """
     mock_client_filter = NonCallableMock()
-    run_parse_where_test(
+    parse_where_runner(
         mock_get_filter_return=[{"filter1": "val1", "filter2": "val2"}],
         mock_get_filter_func_return=mock_client_filter,
         expected_server_side_filters=[{"filter1": "val1", "filter2": "val2"}],
@@ -140,13 +140,13 @@ def test_parse_where_with_single_filter(run_parse_where_test):
     )
 
 
-def test_parse_where_with_filter_list(run_parse_where_test):
+def test_parse_where_with_filter_list(parse_where_runner):
     """
-    Tests that parse_where where server-side-handler get_filters returns a list of filters
+    Tests parse_where where server-side-handler get_filters returns a list of filters
     """
     mock_client_filter = NonCallableMock()
     mock_server_filter = [{"filter1": "val1"}, {"filter2": "val2"}]
-    run_parse_where_test(
+    parse_where_runner(
         mock_get_filter_return=mock_server_filter,
         mock_get_filter_func_return=mock_client_filter,
         expected_server_side_filters=mock_server_filter,
@@ -155,13 +155,13 @@ def test_parse_where_with_filter_list(run_parse_where_test):
     )
 
 
-def test_parse_where_with_no_filters(run_parse_where_test):
+def test_parse_where_with_no_filters(parse_where_runner):
     """
-    Tests that parse_where where server-side-handler get_filters returns no filters
+    Tests parse_where where server-side-handler get_filters returns no filters
     """
     mock_client_filter = NonCallableMock()
     mock_server_filter = None
-    run_parse_where_test(
+    parse_where_runner(
         mock_get_filter_return=mock_server_filter,
         mock_get_filter_func_return=mock_client_filter,
         expected_server_side_filters=[],
@@ -170,110 +170,161 @@ def test_parse_where_with_no_filters(run_parse_where_test):
     )
 
 
-@pytest.mark.parametrize(
-    "existing_filters, new_filters, expected_out",
-    [
-        # one (non-overlapping) server-side filter set
-        # one server-side filter set to add
-        (
-            [{"filter1": "val1"}],
-            [{"filter2": "val2"}],
-            [{"filter1": "val1", "filter2": "val2"}],
-        ),
-        # multiple (non-overlapping) server-side filters set, one
-        # one server-side filter set to add
-        (
-            [{"filter1": "val1"}, {"filter2": "val2"}],
-            [{"filter3": "val3"}],
-            [
-                {"filter1": "val1", "filter3": "val3"},
-                {"filter2": "val2", "filter3": "val3"},
-            ],
-        ),
-        # multiple (non-overlapping) server-side filters set
-        # multiple server-side filter sets to add
-        (
-            [{"filter1": "val1"}, {"filter2": "val2"}],
-            [{"filter3": "val3"}, {"filter4": "val4"}],
-            [
-                {"filter1": "val1", "filter3": "val3"},
-                {"filter1": "val1", "filter4": "val4"},
-                {"filter2": "val2", "filter3": "val3"},
-                {"filter2": "val2", "filter4": "val4"},
-            ],
-        ),
-    ],
-)
-def test_parse_where_when_filter_exists(
-    existing_filters, new_filters, expected_out, instance, run_parse_where_test
+@pytest.fixture(name="parse_where_runner_with_server_side_filter_set")
+def parse_where_runner_with_server_side_filter_set_fixture(
+    instance, parse_where_runner
 ):
     """
-    Tests parse_where, for various cases where adding new preset requires a new
-    server-side filter to be added, to an already populated server_side_filters property from previous presets
-    Tests that the two filters are concatenated properly
+    A fixture to setup and test different test-cases for parse_where when server side filter is already set
     """
-    instance.server_side_filters = existing_filters
 
-    filter1_fallback_func = NonCallableMock()
-    instance.server_filter_fallback = [filter1_fallback_func]
+    def _server_side_filter_set_runner(
+        expected_server_side_filters,
+        current_server_side_filters,
+        new_server_side_filters,
+        expect_conflict=False,
+    ):
+        """
+        function to setup and test different test-cases for parse_where when server side filter is already set.
 
-    mock_client_filter = NonCallableMock()
-    run_parse_where_test(
-        mock_get_filter_return=new_filters,
-        mock_get_filter_func_return=mock_client_filter,
-        expected_server_side_filters=expected_out,
-        expected_client_side_filters=[],
-        expected_fallback_filters=[filter1_fallback_func, mock_client_filter],
+        :param expected_server_side_filters: a list of server-side-filters we expect the parse_where method to set
+        after calling it
+        :param current_server_side_filters: a list of filters that have already been set
+        :param new_server_side_filters: a list of filters to add
+        :param expect_conflict: whether we expect server-side filter conflict to be detected
+            - (If we expect a conflict, we expect that client-side filter will be set
+            and the new server-side filters to be ignored)
+
+        """
+        instance.server_side_filters = current_server_side_filters
+
+        filter1_fallback_func = NonCallableMock()
+        instance.server_filter_fallback = [filter1_fallback_func]
+
+        mock_client_filter = NonCallableMock()
+        if expect_conflict:
+            parse_where_runner(
+                mock_get_filter_return=new_server_side_filters,
+                mock_get_filter_func_return=mock_client_filter,
+                expected_server_side_filters=expected_server_side_filters,
+                expected_client_side_filters=[mock_client_filter],
+                expected_fallback_filters=[filter1_fallback_func],
+            )
+        else:
+            # conflict occurred - don't add server-side filter, instead add client_side filter
+            parse_where_runner(
+                mock_get_filter_return=new_server_side_filters,
+                mock_get_filter_func_return=mock_client_filter,
+                expected_server_side_filters=expected_server_side_filters,
+                expected_client_side_filters=[],
+                expected_fallback_filters=[filter1_fallback_func, mock_client_filter],
+            )
+
+    return _server_side_filter_set_runner
+
+
+def test_parse_where_single_filter_set_non_conflicting(
+    parse_where_runner_with_server_side_filter_set,
+):
+    """
+    Tests parse_where where server-side-handler get_filters returns a single server-side filter, when another
+    (non-conflicting) filter is already set - should concatenate the two filter sets into one set
+    """
+    parse_where_runner_with_server_side_filter_set(
+        expected_server_side_filters=[{"filter1": "val1", "filter2": "val2"}],
+        current_server_side_filters=[{"filter1": "val1"}],
+        new_server_side_filters=[{"filter2": "val2"}],
     )
 
 
-@pytest.mark.parametrize(
-    "existing_filters, new_filters",
-    [
-        # one server-side filter set
-        # same filter to add again - conflicting
-        (
-            [{"filter1": "val1"}],
-            [{"filter1": "val2"}],
-        ),
-        # multiple server-side filters set
-        # one to add which conflicts with existing filter in set
-        (
-            [{"filter1": "val1"}, {"filter2": "val2"}],
-            [{"filter2": "val3"}],
-        ),
-        # multiple server-side filters with multiple items in them
-        # one to add which conflicts with one filter of one item in set
-        (
-            [
-                {"filter1": "val1", "filter3": "val3"},
-                {"filter1": "val1", "filter4": "val4"},
-                {"filter2": "val2", "filter3": "val3"},
-                {"filter2": "val2", "filter4": "val4"},
-            ],
-            [{"filter3": "val4"}],
-        ),
-    ],
-)
-def test_add_filter_conflicting_presets(
-    existing_filters, new_filters, instance, run_parse_where_test
+def test_parse_where_multi_filter_set_non_conflicting_add_single(
+    parse_where_runner_with_server_side_filter_set,
 ):
     """
-    Tests parse_where - when a conflict occurs between server-side filter params
-    In this case, we add the new client_side filter to client_side_filters attribute instead
+    Tests parse_where where server-side-handler get_filters returns a single server-side filter, when
+    multiple (non-conflicting) filters already set - should concatenate new filter set onto each currently existing set
     """
-    instance.server_side_filters = existing_filters
 
-    filter1_fallback_func = NonCallableMock()
-    instance.server_filter_fallback = [filter1_fallback_func]
+    parse_where_runner_with_server_side_filter_set(
+        expected_server_side_filters=[
+            {"filter1": "val1", "filter3": "val3"},
+            {"filter2": "val2", "filter3": "val3"},
+        ],
+        current_server_side_filters=[{"filter1": "val1"}, {"filter2": "val2"}],
+        new_server_side_filters=[{"filter3": "val3"}],
+    )
 
-    mock_client_filter = NonCallableMock()
-    run_parse_where_test(
-        mock_get_filter_return=new_filters,
-        mock_get_filter_func_return=mock_client_filter,
-        expected_server_side_filters=existing_filters,
-        expected_client_side_filters=[mock_client_filter],
-        expected_fallback_filters=[filter1_fallback_func],
+
+def test_parse_where_multi_filter_set_non_conflicting_add_multi(
+    parse_where_runner_with_server_side_filter_set,
+):
+    """
+    Tests parse_where where server-side-handler get_filters returns multiple server-side filters, when
+    multiple (non-conflicting) filters already set - should create a list with all unique combinations of filters
+    between the two lists
+    """
+    parse_where_runner_with_server_side_filter_set(
+        expected_server_side_filters=[
+            {"filter1": "val1", "filter3": "val3"},
+            {"filter1": "val1", "filter4": "val4"},
+            {"filter2": "val2", "filter3": "val3"},
+            {"filter2": "val2", "filter4": "val4"},
+        ],
+        current_server_side_filters=[{"filter1": "val1"}, {"filter2": "val2"}],
+        new_server_side_filters=[{"filter3": "val3"}, {"filter4": "val4"}],
+    )
+
+
+def test_parse_where_single_filter_set_conflicting(
+    parse_where_runner_with_server_side_filter_set,
+):
+    """
+    Tests parse_where where server-side-handler get_filters returns a single server-side filter, when another
+    (conflicting) filter is already set - should add the new filter as a client-side filter
+    """
+    current_filters = [{"filter1": "val1"}]
+    parse_where_runner_with_server_side_filter_set(
+        expected_server_side_filters=current_filters,
+        current_server_side_filters=current_filters,
+        new_server_side_filters=[{"filter1": "val2"}],
+        expect_conflict=True,
+    )
+
+
+def test_parse_where_multi_filter_set_conflicting_add_single(
+    parse_where_runner_with_server_side_filter_set,
+):
+    """
+    Tests parse_where where server-side-handler get_filters returns a single server-side filter, when
+    multiple filters already set which are conflicting - should add a the new filter as a client-side filter
+    """
+    current_filters = [{"filter1": "val1"}, {"filter2": "val2"}]
+    parse_where_runner_with_server_side_filter_set(
+        expected_server_side_filters=current_filters,
+        current_server_side_filters=current_filters,
+        new_server_side_filters=[{"filter2": "val3"}],
+        expect_conflict=True,
+    )
+
+
+def test_parse_where_multi_filter_set_conflicting_add_multi(
+    parse_where_runner_with_server_side_filter_set,
+):
+    """
+    Tests parse_where where server-side-handler get_filters returns multiple server-side filters, when
+    multiple filters already set which conflict - should add the new filter as a client-side filter
+    """
+    current_filters = [
+        {"filter1": "val1", "filter3": "val3"},
+        {"filter1": "val1", "filter4": "val4"},
+        {"filter2": "val2", "filter3": "val3"},
+        {"filter2": "val2", "filter4": "val4"},
+    ]
+    parse_where_runner_with_server_side_filter_set(
+        expected_server_side_filters=current_filters,
+        current_server_side_filters=current_filters,
+        new_server_side_filters=[{"filter3": "val4"}],
+        expect_conflict=True,
     )
 
 

--- a/tests/lib/openstack_query/query_blocks/test_query_builder.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_builder.py
@@ -29,17 +29,11 @@ def mock_valid_client_handler_fixture():
 
     def _mock_preset_known(preset):
         """A dummy function to mock the preset_known method on the client handler"""
-        return (
-            True
-            if preset in [MockQueryPresets.ITEM_1, MockQueryPresets.ITEM_3]
-            else False
-        )
+        return preset in [MockQueryPresets.ITEM_1, MockQueryPresets.ITEM_3]
 
     def _mock_check_supported(preset, prop):
         """A dummy function to mock the check_supported method on the client handler"""
-        if preset == MockQueryPresets.ITEM_1 and prop == MockProperties.PROP_1:
-            return True
-        return False
+        return preset == MockQueryPresets.ITEM_1 and prop == MockProperties.PROP_1
 
     mock_invalid_client_handler = MagicMock()
     mock_invalid_client_handler.preset_known = MagicMock(wraps=_mock_preset_known)
@@ -304,7 +298,7 @@ def test_parse_where_preset_misconfigured(instance):
     # when preset_known returns True, but client_side filter missing
     with patch.object(MockProperties, "get_prop_mapping") as mock_prop_func:
         with pytest.raises(QueryPresetMappingError):
-            instance.parse_where(MockQueryPresets.ITEM_2, MockProperties.PROP_1)
+            instance.parse_where(MockQueryPresets.ITEM_3, MockProperties.PROP_1)
     mock_prop_func.assert_called_once_with(MockProperties.PROP_1)
 
 


### PR DESCRIPTION
I rewrote these tests so that they aren't accessing protected methods, plus I think the tests are neater
see #108 
