### PR TITLE
BUG: change image_id mapping

### DIFF
--- a/lib/enums/query/props/server_properties.py
+++ b/lib/enums/query/props/server_properties.py
@@ -59,7 +59,7 @@ class ServerProperties(PropEnum):
             ServerProperties.SERVER_CREATION_DATE: lambda a: a["created_at"],
             ServerProperties.SERVER_LAST_UPDATED_DATE: lambda a: a["updated_at"],
             ServerProperties.FLAVOR_ID: lambda a: a["flavor"]["id"],
-            ServerProperties.IMAGE_ID: lambda a: a["image_id"],
+            ServerProperties.IMAGE_ID: lambda a: a["image"]["id"],
             ServerProperties.PROJECT_ID: lambda a: a["location"]["project"]["id"],
             ServerProperties.ADDRESSES: ServerProperties.get_ips,
         }


### PR DESCRIPTION
Openstack Server["image_id"] is not always populated, changed mapping to Server["image"]["id"]
