### PR TITLE
BUG: fix Runner and Sort By types

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -74,7 +74,7 @@ class QueryAPI:
         self.builder.parse_where(preset, prop, kwargs)
         return self
 
-    def sort_by(self, *sort_by: Tuple[PropEnum, SortOrder]):
+    def sort_by(self, *sort_by: Tuple[Union[PropEnum, str], Union[SortOrder, str]]):
         """
         Public method used to configure sorting results
         :param sort_by: Tuple of property enum to sort by and enum representing sorting order

--- a/lib/openstack_query/runners/flavor_runner.py
+++ b/lib/openstack_query/runners/flavor_runner.py
@@ -6,7 +6,7 @@ from openstack_api.openstack_connection import OpenstackConnection
 from openstack_query.runners.runner_wrapper import RunnerWrapper
 from openstack_query.runners.runner_utils import RunnerUtils
 
-from custom_types.openstack_query.aliases import ServerSideFilters
+from custom_types.openstack_query.aliases import ServerSideFilter
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class FlavorRunner(RunnerWrapper):
     def run_query(
         self,
         conn: OpenstackConnection,
-        filter_kwargs: Optional[ServerSideFilters] = None,
+        filter_kwargs: Optional[ServerSideFilter] = None,
         **_,
     ) -> List[Flavor]:
         """
@@ -38,7 +38,7 @@ class FlavorRunner(RunnerWrapper):
 
         For FlavorQuery, this command finds all flavors that match a given set of filter_kwargs
         :param conn: An OpenstackConnection object - used to connect to openstacksdk
-        :param filter_kwargs: An Optional list of filter kwargs to pass to conn.compute.flavors()
+        :param filter_kwargs: An Optional set of filter kwargs to pass to conn.compute.flavors()
             to limit the flavors being returned.
             - see https://docs.openstack.org/api-ref/compute/#list-flavors-with-details
         """

--- a/lib/openstack_query/runners/project_runner.py
+++ b/lib/openstack_query/runners/project_runner.py
@@ -7,7 +7,7 @@ from openstack_api.openstack_connection import OpenstackConnection
 from openstack_query.runners.runner_utils import RunnerUtils
 from openstack_query.runners.runner_wrapper import RunnerWrapper
 
-from custom_types.openstack_query.aliases import ServerSideFilters
+from custom_types.openstack_query.aliases import ServerSideFilter
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class ProjectRunner(RunnerWrapper):
     def run_query(
         self,
         conn: OpenstackConnection,
-        filter_kwargs: Optional[ServerSideFilters] = None,
+        filter_kwargs: Optional[ServerSideFilter] = None,
         **_,
     ) -> List[Project]:
         """
@@ -39,7 +39,7 @@ class ProjectRunner(RunnerWrapper):
 
         For ProjectQuery, this command finds all projects that match a given set of filter_kwargs
         :param conn: An OpenstackConnection object - used to connect to openstacksdk
-        :param filter_kwargs: An Optional list of filter kwargs to pass to conn.identity.projects()
+        :param filter_kwargs: An Optional set of filter kwargs to pass to conn.identity.projects()
             to limit the flavors being returned.
             - see https://docs.openstack.org/api-ref/compute/#list-flavors-with-details
         """

--- a/lib/openstack_query/runners/user_runner.py
+++ b/lib/openstack_query/runners/user_runner.py
@@ -11,6 +11,8 @@ from exceptions.parse_query_error import ParseQueryError
 from exceptions.enum_mapping_error import EnumMappingError
 from enums.user_domains import UserDomains
 
+from custom_types.openstack_query.aliases import ServerSideFilter
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,7 +68,7 @@ class UserRunner(RunnerWrapper):
     def run_query(
         self,
         conn: OpenstackConnection,
-        filter_kwargs: Optional[Dict[str, str]] = None,
+        filter_kwargs: Optional[ServerSideFilter] = None,
         **meta_params,
     ) -> List[Optional[User]]:
         """
@@ -74,7 +76,7 @@ class UserRunner(RunnerWrapper):
 
         For UserQuery, this command gets all users by domain ID
         :param conn: An OpenstackConnection object - used to connect to openstacksdk
-        :param filter_kwargs: An Optional list of filter kwargs to pass to conn.identity.users()
+        :param filter_kwargs: An Optional set of filter kwargs to pass to conn.identity.users()
         """
 
         if not filter_kwargs:


### PR DESCRIPTION
`filter_kwargs` should be a single set of server-side filters not a list of them. Changed the type accordingly.
`sort_by` should be able to take string aliases like `sort_by(('id', 'ascending'))`. Changed the type accordingly