### PR TITLE
MAINT: refactor Runner and Executer 

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -103,7 +103,7 @@ class QueryAPI:
 
     def run(
         self,
-        cloud_account: Union[str, CloudDomains],
+        cloud_account: Union[str, CloudDomains] = None,
         from_subset: Optional[List[OpenstackResourceObj]] = None,
         **kwargs,
     ):
@@ -114,24 +114,27 @@ class QueryAPI:
         :param kwargs: keyword args that can be used to configure details of how query is run
             - valid kwargs specific to resource
         """
+        if not cloud_account and not from_subset:
+            raise ParseQueryError(
+                "please provide either:"
+                "\n\tcloud_account - a cloud domain to run query using openstacksdk"
+                "\n\tfrom_subset - a set of openstack objects"
+            )
 
         if from_subset:
-            logger.debug(
-                "'from_subset' optional param given - will run client-side filters only"
-            )
-            self.executer.client_side_filters = (
+            filters = (
                 self.builder.client_side_filters + self.builder.server_filter_fallback
             )
-            self.executer.server_side_filters = None
+            self.executer.run_with_subset(
+                subset=from_subset, client_side_filters=filters
+            )
         else:
-            self.executer.client_side_filters = self.builder.client_side_filters
-            self.executer.server_side_filters = self.builder.server_side_filters
-
-        self.executer.run_query(
-            cloud_account=cloud_account,
-            from_subset=from_subset,
-            **kwargs,
-        )
+            self.executer.run_with_openstacksdk(
+                cloud_account=cloud_account,
+                client_side_filters=self.builder.client_side_filters,
+                server_side_filters=self.builder.server_side_filters,
+                **kwargs,
+            )
 
         link_prop, forwarded_vals = self.chainer.forwarded_info
         if forwarded_vals:

--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -116,7 +116,7 @@ class QueryAPI:
         """
         if not cloud_account and not from_subset:
             raise ParseQueryError(
-                "please provide either:"
+                "please provide as a parameter, one of:"
                 "\n\tcloud_account - a cloud domain to run query using openstacksdk"
                 "\n\tfrom_subset - a set of openstack objects"
             )

--- a/lib/openstack_query/query_blocks/query_executer.py
+++ b/lib/openstack_query/query_blocks/query_executer.py
@@ -19,9 +19,6 @@ from custom_types.openstack_query.aliases import (
 logger = logging.getLogger(__name__)
 
 
-# pylint:disable=too-many-instance-attributes
-
-
 class QueryExecuter:
     """
     Helper class to handle executing the query - primarily performing 'run()' method
@@ -117,7 +114,7 @@ class QueryExecuter:
         subset = self.runner.parse_subset(subset)
 
         resource_objects = RunnerUtils.apply_client_side_filters(
-            items=subset, filters=client_side_filters
+            subset, client_side_filters
         )
 
         logger.info(

--- a/lib/openstack_query/query_blocks/query_executer.py
+++ b/lib/openstack_query/query_blocks/query_executer.py
@@ -1,10 +1,13 @@
-import time
 import logging
-from typing import Optional, Dict, List, Any, Union, Type
+import time
+from typing import Optional, Dict, List, Type
 
 from openstack_query.query_blocks.results_container import ResultsContainer
 from openstack_query.runners.runner_wrapper import RunnerWrapper
-from enums.cloud_domains import CloudDomains
+from openstack_query.runners.runner_utils import RunnerUtils
+
+from openstack_api.openstack_connection import OpenstackConnection
+
 from enums.query.props.prop_enum import PropEnum
 
 from custom_types.openstack_query.aliases import (
@@ -28,11 +31,11 @@ class QueryExecuter:
         self,
         prop_enum_cls: Type[PropEnum],
         runner_cls: Type[RunnerWrapper],
+        connection_cls=OpenstackConnection,
     ):
         self._results_container = ResultsContainer(prop_enum_cls)
+        self._connection_cls = connection_cls
         self.runner = runner_cls(prop_enum_cls.get_marker_prop_func())
-        self._client_side_filters = None
-        self._server_side_filters = None
         self.has_forwarded_results = False
 
     @property
@@ -41,69 +44,6 @@ class QueryExecuter:
         a getter method for results container object holding query results
         """
         return self._results_container
-
-    @property
-    def client_side_filters(self):
-        """
-        a getter method to return the client-side filter function
-        """
-        return self._client_side_filters
-
-    @client_side_filters.setter
-    def client_side_filters(self, client_filters=ClientSideFilters):
-        """
-        Setter method for setting run filters
-        :param client_filters: a list of filter functions that each take an openstack resource
-        and returns True if it matches filter, False if not
-        """
-        self._client_side_filters = client_filters
-
-    @property
-    def server_side_filters(self):
-        """
-        a getter method to return the server side filter functions
-        """
-        return self._server_side_filters
-
-    @server_side_filters.setter
-    def server_side_filters(self, server_filters: ServerSideFilters):
-        """
-        a setter method to return the server side filter functions
-        :param server_filters: A dictionary of filter kwargs to pass to openstacksdk
-        """
-        self._server_side_filters = server_filters
-
-    def run_query(
-        self,
-        cloud_account: Union[str, CloudDomains],
-        from_subset: Optional[List[Any]] = None,
-        **kwargs,
-    ):
-        """
-        method that runs the query provided and outputs
-        :param cloud_account: An Enum for the account from the clouds configuration to use
-        :param from_subset: A subset of openstack resources to run query on instead of querying openstacksdk
-        :param kwargs: An extra set of kwargs to pass to internal _run_query method that changes what/how the
-        openstacksdk query is run
-            - valid kwargs to _run_query is specific to the runner object - see docstrings for _run_query() on the
-            runner of interest.
-        """
-
-        if isinstance(cloud_account, CloudDomains):
-            cloud_account = cloud_account.name.lower()
-
-        start = time.time()
-
-        self.results_container.store_query_results(
-            self.runner.run(
-                cloud_account=cloud_account,
-                client_side_filters=self.client_side_filters,
-                server_side_filters=self.server_side_filters,
-                from_subset=from_subset,
-                **kwargs,
-            )
-        )
-        logger.debug("run completed - time elapsed: %s seconds", time.time() - start)
 
     def apply_forwarded_results(
         self, link_prop: PropEnum, forwarded_results: Dict[PropValue, List[Dict]]
@@ -115,3 +55,74 @@ class QueryExecuter:
         """
         self.has_forwarded_results = True
         self.results_container.apply_forwarded_results(link_prop, forwarded_results)
+
+    def run_with_openstacksdk(
+        self,
+        cloud_account: str,
+        client_side_filters: Optional[ClientSideFilters] = None,
+        server_side_filters: Optional[ServerSideFilters] = None,
+        **kwargs,
+    ):
+        """
+        public method that runs the query by querying openstacksdk using the Runner class stored one or more times
+        and then applying any client-side filter function(s).
+        :param cloud_account: A string for the account from the clouds configuration to use
+        :param client_side_filters: An Optional list of filter functions to run locally that we can use to limit the
+        results after querying openstacksdk
+        :param server_side_filters: An Optional list of filter kwargs to limit the results by when querying openstacksdk
+        :param kwargs: An extra set of kwargs to pass to internal _run_query method that changes what/how the
+        openstacksdk query is run
+            - valid kwargs to _run_query is specific to the runner object - see docstrings for _run_query() on the
+            runner of interest.
+        """
+        if not server_side_filters:
+            server_side_filters = [None]
+
+        start = time.time()
+        resource_objects = []
+        with self._connection_cls(cloud_account) as conn:
+            logger.debug(
+                "openstack connection established - using cloud account '%s'",
+                cloud_account,
+            )
+            meta_params = self.runner.parse_meta_params(conn, **kwargs)
+            for i, query_filters in enumerate(server_side_filters, 1):
+                logger.debug("running query %s / %s", i, len(server_side_filters))
+                resource_objects.extend(
+                    self.runner.run_query(conn, query_filters, **meta_params)
+                )
+
+        if client_side_filters:
+            resource_objects = RunnerUtils.apply_client_side_filters(
+                resource_objects, client_side_filters
+            )
+        logger.info(
+            "Query Complete! Found %s items. Time elapsed: %0.4f seconds",
+            len(resource_objects),
+            time.time() - start,
+        )
+
+        self.results_container.store_query_results(resource_objects)
+
+    def run_with_subset(self, subset: List, client_side_filters: ClientSideFilters):
+        """
+        Public method that runs the query when provided a subset. This will apply client-side filter functions
+        on the subset without needing to query using the sdk
+        :param subset: A subset of openstack resources to run query on instead of querying openstacksdk
+        :param client_side_filters: A list of filter functions to apply
+        """
+        logger.info("'from_subset' meta param given - running query on subset")
+        start = time.time()
+
+        subset = self.runner.parse_subset(subset)
+
+        resource_objects = RunnerUtils.apply_client_side_filters(
+            items=subset, filters=client_side_filters
+        )
+
+        logger.info(
+            "Query Complete! Found %s items. Time elapsed: %0.4f seconds",
+            len(resource_objects),
+            time.time() - start,
+        )
+        self.results_container.store_query_results(resource_objects)

--- a/lib/openstack_query/runners/flavor_runner.py
+++ b/lib/openstack_query/runners/flavor_runner.py
@@ -4,12 +4,11 @@ import logging
 from openstack.compute.v2.flavor import Flavor
 from openstack_api.openstack_connection import OpenstackConnection
 from openstack_query.runners.runner_wrapper import RunnerWrapper
+from openstack_query.runners.runner_utils import RunnerUtils
 
 from custom_types.openstack_query.aliases import ServerSideFilters
 
 logger = logging.getLogger(__name__)
-
-# pylint:disable=too-few-public-methods
 
 
 class FlavorRunner(RunnerWrapper):
@@ -20,11 +19,15 @@ class FlavorRunner(RunnerWrapper):
 
     RESOURCE_TYPE = Flavor
 
-    def _parse_meta_params(self, _: OpenstackConnection, **__):
+    def parse_meta_params(self, conn: OpenstackConnection, **kwargs):
+        """
+        This method is a helper function that will parse a set of meta params specific to the resource and
+        return a set of parsed meta-params to pass to _run_query
+        """
         logger.debug("FlavorQuery has no meta-params available")
-        return {}
+        return super().parse_meta_params(conn, **kwargs)
 
-    def _run_query(
+    def run_query(
         self,
         conn: OpenstackConnection,
         filter_kwargs: Optional[ServerSideFilters] = None,
@@ -46,4 +49,6 @@ class FlavorRunner(RunnerWrapper):
             "running openstacksdk command conn.compute.flavors(%s)",
             ",".join(f"{key}={value}" for key, value in filter_kwargs.items()),
         )
-        return self._run_paginated_query(conn.compute.flavors, filter_kwargs)
+        return RunnerUtils.run_paginated_query(
+            conn.compute.flavors, self._page_marker_prop_func, filter_kwargs
+        )

--- a/lib/openstack_query/runners/project_runner.py
+++ b/lib/openstack_query/runners/project_runner.py
@@ -4,13 +4,12 @@ import logging
 from openstack.identity.v3.project import Project
 
 from openstack_api.openstack_connection import OpenstackConnection
+from openstack_query.runners.runner_utils import RunnerUtils
 from openstack_query.runners.runner_wrapper import RunnerWrapper
 
 from custom_types.openstack_query.aliases import ServerSideFilters
 
 logger = logging.getLogger(__name__)
-
-# pylint:disable=too-few-public-methods
 
 
 class ProjectRunner(RunnerWrapper):
@@ -21,11 +20,15 @@ class ProjectRunner(RunnerWrapper):
 
     RESOURCE_TYPE = Project
 
-    def _parse_meta_params(self, _: OpenstackConnection, **__):
+    def parse_meta_params(self, conn: OpenstackConnection, **kwargs):
+        """
+        This method is a helper function that will parse a set of meta params specific to the resource and
+        return a set of parsed meta-params to pass to _run_query
+        """
         logger.debug("ProjectQuery has no meta-params available")
-        return {}
+        return super().parse_meta_params(conn, **kwargs)
 
-    def _run_query(
+    def run_query(
         self,
         conn: OpenstackConnection,
         filter_kwargs: Optional[ServerSideFilters] = None,
@@ -52,4 +55,6 @@ class ProjectRunner(RunnerWrapper):
             "running openstacksdk command conn.identity.projects(%s)",
             ",".join(f"{key}={value}" for key, value in filter_kwargs.items()),
         )
-        return self._run_paginated_query(conn.identity.projects, filter_kwargs)
+        return RunnerUtils.run_paginated_query(
+            conn.identity.projects, self._page_marker_prop_func, filter_kwargs
+        )

--- a/lib/openstack_query/runners/runner_utils.py
+++ b/lib/openstack_query/runners/runner_utils.py
@@ -1,10 +1,11 @@
 from typing import Callable, Optional, List
+import logging
+
 from custom_types.openstack_query.aliases import (
     ServerSideFilter,
     ClientSideFilters,
     ClientSideFilterFunc,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,8 @@ class RunnerUtils:
         :param server_side_filter_set: A set of filters to pass to openstacksdk call
         :param page_size: (Default 1000) how many items are returned by single call
         :param call_limit: (Default 1000) max number of paging iterations.
-            - this is required to mitigate some bugs where successive paging loops back on itself leading to endless calls
+            - this is required to mitigate some bugs where successive paging loops back on itself leading
+            to endless calls
         """
 
         paginated_filters = {"limit": page_size, "marker": None}

--- a/lib/openstack_query/runners/runner_utils.py
+++ b/lib/openstack_query/runners/runner_utils.py
@@ -1,0 +1,107 @@
+from typing import Callable, Optional, List
+from custom_types.openstack_query.aliases import (
+    ServerSideFilter,
+    ClientSideFilters,
+    ClientSideFilterFunc,
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RunnerUtils:
+    """
+    A helper class which holds utility functions for Runner classes
+    """
+
+    @staticmethod
+    def run_paginated_query(
+        paginated_call: Callable,
+        marker_prop_func: Callable,
+        server_side_filter_set: Optional[ServerSideFilter] = None,
+        page_size=1000,
+        call_limit=1000,
+    ):
+        """
+        Helper method for running a query using pagination - openstacksdk calls usually return a maximum number of
+        values - (set by limit) and to continue getting values we can pass a "marker" value of the last item seen to
+        continue the query - this speeds up the time needed to run queries
+        :param paginated_call: A function which takes a openstacksdk call which allows limit and marker to be set
+        :param marker_prop_func: A function which takes a openstack resource object and return value of a property
+        that can be used as a marker for pagination
+        :param server_side_filter_set: A set of filters to pass to openstacksdk call
+        :param page_size: (Default 1000) how many items are returned by single call
+        :param call_limit: (Default 1000) max number of paging iterations.
+            - this is required to mitigate some bugs where successive paging loops back on itself leading to endless calls
+        """
+
+        paginated_filters = {"limit": page_size, "marker": None}
+        paginated_filters.update(server_side_filter_set)
+        query_res = []
+
+        curr_marker = None
+        num_calls = 1
+        while True:
+            logger.debug("starting page loop, completed %s loops", num_calls)
+            num_calls += 1
+            if num_calls > call_limit:
+                logger.warning(
+                    "max page loops reached %s - terminating early", num_calls
+                )
+                break
+
+            prev = None
+            for i, resource in enumerate(paginated_call(**paginated_filters)):
+                # Workaround for Endless loop error detected if querying for stfc users (via ldap)
+                # for loop doesn't seem to terminate - and outputs the same value when given "limit" and "marker"
+                if prev == resource:
+                    logger.warning(
+                        "duplicate entries found, likely an endless page loop - terminating early"
+                    )
+                    break
+
+                query_res.append(resource)
+                # openstacksdk calls break after going over pagination limit
+                if i == page_size - 1:
+                    # restart the for loop with marker set
+                    paginated_filters.update({"marker": marker_prop_func(resource)})
+                    logger.debug(
+                        "page limit reached: %s - setting new marker: %s",
+                        page_size,
+                        paginated_filters["marker"],
+                    )
+                    break
+
+                prev = resource
+
+            # if marker hasn't changed, then has query terminated
+            if not paginated_filters or paginated_filters["marker"] == curr_marker:
+                logger.debug("page loop terminated")
+                break
+            # set marker as current
+            curr_marker = paginated_filters["marker"]
+        return query_res
+
+    @staticmethod
+    def apply_client_side_filters(items: List, filters: ClientSideFilters):
+        """
+        Removes items from a list by running a given filter functions
+        :param items: List of items to query e.g. list of servers
+        :param filters: filter functions that we can use to limit the results after querying openstacksdk,
+            - each function takes an openstack resource object and returns True if it passes the filter, false if not
+        :return: List of items that match the1 given query
+        """
+        for client_filter in filters:
+            items = RunnerUtils._apply_client_side_filter(items, client_filter)
+        return items
+
+    @staticmethod
+    def _apply_client_side_filter(
+        items: List, client_filter: ClientSideFilterFunc
+    ) -> Optional[List]:
+        """
+        Method that will apply a client filter on a list of openstack items
+        :param items: A list of openstack resources
+        :param client_filter: A client filter to apply
+        """
+        return [item for item in items if client_filter(item) is True]

--- a/lib/openstack_query/runners/runner_wrapper.py
+++ b/lib/openstack_query/runners/runner_wrapper.py
@@ -1,237 +1,43 @@
-import logging
-import time
 from abc import abstractmethod
-from typing import Optional, List, Any, Dict, Callable
+from typing import Optional, List, Dict
 
 from custom_types.openstack_query.aliases import (
     PropFunc,
     ServerSideFilters,
-    ClientSideFilters,
     OpenstackResourceObj,
-    ClientSideFilterFunc,
 )
-from exceptions.parse_query_error import ParseQueryError
 from openstack_api.openstack_connection import OpenstackConnection
-from openstack_api.openstack_wrapper_base import OpenstackWrapperBase
-
-logger = logging.getLogger(__name__)
-
-# pylint:disable=too-few-public-methods
+from exceptions.parse_query_error import ParseQueryError
 
 
-class RunnerWrapper(OpenstackWrapperBase):
+class RunnerWrapper:
     """
     Base class for Runner classes.
     Runner classes encapsulate running any openstacksdk commands
     """
 
-    # Sets the limit for getting values from openstack
-    _LIMIT_FOR_PAGINATION = 1000
-    _PAGINATION_CALL_LIMIT = 1000
     RESOURCE_TYPE = type(None)
 
-    def __init__(self, marker_prop_func: PropFunc, connection_cls=OpenstackConnection):
-        OpenstackWrapperBase.__init__(self, connection_cls)
+    def __init__(self, marker_prop_func: PropFunc):
         self._page_marker_prop_func = marker_prop_func
 
-    def run(
-        self,
-        cloud_account: str,
-        client_side_filters: Optional[ClientSideFilters] = None,
-        server_side_filters: Optional[ServerSideFilters] = None,
-        from_subset: Optional[List[Any]] = None,
-        **kwargs,
+    def parse_subset(
+        self, subset: List[OpenstackResourceObj]
     ) -> List[OpenstackResourceObj]:
         """
-        Public method that runs the query by querying openstacksdk and then applying a filter function.
-        :param cloud_account: A string for the account from the clouds configuration to use
-        :param client_side_filters: An Optional list of filter functions to run locally that we can use to limit the
-        results after querying openstacksdk
-        :param server_side_filters: An Optional list of filter kwargs to limit the results by when querying openstacksdk
-        :param from_subset: A subset of openstack resources to run query on instead of querying openstacksdk
-        :param kwargs: An extra set of kwargs to pass to internal _run_query method that changes what/how the
-        openstacksdk query is run
-            - valid kwargs to _run_query is specific to the runner object - see docstrings for _run_query() on the
-            runner of interest.
+        This method is a helper function that will check a subset of openstack objects and check their validity
+        :param subset: A list of openstack objects to parse
         """
 
-        if from_subset and server_side_filters:
-            logger.error(
-                "Error: Received server-side filters - suggesting that the query requires getting results via "
-                "openstacksdk, but also openstack objects directly - suggesting that we want to filter a set already "
-                "given. Not sure what to do - aborting."
+        # connection object may need to be used if we want to run validation checks
+        if any(not isinstance(i, self.RESOURCE_TYPE) for i in subset):
+            raise ParseQueryError(
+                f"'from_subset' only accepts openstack objects of type {self.RESOURCE_TYPE}"
             )
-            raise RuntimeError(
-                "Ambiguous Query: received both server-side filters and values passed directly"
-            )
-
-        logger.debug("making connection to openstack")
-        start = time.time()
-
-        if from_subset:
-            logger.info("'from_subset' meta param given - running query on subset")
-            resource_objects = self._parse_subset(
-                subset=from_subset,
-            )
-            logger.debug(
-                "subset parsed. (time elapsed: %0.4f seconds)", time.time() - start
-            )
-        else:
-            logger.info("running query using openstacksdk and server-side filters")
-            with self._connection_cls(cloud_account) as conn:
-                logger.debug(
-                    "openstack connection established - using cloud account '%s'",
-                    cloud_account,
-                )
-                resource_objects = self._run_with_openstacksdk(
-                    conn=conn, server_filters=server_side_filters, **kwargs
-                )
-            logger.debug(
-                "server-side quer(y/ies) completed - found %s items. (time elapsed: %0.4f seconds)",
-                len(resource_objects),
-                time.time() - start,
-            )
-
-        logger.info("applying client side filters - if any")
-        if client_side_filters:
-            resource_objects = self._apply_client_side_filters(
-                items=resource_objects, filters=client_side_filters
-            )
-
-        logger.info(
-            "Query Complete! Found %s items. Time elapsed: %0.4f seconds",
-            len(resource_objects),
-            time.time() - start,
-        )
-        return resource_objects
-
-    def _run_with_openstacksdk(
-        self,
-        conn: OpenstackConnection,
-        server_filters: Optional[ServerSideFilters] = None,
-        **kwargs,
-    ):
-        if not server_filters:
-            server_filters = [None]
-
-        kwargs = self._parse_meta_params(conn, **kwargs)
-        meta_param_log_str = "\n\t\t".join(
-            [f"{key}: '{val}'" for key, val in kwargs.items()]
-        )
-        logger.info("found %s set(s) of server-side filters", len(server_filters))
-        resource_objects = []
-        for i, query_filters in enumerate(server_filters, 1):
-            logger.debug("running query %s / %s", i, len(server_filters))
-
-            filters_log_str = "None (getting all)"
-            if query_filters:
-                filters_log_str = "\n\t".join(
-                    [f"{key}: '{val}'" for key, val in query_filters.items()]
-                )
-
-            logger.debug(
-                "Running OpenstackSDK Query with: "
-                "\n\tserver side filters: "
-                "\n%s "
-                "\n\n meta kwargs: "
-                "\n\t%s",
-                filters_log_str,
-                "None" if not meta_param_log_str else meta_param_log_str,
-            )
-
-            resource_objects.extend(self._run_query(conn, query_filters, **kwargs))
-
-        return resource_objects
-
-    def _run_paginated_query(
-        self,
-        paginated_call: Callable,
-        server_side_filters: Optional[ServerSideFilters] = None,
-    ):
-        """
-        Helper method for running a query using pagination - openstacksdk calls usually return a maximum number of
-        values - (set by limit) and to continue getting values we can pass a "marker" value of the last item seen to
-        continue the query - this speeds up the time needed to run queries
-        :param paginated_call: A lambda function which takes a openstacksdk call which allows limit and marker to be set
-        :param server_side_filters: A set of filters to pass to openstacksdk call
-        """
-
-        paginated_filters = {"limit": self._LIMIT_FOR_PAGINATION, "marker": None}
-        paginated_filters.update(server_side_filters)
-        query_res = []
-
-        curr_marker = None
-        num_calls = 1
-        while True:
-            logger.debug("starting page loop, completed %s loops", num_calls)
-            num_calls += 1
-            if num_calls > self._PAGINATION_CALL_LIMIT:
-                logger.warning(
-                    "max page loops reached %s - terminating early", num_calls
-                )
-                break
-
-            prev = None
-            for i, resource in enumerate(paginated_call(**paginated_filters)):
-                # Workaround for Endless loop error detected if querying for stfc users (via ldap)
-                # for loop doesn't seem to terminate - and outputs the same value when given "limit" and "marker"
-                if prev == resource:
-                    logger.warning(
-                        "duplicate entries found, likely an endless page loop - terminating early"
-                    )
-                    break
-
-                query_res.append(resource)
-                # openstacksdk calls break after going over pagination limit
-                if i == self._LIMIT_FOR_PAGINATION - 1:
-                    # restart the for loop with marker set
-                    paginated_filters.update(
-                        {"marker": self._page_marker_prop_func(resource)}
-                    )
-                    logger.debug(
-                        "page limit reached: %s - setting new marker: %s",
-                        self._LIMIT_FOR_PAGINATION,
-                        paginated_filters["marker"],
-                    )
-                    break
-
-                prev = resource
-
-            # if marker hasn't changed, then has query terminated
-            if not paginated_filters or paginated_filters["marker"] == curr_marker:
-                logger.debug("page loop terminated")
-                break
-            # set marker as current
-            curr_marker = paginated_filters["marker"]
-        return query_res
-
-    def _apply_client_side_filters(
-        self, items: List[OpenstackResourceObj], filters: ClientSideFilters
-    ) -> List[OpenstackResourceObj]:
-        """
-        Removes items from a list by running a given filter functions
-        :param items: List of items to query e.g. list of servers
-        :param filters: filter functions that we can use to limit the results after querying openstacksdk,
-            - each function takes an openstack resource object and returns True if it passes the filter, false if not
-        :return: List of items that match the1 given query
-        """
-        for client_filter in filters:
-            items = self._apply_client_side_filter(items, client_filter)
-        return items
-
-    @staticmethod
-    def _apply_client_side_filter(
-        items: List[OpenstackResourceObj], client_filter: ClientSideFilterFunc
-    ) -> Optional[List[OpenstackResourceObj]]:
-        """
-        Method that will apply a client filter on a list of openstack items
-        :param items: A list of openstack resources
-        :param client_filter: A client filter to apply
-        """
-        return [item for item in items if client_filter(item) is True]
+        return subset
 
     @abstractmethod
-    def _run_query(
+    def run_query(
         self,
         conn: OpenstackConnection,
         filter_kwargs: Optional[ServerSideFilters] = None,
@@ -246,25 +52,10 @@ class RunnerWrapper(OpenstackWrapperBase):
         openstacksdk query is run - these kwargs are specific to the resource runner.
         """
 
-    def _parse_subset(
-        self, subset: List[OpenstackResourceObj]
-    ) -> List[OpenstackResourceObj]:
-        """
-        This method is a helper function that will check a subset of openstack objects and check their validity
-        :param _: An OpenstackConnection object - not used right now
-        :param subset: A list of openstack objects to parse
-        """
-
-        # connection object may need to be used if we want to run validation checks
-        if any(not isinstance(i, self.RESOURCE_TYPE) for i in subset):
-            raise ParseQueryError(
-                f"'from_subset' only accepts openstack objects of type {self.RESOURCE_TYPE}"
-            )
-        return subset
-
     @abstractmethod
-    def _parse_meta_params(self, conn: OpenstackConnection, **kwargs) -> Dict[str, str]:
+    def parse_meta_params(self, conn: OpenstackConnection, **kwargs) -> Dict[str, str]:
         """
         This method is a helper function that will parse a set of meta params specific to the resource and
         return a set of parsed meta-params to pass to _run_query
         """
+        return {}

--- a/tests/lib/openstack_query/query_blocks/test_query_executer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_executer.py
@@ -1,11 +1,9 @@
-from unittest.mock import MagicMock, NonCallableMock
+from unittest.mock import MagicMock, NonCallableMock, patch
 import pytest
 
 from enums.cloud_domains import CloudDomains
 from openstack_query.query_blocks.query_executer import QueryExecuter
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
-
-# pylint:disable=protected-access
 
 
 @pytest.fixture(name="instance")
@@ -15,17 +13,8 @@ def instance_fixture():
     """
     mock_prop_enum_cls = MockProperties
     mock_runner_cls = MagicMock()
-    query_executer = QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
-    query_executer._results_container = MagicMock()
-    return query_executer
-
-
-def test_results_container(instance):
-    """
-    Tests that results container property works as expected
-    """
-    mock_results_container = instance._results_container
-    assert instance.results_container == mock_results_container
+    with patch("openstack_query.query_blocks.query_executer.ResultsContainer"):
+        return QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
 
 
 def test_client_side_filter_func(instance):

--- a/tests/lib/openstack_query/query_blocks/test_query_executer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_executer.py
@@ -1,20 +1,27 @@
-from unittest.mock import MagicMock, NonCallableMock, patch
+from unittest.mock import MagicMock, NonCallableMock, patch, call
 import pytest
 
-from enums.cloud_domains import CloudDomains
 from openstack_query.query_blocks.query_executer import QueryExecuter
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 
 
+@pytest.fixture(scope="function", name="mock_connection_cls")
+def mock_connection_cls_fixture():
+    """
+    Returns a mocked OpenstackConnection class
+    """
+    return MagicMock()
+
+
 @pytest.fixture(name="instance")
-def instance_fixture():
+def instance_fixture(mock_connection_cls):
     """
     Returns an instance with a mocked runner and prop enum class
     """
     mock_prop_enum_cls = MockProperties
     mock_runner_cls = MagicMock()
     with patch("openstack_query.query_blocks.query_executer.ResultsContainer"):
-        return QueryExecuter(mock_prop_enum_cls, mock_runner_cls)
+        return QueryExecuter(mock_prop_enum_cls, mock_runner_cls, mock_connection_cls)
 
 
 def test_client_side_filter_func(instance):
@@ -35,37 +42,6 @@ def test_server_side_filters(instance):
     assert instance.server_side_filters == mock_client_filter
 
 
-@pytest.mark.parametrize(
-    "mock_cloud_account, expected_cloud_account_str",
-    [(CloudDomains.PROD, "prod"), ("domain", "domain")],
-)
-def test_run_query(mock_cloud_account, expected_cloud_account_str, instance):
-    """
-    Tests that run_query method works as expected
-    simply calls runner.run() and saves result in raw_results
-    """
-    instance.client_side_filters = MagicMock()
-    instance.server_side_filters = MagicMock()
-
-    instance.run_query(
-        cloud_account=mock_cloud_account,
-        from_subset="some-subset",
-        **{"arg1": "val1", "arg2": "val2"}
-    )
-
-    instance.results_container.store_query_results.assert_called_once_with(
-        instance.runner.run.return_value
-    )
-
-    instance.runner.run.assert_called_once_with(
-        cloud_account=expected_cloud_account_str,
-        client_side_filters=instance.client_side_filters,
-        server_side_filters=instance.server_side_filters,
-        from_subset="some-subset",
-        **{"arg1": "val1", "arg2": "val2"}
-    )
-
-
 def test_apply_forwarded_results(instance):
     """
     Test apply_forwarded_results method - should forward to results_container
@@ -78,3 +54,146 @@ def test_apply_forwarded_results(instance):
         mock_link_prop, mock_results
     )
     assert instance.has_forwarded_results
+
+
+@pytest.fixture(name="run_with_openstacksdk_runner")
+def run_with_openstacksdk_runner_fixture(instance, mock_connection_cls):
+    """
+    Fixture to run run_with_openstacksdk() test cases with different args
+    """
+
+    @patch("openstack_query.runners.runner_utils.RunnerUtils.apply_client_side_filters")
+    def _run_with_openstacksdk_runner(
+        mock_server_side_filters,
+        use_client_side_filters,
+        mock_apply_client_side_filters,
+    ):
+        """
+        method to run_with_openstacksdk() test case with provided input values
+        The individual methods that are called in run must be patched out by the test function
+        prior to this and any asserts need to be done by the test function
+        """
+        mock_cloud_account = NonCallableMock()
+        mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+        mock_meta_params = {"meta-arg1": "val1", "meta-arg2": "val2"}
+        instance.runner.parse_meta_params.return_value = mock_meta_params
+
+        mock_run_query_out = NonCallableMock()
+        instance.runner.run_query.return_value = [mock_run_query_out]
+
+        mock_conn = mock_connection_cls.return_value.__enter__.return_value
+
+        mock_client_side_filters = None
+        if use_client_side_filters:
+            mock_client_side_filters = NonCallableMock()
+
+        instance.run_with_openstacksdk(
+            cloud_account=mock_cloud_account,
+            client_side_filters=mock_client_side_filters,
+            server_side_filters=mock_server_side_filters,
+            **mock_kwargs,
+        )
+
+        mock_connection_cls.assert_called_once_with(mock_cloud_account)
+
+        instance.runner.parse_meta_params.assert_called_once_with(
+            mock_conn,
+            **mock_kwargs,
+        )
+
+        if mock_server_side_filters:
+            instance.runner.run_query.assert_has_calls(
+                [
+                    call(mock_conn, mock_filter, **mock_meta_params)
+                    for mock_filter in mock_server_side_filters
+                ]
+            )
+            query_out = [mock_run_query_out for _ in mock_server_side_filters]
+
+        else:
+            instance.runner.run_query.assert_called_once_with(
+                mock_conn, None, **mock_meta_params
+            )
+            query_out = [mock_run_query_out]
+
+        if use_client_side_filters:
+            mock_apply_client_side_filters.assert_called_once_with(
+                query_out, mock_client_side_filters
+            )
+            query_out = mock_apply_client_side_filters.return_value
+        instance.results_container.store_query_results.assert_called_once_with(
+            query_out
+        )
+
+    return _run_with_openstacksdk_runner
+
+
+def test_run_with_openstacksdk_one_server_filter(run_with_openstacksdk_runner):
+    """
+    Tests run_with_openstacksdk with one server filter no client filters
+    """
+    run_with_openstacksdk_runner(
+        [{"filter1": "val1"}],
+        False,
+    )
+
+
+def test_run_with_openstacksdk_one_server_and_client_filter(
+    run_with_openstacksdk_runner,
+):
+    """
+    Tests run_with_openstacksdk with one server filter and client filters
+    """
+    run_with_openstacksdk_runner(
+        [{"filter1": "val1"}],
+        True,
+    )
+
+
+def test_run_with_openstacksdk_multi_server_and_client_filters(
+    run_with_openstacksdk_runner,
+):
+    """
+    Tests run_with_openstacksdk with multiple server filters and client filters
+    """
+    run_with_openstacksdk_runner(
+        [{"filter1": "val1"}, {"filter2": "val2"}],
+        True,
+    )
+
+
+def test_run_with_openstacksdk_multi_server_filters(run_with_openstacksdk_runner):
+    """
+    Tests run_with_openstacksdk with multiple server filters and no client filters
+    """
+    run_with_openstacksdk_runner(
+        [{"filter1": "val1"}, {"filter2": "val2"}],
+        False,
+    )
+
+
+def test_run_with_openstacksdk_no_filters(run_with_openstacksdk_runner):
+    """
+    Tests run_with_openstacksdk with no server filters
+    """
+    run_with_openstacksdk_runner(None, False)
+
+
+@patch("openstack_query.runners.runner_utils.RunnerUtils.apply_client_side_filters")
+def test_with_subset(mock_apply_client_side_filters, instance):
+    """
+    Tests run_with_subset
+    """
+    mock_subset = NonCallableMock()
+    mock_client_filters = NonCallableMock()
+    instance.run_with_subset(mock_subset, mock_client_filters)
+    instance.runner.parse_subset.assert_called_once_with(mock_subset)
+
+    mock_apply_client_side_filters.assert_called_once_with(
+        instance.runner.parse_subset.return_value, mock_client_filters
+    )
+
+    instance.results_container.store_query_results.assert_called_once_with(
+        mock_apply_client_side_filters.return_value
+    )

--- a/tests/lib/openstack_query/runners/conftest.py
+++ b/tests/lib/openstack_query/runners/conftest.py
@@ -2,17 +2,6 @@ from unittest.mock import MagicMock
 import pytest
 
 
-@pytest.fixture(scope="function", name="mock_connection")
-def mock_connection_fixture():
-    """
-    Returns a mocked OpenstackConnection class
-    """
+@pytest.fixture(scope="function", name="mock_marker_prop_func")
+def mock_marker_prop_func_fixture():
     return MagicMock()
-
-
-@pytest.fixture(scope="function", name="mock_openstack_connection")
-def mock_openstack_connection_fixture(mock_connection):
-    """
-    Returns a mocked openstacksdk connection object
-    """
-    return mock_connection.return_value.__enter__.return_value

--- a/tests/lib/openstack_query/runners/test_project_runner.py
+++ b/tests/lib/openstack_query/runners/test_project_runner.py
@@ -1,42 +1,35 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, NonCallableMock, patch
 import pytest
 
 from openstack_query.runners.project_runner import ProjectRunner
-from openstack.identity.v3.project import Project
-from exceptions.parse_query_error import ParseQueryError
-
-# pylint:disable=protected-access
 
 
 @pytest.fixture(name="instance")
-def instance_fixture(mock_connection):
+def instance_fixture(mock_marker_prop_func):
     """
     Returns an instance to run tests with
     """
-    mock_marker_prop_func = MagicMock()
-    return ProjectRunner(
-        marker_prop_func=mock_marker_prop_func, connection_cls=mock_connection
-    )
+    return ProjectRunner(marker_prop_func=mock_marker_prop_func)
 
 
-def test_parse_query_params_raise_error(instance, mock_openstack_connection):
+def test_parse_meta_params(instance):
     """
     tests that parse_query_params returns empty dict - ProjectQuery accepts no meta-params currently
     """
     assert (
-        instance._parse_meta_params(
-            mock_openstack_connection, **{"arg1": "val1", "arg2": "val2"}
+        instance.parse_meta_params(
+            NonCallableMock(), **{"arg1": "val1", "arg2": "val2"}
         )
         == {}
     )
 
 
-@patch("openstack_query.runners.project_runner.ProjectRunner._run_paginated_query")
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
 def test_run_query_no_server_filters(
-    mock_run_paginated_query, instance, mock_openstack_connection
+    mock_run_paginated_query, instance, mock_marker_prop_func
 ):
     """
-    Tests that _run_query method works expectedly with no server-side filters
+    Tests that run_query method works expectedly with no server-side filters
     """
     mock_user_list = mock_run_paginated_query.return_value = [
         "project1",
@@ -44,59 +37,34 @@ def test_run_query_no_server_filters(
         "project3",
     ]
     mock_filter_kwargs = None
-    res = instance._run_query(
-        mock_openstack_connection,
+    mock_connection = MagicMock()
+
+    res = instance.run_query(
+        mock_connection,
         filter_kwargs=mock_filter_kwargs,
     )
 
     mock_run_paginated_query.assert_called_once_with(
-        mock_openstack_connection.identity.projects, {}
+        mock_connection.identity.projects, mock_marker_prop_func, {}
     )
     assert res == mock_user_list
 
 
-def test_run_query_with_id_in_filter(instance, mock_openstack_connection):
+def test_run_query_with_id_in_filter(instance):
     """
-    Tests that _run_query method works expectedly with 'id' in server-side filters
+    Tests that run_query method works expectedly with 'id' in server-side filters
     """
 
     mock_filter_kwargs = {"id": "project_id1"}
-    res = instance._run_query(
-        mock_openstack_connection,
+    mock_connection = MagicMock()
+
+    res = instance.run_query(
+        mock_connection,
         filter_kwargs=mock_filter_kwargs,
     )
 
-    mock_openstack_connection.identity.find_project.assert_called_once_with(
+    mock_connection.identity.find_project.assert_called_once_with(
         "project_id1", ignore_missing=True
     )
 
-    assert res == [mock_openstack_connection.identity.find_project.return_value]
-
-
-def test_parse_subset(instance):
-    """
-    Tests _parse_subset works expectedly
-    method simply checks each value in 'subset' param is of the Flavor type and returns it
-    """
-
-    # with one item
-    mock_project_1 = MagicMock()
-    mock_project_1.__class__ = Project
-    res = instance._parse_subset([mock_project_1])
-    assert res == [mock_project_1]
-
-    # with two items
-    mock_project_2 = MagicMock()
-    mock_project_2.__class__ = Project
-    res = instance._parse_subset([mock_project_1, mock_project_2])
-    assert res == [mock_project_1, mock_project_2]
-
-
-def test_parse_subset_invalid(instance):
-    """
-    Tests _parse_subset works expectedly
-    method raises error when provided value which is not of Flavor type
-    """
-    invalid_project = "invalid-project-obj"
-    with pytest.raises(ParseQueryError):
-        instance._parse_subset([invalid_project])
+    assert res == [mock_connection.identity.find_project.return_value]

--- a/tests/lib/openstack_query/runners/test_runner_utils.py
+++ b/tests/lib/openstack_query/runners/test_runner_utils.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock
+from openstack_query.runners.runner_utils import RunnerUtils
+
+
+def run_paginated_query_test(number_iterations):
+    """
+    tests that run_paginated_query works expectedly - with one round or more of pagination
+    mocked paginated call simulates the effect of retrieving a list of values up to a limit and then calling the
+    same call again with a "marker" set to the last seen item to continue reading
+    """
+    mock_paginated_call = MagicMock()
+    mock_marker_prop_func = MagicMock(wraps=lambda resource: resource["id"])
+    mock_server_side_filter_set = {"arg1": "val1", "arg2": "val2"}
+
+    pagination_order = []
+    expected_out = []
+
+    for i in range(0, number_iterations - 1):
+        # Generate markers, it's a list of results with an ID
+        marker = {"id": f"marker{i}"}
+        expected_out.append(marker)
+        pagination_order.append([marker])
+
+    pagination_order.append([])
+
+    mock_paginated_call.side_effect = pagination_order
+
+    res = RunnerUtils.run_paginated_query(
+        mock_paginated_call,
+        mock_marker_prop_func,
+        mock_server_side_filter_set,
+        # set page_size to 1, so new calls begins after returning one value
+        1,
+        10,
+    )
+    assert res == expected_out
+
+
+def test_run_pagination_query_gt_0():
+    """
+    Calls the testing case with various numbers of iterations
+    to ensure pagination is working
+    """
+    for i in range(1, 3):
+        run_paginated_query_test(i)
+
+
+def test_apply_client_side_filters_one_item_one_filter_passes():
+    """
+    tests apply_client_side_filters method.
+    Should run one filter on one item which should pass
+    Should return same list as inputted
+    """
+    mock_filter_1 = MagicMock()
+    mock_filter_1.return_value = True
+
+    mock_item = MagicMock()
+    assert RunnerUtils.apply_client_side_filters([mock_item], [mock_filter_1]) == [
+        mock_item
+    ]
+
+
+def test_apply_client_side_filters_one_item_one_filter_fails():
+    """
+    tests apply_client_side_filters method.
+    Should run one filter on one item which should fail
+    Should return empty list
+    """
+
+    mock_filter_1 = MagicMock()
+    mock_filter_1.return_value = False
+
+    mock_item = MagicMock()
+    assert RunnerUtils.apply_client_side_filters([mock_item], [mock_filter_1]) == []
+
+
+def test_apply_client_side_filters_many_items_one_filter():
+    """
+    tests apply_client_side_filters method
+    Should run one filter on each item, should return item that passes filter
+    """
+
+    mock_filter_1 = MagicMock()
+    mock_filter_1.side_effect = [True, False]
+    mock_item_1 = MagicMock()
+    mock_item_2 = MagicMock()
+
+    assert RunnerUtils.apply_client_side_filters(
+        [mock_item_1, mock_item_2], [mock_filter_1]
+    ) == [mock_item_1]
+
+
+def test_apply_client_side_filters_many_items_many_filters():
+    """
+    tests apply_client_side_filters method
+    Should run each filter on each item
+    only first item which passes both filters should be returned
+    """
+
+    mock_item_1 = MagicMock()
+    mock_item_2 = MagicMock()
+    mock_item_3 = MagicMock()
+    mock_item_4 = MagicMock()
+
+    mock_filter_1 = MagicMock()
+    mock_filter_2 = MagicMock()
+
+    mock_filter_1.side_effect = [True, True, False, False]
+    mock_filter_2.side_effect = [True, False, True, False]
+
+    assert RunnerUtils.apply_client_side_filters(
+        [mock_item_1, mock_item_2, mock_item_3, mock_item_4],
+        [mock_filter_1, mock_filter_2],
+    ) == [mock_item_1]

--- a/tests/lib/openstack_query/runners/test_runner_wrapper.py
+++ b/tests/lib/openstack_query/runners/test_runner_wrapper.py
@@ -1,378 +1,51 @@
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, NonCallableMock
 import pytest
+
+from exceptions.parse_query_error import ParseQueryError
 from openstack_query.runners.runner_wrapper import RunnerWrapper
-
-# pylint:disable=protected-access
-
-
-@pytest.fixture(name="mock_page_func")
-def mock_page_func_fixture():
-    """
-    Returns a stub function for mock_page_func
-    """
-
-    def _mock_page_func(mock_obj):
-        """simple mock func which returns "id" key from given dict"""
-        return mock_obj["id"]
-
-    return _mock_page_func
 
 
 @pytest.fixture(name="instance")
-def instance_fixture(mock_connection, mock_page_func):
+def instance_fixture(mock_marker_prop_func):
     """
     Returns an instance to run tests with
     """
-
-    with patch.multiple(RunnerWrapper, __abstractmethods__=set()):
-        return RunnerWrapper(
-            marker_prop_func=mock_page_func, connection_cls=mock_connection
-        )
+    return RunnerWrapper(marker_prop_func=mock_marker_prop_func)
 
 
-@pytest.fixture(name="run_paginated_query_test")
-def run_paginated_query_test_fixture(instance):
+def test_parse_subset_one_item_pass(instance):
     """
-    Fixture which runs a paginated query test case
+    tests parse_subset method with one item which should pass
     """
-
-    def _run_paginated_query_test(number_iterations):
-        """
-        tests that run_paginated_query works expectedly - with one round or more of pagination
-        mocked paginated call simulates the effect of retrieving a list of values up to a limit and then calling the
-        same call again with a "marker" set to the last seen item to continue reading
-        """
-        pagination_order = []
-        expected_out = []
-
-        for i in range(0, number_iterations - 1):
-            # Generate markers, it's a list of results with an ID
-            marker = {"id": f"marker{i}"}
-            expected_out.append(marker)
-            pagination_order.append([marker])
-
-        pagination_order.append([])
-
-        mock_paginated_call = MagicMock()
-        mock_paginated_call.side_effect = pagination_order
-        instance._page_marker_prop_func = MagicMock(
-            wraps=lambda resource: resource["id"]
-        )
-
-        # set round to 1, so new calls begins after returning one value
-        instance._LIMIT_FOR_PAGINATION = 1
-        instance._PAGINATION_CALL_LIMIT = 10
-
-        mock_server_side_filters = {"arg1": "val1", "arg2": "val2"}
-        res = instance._run_paginated_query(
-            mock_paginated_call, mock_server_side_filters
-        )
-        assert res == expected_out
-
-    return _run_paginated_query_test
+    instance.RESOURCE_TYPE = MagicMock
+    mock_item = MagicMock()
+    assert instance.parse_subset([mock_item]) == [mock_item]
 
 
-# pylint:disable=too-many-arguments
-
-
-@pytest.fixture(name="runner_run_test_case")
-def runner_run_test_case_fixture(instance, mock_connection, mock_openstack_connection):
+def test_parse_subset_one_item_fails(instance):
     """
-    Fixture to run run() test cases with different args
+    tests parse_subset method with one item which should pass
+    """
+    instance.RESOURCE_TYPE = int
+    with pytest.raises(ParseQueryError):
+        instance.parse_subset([MagicMock()])
+
+
+def test_parse_subset_many_items_valid(instance):
+    """
+    tests parse_subset method with one item where all should pass
     """
 
-    def _runner_run_test_case(
-        mock_client_side_filters=None,
-        mock_server_side_filters=None,
-        mock_from_subset=None,
-        **mock_kwargs,
-    ):
-        """
-        method to run run() test case with provided input values
-        The individual methods that are called in run must be patched out by the test function
-        prior to this and any asserts need to be done by the test function
-        """
-
-        with patch(
-            "openstack_query.runners.runner_wrapper.RunnerWrapper._parse_subset"
-        ) as mock_parse_subset:
-            with patch(
-                "openstack_query.runners.runner_wrapper.RunnerWrapper._run_with_openstacksdk"
-            ) as mock_run_with_openstacksdk:
-                with patch(
-                    "openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filters"
-                ) as mock_apply_client_side_filters:
-                    res = instance.run(
-                        cloud_account="test-account",
-                        client_side_filters=mock_client_side_filters,
-                        server_side_filters=mock_server_side_filters,
-                        from_subset=mock_from_subset,
-                        **mock_kwargs,
-                    )
-
-        if mock_from_subset:
-            mock_parse_subset.assert_called_once_with(subset=mock_from_subset)
-            mock_run_with_openstacksdk.assert_not_called()
-
-        else:
-            mock_connection.assert_called_once_with("test-account")
-            mock_run_with_openstacksdk.assert_called_once_with(
-                conn=mock_openstack_connection,
-                server_filters=mock_server_side_filters,
-                **mock_kwargs,
-            )
-            mock_parse_subset.assert_not_called()
-
-        query_out = mock_run_with_openstacksdk.return_value
-        if mock_from_subset:
-            query_out = mock_parse_subset.return_value
-
-        if mock_client_side_filters:
-            mock_apply_client_side_filters.assert_called_once_with(
-                items=query_out, filters=mock_client_side_filters
-            )
-            query_out = mock_apply_client_side_filters.return_value
-
-        assert res == query_out
-
-    return _runner_run_test_case
+    instance.RESOURCE_TYPE = MagicMock
+    mock_subset = [MagicMock(), MagicMock()]
+    assert instance.parse_subset(mock_subset) == mock_subset
 
 
-def test_run_with_subset_no_client_filters(runner_run_test_case):
+def test_run_with_subset_many_items_invalid(instance):
     """
-    Tests run() method functions expectedly - given subset and no client filters
+    tests parse_subset method with one item invalid
     """
-    runner_run_test_case(
-        mock_from_subset=["item1", "item2", "item3"],
-    )
-
-
-def test_run_with_subset_and_client_filter(runner_run_test_case):
-    """
-    Tests run() method functions expectedly - given subset and client filters
-    """
-    runner_run_test_case(
-        mock_client_side_filters=["client-filter1", "client-filter2"],
-        mock_from_subset=["item1", "item2", "item3"],
-    )
-
-
-def test_run_with_server_side_filter_no_client_filter(runner_run_test_case):
-    """
-    Tests run() method functions expectedly - given subset and kwargs, no client filters
-    """
-    runner_run_test_case(
-        mock_server_side_filters=["server-filter1", "server-filter2"],
-        mock_kwargs={"arg1": "val1", "arg2": "val2"},
-    )
-
-
-def test_run_with_server_side_filter_and_client_filter(runner_run_test_case):
-    """
-    Tests run() method functions expectedly - given subset and client filters
-    """
-    runner_run_test_case(
-        mock_client_side_filters=["client-filter1", "client-filter2"],
-        mock_server_side_filters=["server-filter1", "server-filter2"],
-    )
-
-
-def test_run_both_server_filter_and_subset(instance):
-    """
-    Tests run() method functions expectedly - given subset and server filters
-    should raise an error
-    """
-    with pytest.raises(RuntimeError):
-        instance.run(
-            cloud_account="test_account",
-            from_subset=["item1", "item2"],
-            server_side_filters=["server-filter1", "server-filter2"],
-        )
-
-
-@pytest.fixture(name="run_with_openstacksdk_test_case")
-def run_with_openstacksdk_test_case_fixture(instance, mock_connection):
-    """
-    Fixture to test _run_with_openstacksdk with different test cases
-    """
-
-    def _run_with_openstacksdk_test_case(mock_server_filters, **mock_kwargs):
-        with patch(
-            "openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params"
-        ) as mock_parse_meta_params:
-            with patch(
-                "openstack_query.runners.runner_wrapper.RunnerWrapper._run_query"
-            ) as mock_run_query:
-                mock_parse_meta_params.return_value = {"parsed_arg1": "val1"}
-                mock_run_query.return_value = ["query_outputs"]
-                res = instance._run_with_openstacksdk(
-                    conn=mock_connection,
-                    server_filters=mock_server_filters,
-                    **mock_kwargs,
-                )
-
-        mock_parse_meta_params.assert_called_once_with(mock_connection, **mock_kwargs)
-        run_query_kwargs = mock_parse_meta_params.return_value
-
-        # check that run_query has been called correctly for each mock filter given
-        for mock_filter in mock_server_filters:
-            mock_run_query.assert_any_call(
-                mock_connection, mock_filter, **run_query_kwargs
-            )
-        # assert that result contains concatenated results of mock_run_query
-        assert res == [
-            i for i in mock_run_query.return_value for _ in mock_server_filters
-        ]
-
-    return _run_with_openstacksdk_test_case
-
-
-def test_run_with_openstacksdk_one_filter_and_kwargs(run_with_openstacksdk_test_case):
-    """
-    Tests _run_with_openstacksdk works properly - with one filter, and with kwargs
-    """
-    run_with_openstacksdk_test_case(
-        [{"filter1": "val1"}], **{"arg1": "val1", "arg2": "val2"}
-    )
-
-
-def test_run_with_openstacksdk_one_filter_no_kwargs(run_with_openstacksdk_test_case):
-    """
-    Tests _run_with_openstacksdk works properly - with one filter, and with no kwargs
-    """
-    run_with_openstacksdk_test_case([{"filter1": "val1"}])
-
-
-def test_run_with_openstacksdk_two_filters_no_kwargs(run_with_openstacksdk_test_case):
-    """
-    Tests _run_with_openstacksdk works properly - with two filters, and with no kwargs
-    """
-    run_with_openstacksdk_test_case([{"filter1": "val1"}, {"filter2": "val2"}])
-
-
-def test_run_with_openstacksdk_two_filters_and_kwargs(run_with_openstacksdk_test_case):
-    """
-    Tests _run_with_openstacksdk works properly - with two filters, and with kwargs
-    """
-    run_with_openstacksdk_test_case(
-        [{"filter1": "val1"}, {"filter2": "val2"}], **{"arg1": "val1", "arg2": "val2"}
-    )
-
-
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._parse_meta_params")
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._run_query")
-def test_run_with_openstacksdk_no_filters(
-    mock_run_query, mock_parse_meta_params, instance, mock_connection
-):
-    """
-    Tests _run_with_openstacksdk works properly - with no filters
-    run_query should be called with no filters
-    """
-    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
-    mock_parse_meta_params.return_value = {"parsed-arg1": "val1"}
-    mock_run_query.return_value = ["query-output"]
-    res = instance._run_with_openstacksdk(
-        conn=mock_connection, server_filters=None, **mock_kwargs
-    )
-
-    mock_parse_meta_params.assert_called_once_with(mock_connection, **mock_kwargs)
-
-    mock_run_query.assert_called_once_with(
-        mock_connection, None, **mock_parse_meta_params.return_value
-    )
-    assert res == mock_run_query.return_value
-
-
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter")
-def test_apply_client_side_filters_one_filter(mock_apply_client_side_filter, instance):
-    """
-    Tests that apply_client_side_filters method functions expectedly
-    with one filter function
-    method call apply_client_side_filter once with single filter function
-    """
-    mock_filter = ["filter1"]
-    mock_items = ["openstack-resource-1", "openstack-resource-2"]
-    res = instance._apply_client_side_filters(mock_items, mock_filter)
-    mock_apply_client_side_filter.assert_called_once_with(mock_items, mock_filter[0])
-    assert mock_apply_client_side_filter.return_value == res
-
-
-@patch("openstack_query.runners.runner_wrapper.RunnerWrapper._apply_client_side_filter")
-def test_apply_client_side_filters_multi_filter(
-    mock_apply_client_side_filter, instance
-):
-    """
-    Tests that apply_client_side_filters method functions expectedly
-    with one filter function
-    method call apply_client_side_filter for each filter given
-    """
-    mock_filter = ["filter1", "filter2"]
-    mock_items = "mock-items"
-    mock_apply_client_side_filter.side_effect = ["filter-out-1", "filter-out-2"]
-    res = instance._apply_client_side_filters(mock_items, mock_filter)
-
-    assert mock_apply_client_side_filter.call_args_list == [
-        call(mock_items, mock_filter[0]),
-        call("filter-out-1", mock_filter[1]),
-    ]
-    assert res == "filter-out-2"
-
-
-def test_apply_client_side_filter_no_items(instance):
-    """
-    Tests that apply_client_side_filter method functions expectedly
-    method should run given client_filter with no items
-    """
-    mock_client_filter = MagicMock()
-    mock_items = []
-    res = instance._apply_client_side_filter(mock_items, mock_client_filter)
-    mock_client_filter.assert_not_called()
-    assert res == []
-
-
-def test_apply_client_side_filter_one_item_true(instance):
-    """
-    Tests that apply_client_side_filter method functions expectedly
-    method when run on one item which should pass filter should return that item
-    """
-    mock_client_filter = MagicMock()
-    mock_client_filter.return_value = True
-    mock_items = ["item1"]
-    res = instance._apply_client_side_filter(mock_items, mock_client_filter)
-    mock_client_filter.assert_called_once_with("item1")
-    assert res == mock_items
-
-
-def test_apply_client_side_filter_one_item_false(instance):
-    """
-    Tests that apply_client_side_filter method functions expectedly
-    method when run on one item which should fail filter should return empty list
-    """
-    mock_client_filter = MagicMock()
-    mock_client_filter.return_value = False
-    mock_items = ["item1"]
-    res = instance._apply_client_side_filter(mock_items, mock_client_filter)
-    mock_client_filter.assert_called_once_with("item1")
-    assert res == []
-
-
-def test_apply_client_side_filter_one_many_items(instance):
-    """
-    Tests that apply_client_side_filter method functions expectedly
-    method should run given client_filter with many items - one pass, one fail
-    """
-    mock_client_filter = MagicMock()
-    mock_client_filter.side_effect = [True, False]
-    mock_items = ["item1", "item2"]
-    res = instance._apply_client_side_filter(mock_items, mock_client_filter)
-    mock_client_filter.assert_has_calls([call("item1"), call("item2")])
-    assert res == ["item1"]
-
-
-def test_run_pagination_query_gt_0(run_paginated_query_test):
-    """
-    Calls the testing case with various numbers of iterations
-    to ensure pagination is working
-    """
-    for i in range(1, 3):
-        run_paginated_query_test(i)
+    instance.RESOURCE_TYPE = MagicMock
+    invalid = 10
+    with pytest.raises(ParseQueryError):
+        instance.parse_subset([MagicMock(), MagicMock(), invalid])

--- a/tests/lib/openstack_query/runners/test_runner_wrapper.py
+++ b/tests/lib/openstack_query/runners/test_runner_wrapper.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, NonCallableMock
+from unittest.mock import MagicMock
 import pytest
 
 from exceptions.parse_query_error import ParseQueryError

--- a/tests/lib/openstack_query/runners/test_server_runner.py
+++ b/tests/lib/openstack_query/runners/test_server_runner.py
@@ -1,107 +1,94 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, NonCallableMock, call, patch
 
 import openstack.exceptions
 import pytest
 
 from openstack_query.runners.server_runner import ServerRunner
-from openstack.compute.v2.server import Server
 
 from openstack.exceptions import ResourceNotFound
 from exceptions.parse_query_error import ParseQueryError
 
-# pylint:disable=protected-access
-
 
 @pytest.fixture(name="instance")
-def instance_fixture(mock_connection):
+def instance_fixture(mock_marker_prop_func):
     """
     Returns an instance to run tests with
     """
-    mock_marker_prop_func = MagicMock()
-    return ServerRunner(
-        marker_prop_func=mock_marker_prop_func, connection_cls=mock_connection
-    )
+    return ServerRunner(marker_prop_func=mock_marker_prop_func)
 
 
-def test_parse_meta_params_ambiguous(instance, mock_openstack_connection):
+def test_parse_meta_params_ambiguous(instance):
     """
-    Tests _parse_meta_params method works expectedly - when given both from_project and all_project arguments
+    Tests parse_meta_params method when given both from_project and all_project arguments
     should raise an error
     """
     with pytest.raises(ParseQueryError):
-        instance._parse_meta_params(
-            mock_openstack_connection,
+        instance.parse_meta_params(
+            NonCallableMock(),
             from_projects=["project_id1", "project_id2"],
             all_projects=True,
         )
 
 
-def test_parse_meta_params_with_from_projects_no_admin(
-    instance, mock_openstack_connection
-):
+def test_parse_meta_params_with_from_projects_no_admin(instance):
     """
-    Tests _parse_meta_params method works expectedly - with no as_admin given
+    Tests parse_meta_params method with no as_admin given
     method should raise error because from_projects won't work without admin being set
     """
     with pytest.raises(ParseQueryError):
-        instance._parse_meta_params(
-            mock_openstack_connection,
+        instance.parse_meta_params(
+            NonCallableMock(),
             from_projects=["project_id1", "project_id2"],
             as_admin=False,
         )
 
 
-def test_parse_meta_params_with_no_admin(instance, mock_openstack_connection):
+def test_parse_meta_params_with_no_admin(instance):
     """
-    Tests _parse_meta_params method works expectedly - with no as_admin given
+    Tests parse_meta_params method with no as_admin given
     method should return meta params with projects set to a singleton list containing
     only the current scoped project id
     """
-    res = instance._parse_meta_params(
-        mock_openstack_connection,
+    mock_connection = MagicMock()
+    res = instance.parse_meta_params(
+        mock_connection,
         as_admin=False,
     )
     assert not set(res.keys()).difference({"projects"})
-    assert res["projects"] == [mock_openstack_connection.current_project_id]
+    assert res["projects"] == [mock_connection.current_project_id]
 
 
-def test_parse_meta_params_with_all_projects_no_admin(
-    instance, mock_openstack_connection
-):
+def test_parse_meta_params_with_all_projects_no_admin(instance):
     """
-    Tests _parse_meta_params method works expectedly - with no as_admin given
+    Tests parse_meta_params with no as_admin given
     method should raise error because all_projects won't work without admin being set
     """
     with pytest.raises(ParseQueryError):
-        instance._parse_meta_params(
-            mock_openstack_connection, all_projects=True, as_admin=False
-        )
+        instance.parse_meta_params(NonCallableMock(), all_projects=True, as_admin=False)
 
 
-def test_parse_meta_params_with_from_projects_as_admin(
-    instance, mock_openstack_connection
-):
+def test_parse_meta_params_with_from_projects_as_admin(instance):
     """
-    Tests _parse_meta_params method works expectedly - with valid from_project argument and as_admin
+    Tests parse_meta_params with valid from_project argument and as_admin
     method should iteratively call find_project() to find each project in list and return outputs
     """
 
     mock_project_identifiers = ["project_id1", "project_id2"]
-    mock_openstack_connection.identity.find_project.side_effect = [
+    mock_connection = MagicMock()
+    mock_connection.identity.find_project.side_effect = [
         {"id": "id1"},
         {"id": "id2"},
     ]
-
-    res = instance._parse_meta_params(
-        mock_openstack_connection,
+    res = instance.parse_meta_params(
+        mock_connection,
         from_projects=mock_project_identifiers,
         all_projects=False,
         as_admin=True,
     )
-    mock_openstack_connection.identity.user_projects.assert_called_once_with(
-        mock_openstack_connection.current_user_id
+    mock_connection.identity.user_projects.assert_called_once_with(
+        mock_connection.current_user_id
     )
-    mock_openstack_connection.identity.find_project.assert_has_calls(
+    mock_connection.identity.find_project.assert_has_calls(
         [
             call("project_id1", ignore_missing=False),
             call("project_id2", ignore_missing=False),
@@ -111,105 +98,98 @@ def test_parse_meta_params_with_from_projects_as_admin(
     assert not set(res["projects"]).difference({"id1", "id2"})
 
 
-def test_parse_meta_params_with_all_projects_as_admin(
-    instance, mock_openstack_connection
-):
+def test_parse_meta_params_with_all_projects_as_admin(instance):
     """
-    Tests _parse_meta_params method works expectedly - with all_projects and as_admin set
+    Tests parse_meta_params with all_projects and as_admin set
     method should return meta params with only all_tenants set to true
     """
-    res = instance._parse_meta_params(
-        mock_openstack_connection, all_projects=True, as_admin=True
-    )
+    mock_connection = MagicMock()
+    res = instance.parse_meta_params(mock_connection, all_projects=True, as_admin=True)
     assert not set(res.keys()).difference({"all_tenants"})
 
 
-def test_parse_meta_params_with_only_as_admin(instance, mock_openstack_connection):
+def test_parse_meta_params_with_only_as_admin(instance):
     """
-    Tests _parse_meta_params method works expectedly - with only as_admin set
+    Tests parse_meta_params with only as_admin set
     method should return meta params with all_tenants and projects set to output of user_projects
     """
-    mock_openstack_connection.identity.user_projects.return_value = [
+    mock_connection = MagicMock()
+    mock_connection.identity.user_projects.return_value = [
         "user-project1",
         "user-project2",
     ]
-    mock_openstack_connection.identity.find_project.side_effect = [
+    mock_connection.identity.find_project.side_effect = [
         {"id": "id1"},
         {"id": "id2"},
     ]
-    res = instance._parse_meta_params(mock_openstack_connection, as_admin=True)
-    mock_openstack_connection.identity.find_project.assert_has_calls(
+    res = instance.parse_meta_params(mock_connection, as_admin=True)
+    mock_connection.identity.find_project.assert_has_calls(
         [
             call("user-project1", ignore_missing=False),
             call("user-project2", ignore_missing=False),
         ]
     )
-    mock_openstack_connection.identity.user_projects.assert_called_once_with(
-        mock_openstack_connection.current_user_id
+    mock_connection.identity.user_projects.assert_called_once_with(
+        mock_connection.current_user_id
     )
     assert not set(res.keys()).difference({"projects", "all_tenants"})
     assert not set(res["projects"]).difference({"id1", "id2"})
 
 
-def test_parse_meta_params_with_invalid_project_identifier(
-    instance, mock_openstack_connection
-):
+def test_parse_meta_params_with_invalid_project_identifier(instance):
     """
-    Tests _parse_meta_parms method works expectedly - with invalid from_project argument
+    Tests parse_meta_params method with invalid from_project argument
     method should raise ParseQueryError when an invalid project identifier is given
     (or when project cannot be found)
     """
     mock_project_identifiers = ["project_id3"]
-    mock_openstack_connection.identity.find_project.side_effect = [ResourceNotFound()]
+    mock_connection = MagicMock()
+    mock_connection.identity.find_project.side_effect = [ResourceNotFound()]
     with pytest.raises(ParseQueryError):
-        instance._parse_meta_params(
-            mock_openstack_connection,
+        instance.parse_meta_params(
+            mock_connection,
             from_projects=mock_project_identifiers,
             as_admin=True,
         )
 
 
-def test_parse_meta_params_with_invalid_permissions(
-    instance, mock_openstack_connection
-):
+def test_parse_meta_params_with_invalid_permissions(instance):
     """
-    Tests _parse_meta_parms method works expectedly - with invalid admin creds
+    Tests parse_meta_params with invalid admin creds
     method should raise ParseQueryError when find_project fails with ForbiddenException
     """
     mock_project_identifiers = ["project_id3"]
-    mock_openstack_connection.identity.find_project.side_effect = [
+    mock_connection = MagicMock()
+    mock_connection.identity.find_project.side_effect = [
         openstack.exceptions.ForbiddenException()
     ]
     with pytest.raises(ParseQueryError):
-        instance._parse_meta_params(
-            mock_openstack_connection,
+        instance.parse_meta_params(
+            mock_connection,
             from_projects=mock_project_identifiers,
             as_admin=True,
         )
 
 
-def test_run_query_project_meta_arg_preset_duplication(
-    instance, mock_openstack_connection
-):
+def test_run_query_project_meta_arg_preset_duplication(instance):
     """
     Tests that an error is raised when run_query is called with filter kwargs which contains project_id and with
     meta_params that also contain projects - i.e there's a mismatch in which projects to search
     """
     with pytest.raises(ParseQueryError):
-        instance._run_query(
-            mock_openstack_connection,
+        instance.run_query(
+            NonCallableMock(),
             filter_kwargs={"project_id": "proj1"},
             projects=["proj2", "proj3"],
         )
 
 
-@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
 def test_run_query_with_meta_arg_projects_with_server_side_queries(
-    mock_run_paginated_query, instance, mock_openstack_connection
+    mock_run_paginated_query, instance, mock_marker_prop_func
 ):
     """
-    Tests _run_query method works expectedly - when meta arg projects given
-    method should for each project:
+    Tests run_query method when meta arg projects given method should for each project:
         - update filter kwargs to include "project_id": <id of project>
         - run _run_paginated_query with updated filter_kwargs
     """
@@ -220,45 +200,48 @@ def test_run_query_with_meta_arg_projects_with_server_side_queries(
     mock_filter_kwargs = {"arg1": "val1"}
 
     projects = ["project-id1", "project-id2"]
-
-    res = instance._run_query(
-        mock_openstack_connection,
+    mock_connection = MagicMock()
+    res = instance.run_query(
+        mock_connection,
         filter_kwargs=mock_filter_kwargs,
         projects=projects,
     )
 
     for project in projects:
         mock_run_paginated_query.assert_any_call(
-            mock_openstack_connection.compute.servers,
+            mock_connection.compute.servers,
+            mock_marker_prop_func,
             {"project_id": project, **mock_filter_kwargs},
         )
 
     assert res == ["server1", "server2", "server3", "server4"]
 
 
-@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
 def test_run_query_meta_arg_all_tenants_no_projects(
-    mock_run_paginated_query, instance, mock_openstack_connection
+    mock_run_paginated_query, instance, mock_marker_prop_func
 ):
     """
-    Tests _run_query method works expectedly - when meta arg all_tenants given
+    Tests run_query method when meta arg all_tenants given
     """
     mock_run_paginated_query.return_value = ["server1", "server2"]
-    res = instance._run_query(
-        mock_openstack_connection, filter_kwargs={}, all_tenants=True
-    )
+    mock_connection = MagicMock()
+
+    res = instance.run_query(mock_connection, filter_kwargs={}, all_tenants=True)
     mock_run_paginated_query.assert_called_once_with(
-        mock_openstack_connection.compute.servers, {"all_tenants": True}
+        mock_connection.compute.servers,
+        mock_marker_prop_func,
+        {"all_tenants": True},
     )
     assert res == ["server1", "server2"]
 
 
-@patch("openstack_query.runners.server_runner.ServerRunner._run_paginated_query")
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
 def test_run_query_with_meta_arg_projects_with_no_server_queries(
-    mock_run_paginated_query, instance, mock_openstack_connection
+    mock_run_paginated_query, instance, mock_marker_prop_func
 ):
     """
-    Tests _run_query method works expectedly - when meta arg projects given
+    Tests run_query method when meta arg projects given
     method should for each project run without any filter kwargs
     """
     mock_run_paginated_query.side_effect = [
@@ -266,43 +249,15 @@ def test_run_query_with_meta_arg_projects_with_no_server_queries(
         ["server3", "server4"],
     ]
     projects = ["project-id1", "project-id2"]
-    res = instance._run_query(
-        mock_openstack_connection, filter_kwargs={}, projects=projects
-    )
+    mock_connection = MagicMock()
+
+    res = instance.run_query(mock_connection, filter_kwargs={}, projects=projects)
 
     for project in projects:
         mock_run_paginated_query.assert_any_call(
-            mock_openstack_connection.compute.servers,
+            mock_connection.compute.servers,
+            mock_marker_prop_func,
             {"project_id": project},
         )
 
     assert res == ["server1", "server2", "server3", "server4"]
-
-
-def test_parse_subset(instance):
-    """
-    Tests _parse_subset works expectedly
-    method simply checks each value in 'subset' param is of the Server type and returns it
-    """
-
-    # with one item
-    mock_server_1 = MagicMock()
-    mock_server_1.__class__ = Server
-    res = instance._parse_subset([mock_server_1])
-    assert res == [mock_server_1]
-
-    # with two items
-    mock_server_2 = MagicMock()
-    mock_server_2.__class__ = Server
-    res = instance._parse_subset([mock_server_1, mock_server_2])
-    assert res == [mock_server_1, mock_server_2]
-
-
-def test_parse_subset_invalid(instance):
-    """
-    Tests _parse_subset works expectedly
-    method raises error when provided value which is not of Server type
-    """
-    invalid_server = "invalid-server-obj"
-    with pytest.raises(ParseQueryError):
-        instance._parse_subset([invalid_server])

--- a/tests/lib/openstack_query/runners/test_user_runner.py
+++ b/tests/lib/openstack_query/runners/test_user_runner.py
@@ -2,59 +2,73 @@ from unittest.mock import MagicMock, NonCallableMock, patch
 import pytest
 
 from openstack_query.runners.user_runner import UserRunner
-from openstack.identity.v3.user import User
 
 from exceptions.parse_query_error import ParseQueryError
 from exceptions.enum_mapping_error import EnumMappingError
 from enums.user_domains import UserDomains
 
-# pylint:disable=protected-access
-
 
 @pytest.fixture(name="instance")
-def instance_fixture(mock_connection):
+def instance_fixture(mock_marker_prop_func):
     """
     Returns an instance to run tests with
     """
-    mock_marker_prop_func = MagicMock()
-    return UserRunner(
-        marker_prop_func=mock_marker_prop_func, connection_cls=mock_connection
-    )
+    return UserRunner(marker_prop_func=mock_marker_prop_func)
 
 
-@patch("openstack_query.runners.user_runner.UserRunner._get_user_domain_id")
-def test_parse_meta_params_with_from_domain(
-    mock_get_user_domain, instance, mock_openstack_connection
-):
+@pytest.mark.parametrize(
+    "domain_enum, expected_domain",
+    [
+        (UserDomains.DEFAULT, "default"),
+        (UserDomains.STFC, "stfc"),
+        (UserDomains.OPENID, "openid"),
+    ],
+)
+def test_parse_meta_params_with_from_domain(domain_enum, expected_domain, instance):
     """
-    Tests _parse_meta_params method works expectedly - with valid from_domain argument
+    Tests parse_meta_params with valid from_domain argument
     method should get domain id from a UserDomain enum by calling get_user_domain
     """
+    mock_id = NonCallableMock()
 
-    mock_domain_enum = UserDomains.DEFAULT
-    mock_get_user_domain.return_value = "default-domain-id"
+    mock_domain = {"id": mock_id}
+    mock_connection = MagicMock()
 
-    res = instance._parse_meta_params(
-        mock_openstack_connection, from_domain=mock_domain_enum
-    )
-    mock_get_user_domain.assert_called_once_with(
-        mock_openstack_connection, mock_domain_enum
-    )
+    mock_connection.identity.find_domain.return_value = mock_domain
 
-    assert res == {"domain_id": "default-domain-id"}
+    res = instance.parse_meta_params(mock_connection, from_domain=domain_enum)
+
+    mock_connection.identity.find_domain.assert_called_once_with(expected_domain)
+    assert res == {"domain_id": mock_id}
 
 
-@patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
+def test_parse_meta_params_with_invalid_from_domain(instance):
+    """
+    Tests parse_meta_params with invalid from_domain argument, should raise error
+    """
+    with pytest.raises(EnumMappingError):
+        res = instance.parse_meta_params(NonCallableMock(), from_domain=MagicMock())
+
+
+def test_parse_meta_params_no_from_domain(instance):
+    """
+    Tests parse_meta_params with no from_domain argument
+    should return empty meta-params
+    """
+    assert instance.parse_meta_params(NonCallableMock()) == {}
+
+
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
 def test_run_query_with_meta_arg_domain_id_with_server_side_filters(
-    mock_run_paginated_query, instance, mock_openstack_connection
+    mock_run_paginated_query, instance, mock_marker_prop_func
 ):
     """
-    Tests the _run_query method works expectedly - when meta arg domain id given
+    Tests the run_query method works expectedly - when meta arg domain id given
     method should:
         - update filter kwargs to include "domain_id": <domain id given>
         - run _run_paginated_query with updated filter_kwargs
     """
-
+    mock_connection = MagicMock()
     mock_user_list = mock_run_paginated_query.return_value = [
         "user1",
         "user2",
@@ -63,25 +77,26 @@ def test_run_query_with_meta_arg_domain_id_with_server_side_filters(
     mock_filter_kwargs = {"arg1": "val1", "arg2": "val2"}
     mock_domain_id = "domain-id1"
 
-    res = instance._run_query(
-        mock_openstack_connection,
+    res = instance.run_query(
+        mock_connection,
         filter_kwargs=mock_filter_kwargs,
         domain_id=mock_domain_id,
     )
 
     mock_run_paginated_query.assert_called_once_with(
-        mock_openstack_connection.identity.users,
+        mock_connection.identity.users,
+        mock_marker_prop_func,
         {**{"domain_id": mock_domain_id}, **mock_filter_kwargs},
     )
     assert res == mock_user_list
 
 
-@patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
 def test_run_query_with_meta_arg_domain_id_with_no_server_filters(
-    mock_run_paginated_query, instance, mock_openstack_connection
+    mock_run_paginated_query, instance, mock_marker_prop_func
 ):
     """
-    Tests the _run_query method works expectedly with no server side filters
+    Tests the run_query method works expectedly with no server side filters
     """
 
     mock_user_list = mock_run_paginated_query.return_value = [
@@ -89,57 +104,60 @@ def test_run_query_with_meta_arg_domain_id_with_no_server_filters(
         "user2",
         "user3",
     ]
+    mock_connection = MagicMock()
     mock_filter_kwargs = None
     mock_domain_id = "domain-id1"
-    res = instance._run_query(
-        mock_openstack_connection,
+    res = instance.run_query(
+        mock_connection,
         filter_kwargs=mock_filter_kwargs,
         domain_id=mock_domain_id,
     )
 
     mock_run_paginated_query.assert_called_once_with(
-        mock_openstack_connection.identity.users, {"domain_id": mock_domain_id}
+        mock_connection.identity.users,
+        mock_marker_prop_func,
+        {"domain_id": mock_domain_id},
     )
     assert res == mock_user_list
 
 
-def test_run_query_domain_id_meta_arg_preset_duplication(
-    instance, mock_openstack_connection
-):
+def test_run_query_domain_id_meta_arg_preset_duplication(instance):
     """
     Tests that an error is raised when run_query is called with filter kwargs which contians domain_id and with meta
     params that also contains a domain id - i.e. there's a mismatch in which domain to search
     """
     with pytest.raises(ParseQueryError):
-        instance._run_query(
-            mock_openstack_connection,
+        instance.run_query(
+            NonCallableMock(),
             filter_kwargs={"domain_id": "some-domain"},
             domain_id=["some-other-domain"],
         )
 
 
-@patch("openstack_query.runners.user_runner.UserRunner._run_paginated_query")
-@patch("openstack_query.runners.user_runner.UserRunner._get_user_domain_id")
-def test_run_query_no_meta_args(
-    mock_get_user_domain, mock_run_paginated_query, instance, mock_openstack_connection
-):
+@patch("openstack_query.runners.runner_utils.RunnerUtils.run_paginated_query")
+def test_run_query_no_meta_args(mock_run_paginated_query, instance):
     """
     Tests that run_query functions expectedly - when no meta args given
     method should use the default-domain-id
     """
     mock_run_paginated_query.side_effect = [["user1", "user2"]]
-    mock_get_user_domain.return_value = "default-domain-id"
+
+    mock_default_domain_id = NonCallableMock()
+    mock_connection = MagicMock()
+    mock_domain = {"id": mock_default_domain_id}
+    mock_connection.identity.find_domain.return_value = mock_domain
+
     mock_filter_kwargs = {"test_arg": NonCallableMock()}
 
-    res = instance._run_query(
-        mock_openstack_connection, filter_kwargs=mock_filter_kwargs, domain_id=None
+    res = instance.run_query(
+        mock_connection, filter_kwargs=mock_filter_kwargs, domain_id=None
     )
 
-    mock_get_user_domain.assert_called_once_with(
-        mock_openstack_connection, instance.DEFAULT_DOMAIN
-    )
+    # stfc is default domain
+    mock_connection.identity.find_domain.assert_called_once_with("stfc")
+
     mock_run_paginated_query.asset_called_once_with(
-        mock_openstack_connection.identity.users,
+        mock_connection.identity.users,
         {
             **mock_filter_kwargs,
             "all_tenants": True,
@@ -149,73 +167,40 @@ def test_run_query_no_meta_args(
     assert res == ["user1", "user2"]
 
 
-def test_run_query_returns_list(instance, mock_openstack_connection):
+def test_run_query_returns_list(instance):
     """
     Tests that run_query correctly returns a list of entries
     """
     return_value = NonCallableMock()
-    mock_openstack_connection.identity.find_user.return_value = return_value
+    mock_connection = MagicMock()
+    mock_connection.identity.find_user.return_value = return_value
 
-    returned = instance._run_query(mock_openstack_connection, filter_kwargs={"id": "1"})
-    mock_openstack_connection.identity.find_user.assert_called_once_with(
-        "1", ignore_missing=True
-    )
+    returned = instance.run_query(mock_connection, filter_kwargs={"id": "1"})
+    mock_connection.identity.find_user.assert_called_once_with("1", ignore_missing=True)
     assert [return_value] == returned
 
 
-def test_run_query_with_from_domain_and_id_given(instance, mock_openstack_connection):
+def test_run_query_with_from_domain_and_id_given(instance):
     """
     Test error is raised when the domain name and domain id is provided at
     the same time
     """
     with pytest.raises(ParseQueryError):
-        instance._run_query(
-            mock_openstack_connection,
+        instance.run_query(
+            NonCallableMock(),
             filter_kwargs={"domain_id": 1},
             domain_id="domain-id2",
         )
 
 
-def test_get_user_domain_id(instance, mock_openstack_connection):
+def test_get_user_domain_id(instance):
     """
     Test that user domains have a mapping and no errors are raised
     """
-    for domain in UserDomains:
-        instance._get_user_domain_id(mock_openstack_connection, domain)
+    mock_connection = MagicMock()
+    mock_id = NonCallableMock()
+    mock_connection.identity.find_domain.return_value = {"id": mock_id}
 
-
-def test_get_user_domain_id_error_raised(instance, mock_openstack_connection):
-    """
-    Test that an error is raised if a domain mapping is not found
-    """
-    with pytest.raises(EnumMappingError):
-        instance._get_user_domain_id(mock_openstack_connection, MagicMock())
-
-
-def test_parse_subset(instance):
-    """
-    Tests _parse_subset works expectedly
-    method simply checks each value in 'subset' param is of the User type and returns it
-    """
-
-    # with one item
-    mock_user_1 = MagicMock()
-    mock_user_1.__class__ = User
-    res = instance._parse_subset([mock_user_1])
-    assert res == [mock_user_1]
-
-    # with two items
-    mock_user_2 = MagicMock()
-    mock_user_2.__class__ = User
-    res = instance._parse_subset([mock_user_1, mock_user_2])
-    assert res == [mock_user_1, mock_user_2]
-
-
-def test_parse_subset_invalid(instance):
-    """
-    Tests _parse_subset works expectedly
-    method raises error when provided value which is not of User type
-    """
-    invalid_user = "invalid-user-obj"
-    with pytest.raises(ParseQueryError):
-        instance._parse_subset([invalid_user])
+    for domain_enum in UserDomains:
+        res = instance.parse_meta_params(mock_connection, from_domain=domain_enum)
+        assert res == {"domain_id": mock_id}

--- a/tests/lib/openstack_query/runners/test_user_runner.py
+++ b/tests/lib/openstack_query/runners/test_user_runner.py
@@ -47,7 +47,7 @@ def test_parse_meta_params_with_invalid_from_domain(instance):
     Tests parse_meta_params with invalid from_domain argument, should raise error
     """
     with pytest.raises(EnumMappingError):
-        res = instance.parse_meta_params(NonCallableMock(), from_domain=MagicMock())
+        instance.parse_meta_params(NonCallableMock(), from_domain=MagicMock())
 
 
 def test_parse_meta_params_no_from_domain(instance):


### PR DESCRIPTION
SImplify Runner class to just be concerned with how to interact with openstacksdk. Move the other methods concerned with actually running the queries out into Executer

changes include: 
Executer has two more functions `run_with_subset` and `run_with_openstacksdk`.
`RunnerWrapper` is much simpler now
Created a `RunnerUtils` for holding static methods that are shared between different Runner classes 

