### PR TITLE
BUG: Remove action_module param

### DIFF
--- a/actions/src/workflow_actions.py
+++ b/actions/src/workflow_actions.py
@@ -11,8 +11,7 @@ class WorkflowActions(Action):
         :param kwargs: all user-defined kwargs to pass to the function
         """
         workflow = import_module(f"workflows.{action_name}")
-        action_module = getattr(workflow, action_name)
-        action_func = getattr(action_module, action_name)
+        action_func = getattr(workflow, action_name)
 
         self.logger.info("Workflow Action Received - %s", action_name)
         self.logger.debug(

--- a/tests/actions/test_workflow_actions.py
+++ b/tests/actions/test_workflow_actions.py
@@ -9,7 +9,7 @@ def test_module_exists():
     Test that each action's entry-point module exists
     """
     action_name = "send_decom_flavor_email"
-    workflow_module = import_module("workflows")
+    workflow_module = import_module(f"workflows.{action_name}")
 
     assert hasattr(workflow_module, action_name)
 
@@ -46,7 +46,7 @@ class TestWorkflowActions(OpenstackActionTestBase):
             )
 
         mock_parse_configs.assert_called_once_with(**self.mock_kwargs)
-        mock_import.return_value.action.action.assert_called_once_with(
+        mock_import.return_value.action.assert_called_once_with(
             **mock_parse_configs.return_value
         )
 

--- a/tests/actions/test_workflow_actions.py
+++ b/tests/actions/test_workflow_actions.py
@@ -12,8 +12,6 @@ def test_module_exists():
     workflow_module = import_module("workflows")
 
     assert hasattr(workflow_module, action_name)
-    action_module = getattr(workflow_module, action_name)
-    assert hasattr(action_module, action_name)
 
 
 class TestWorkflowActions(OpenstackActionTestBase):


### PR DESCRIPTION
### Description:
A bug fix had introduced a new bug where we try to get an attribute of an attribute that doesn't exist as we removed the email submodule from email actions. 




### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
