### PR TITLE
ENH: use email wrapper and styling

### DIFF
--- a/email_templates/wrapper.html.j2
+++ b/email_templates/wrapper.html.j2
@@ -2,8 +2,16 @@
 <html>
   <head>
     <style>
-      table, th, td {{ border: 1px solid black; border-collapse: collapse; }}
-      th, td {{ padding: 8px; }}
+      table, td, th {
+        border: 1px solid #ddd;
+        text-align: left;
+      }
+      table {
+        border-collapse: collapse;
+      }
+      th, td {
+        padding: 15px;
+      }
     </style>
   </head>
 {% endraw %}

--- a/lib/email_api/emailer.py
+++ b/lib/email_api/emailer.py
@@ -16,9 +16,10 @@ from structs.email.email_params import EmailParams
 from structs.email.smtp_account import SMTPAccount
 from structs.email.email_template_details import EmailTemplateDetails
 
-import css_inline
+# weird issue where pylint can't find the module - works fine though
+# pylint:disable=no-name-in-module
+from css_inline import CSSInliner
 
-# pylint:disable=too-few-public-methods
 logger = logging.getLogger(__name__)
 
 
@@ -125,10 +126,7 @@ class Emailer:
             html_body = self._template_handler.render_html_template(wrapper_template)
 
             # convert style tags to inline styles for emails
-
-            # weird issue where pylint can't find the module - works fine though
-            # pylint:disable=no-member
-            inliner = css_inline.CSSInliner(keep_style_tags=True)
+            inliner = CSSInliner(keep_style_tags=True)
             html_body = inliner.inline(html_body)
             return MIMEText(html_body, "html")
         return MIMEText(msg_body, "plain", "utf-8")

--- a/lib/email_api/emailer.py
+++ b/lib/email_api/emailer.py
@@ -125,6 +125,9 @@ class Emailer:
             html_body = self._template_handler.render_html_template(wrapper_template)
 
             # convert style tags to inline styles for emails
+
+            # wierd issue where pylint can't find the module - works fine though
+            # pylint:disable=no-member
             inliner = css_inline.CSSInliner(keep_style_tags=True)
             html_body = inliner.inline(html_body)
             return MIMEText(html_body, "html")

--- a/lib/email_api/emailer.py
+++ b/lib/email_api/emailer.py
@@ -126,7 +126,7 @@ class Emailer:
 
             # convert style tags to inline styles for emails
 
-            # wierd issue where pylint can't find the module - works fine though
+            # weird issue where pylint can't find the module - works fine though
             # pylint:disable=no-member
             inliner = css_inline.CSSInliner(keep_style_tags=True)
             html_body = inliner.inline(html_body)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ tabulate
 requests
 python-dateutil
 Jinja2
+css-inline
 
 # for tests
 nose

--- a/tests/lib/email_api/test_emailer.py
+++ b/tests/lib/email_api/test_emailer.py
@@ -216,11 +216,11 @@ def test_build_email_body_plaintext(mock_mime_text, instance, template_handler):
 
 
 @patch("email_api.emailer.MIMEText")
-@patch("email_api.emailer.css_inline")
+@patch("email_api.emailer.CSSInliner")
 @patch("email_api.emailer.EmailTemplateDetails")
 def test_build_email_body_html(
     mock_email_template_details,
-    mock_css_inline,
+    mock_css_inliner,
     mock_mime_text,
     instance,
     template_handler,
@@ -250,8 +250,8 @@ def test_build_email_body_html(
         call(template_2),
         call(mock_email_template_details.return_value),
     ]
-    mock_css_inline.CSSInliner.assert_called_once_with(keep_style_tags=True)
-    mock_css_inline_obj = mock_css_inline.CSSInliner.return_value
+    mock_css_inliner.assert_called_once_with(keep_style_tags=True)
+    mock_css_inline_obj = mock_css_inliner.return_value
     mock_css_inline_obj.inline.assert_called_once_with("template-render-wrapper")
     mock_mime_text.assert_called_once_with(
         mock_css_inline_obj.inline.return_value, "html"


### PR DESCRIPTION
Add styling to make html emails look better. 
Styles can be defined in wrapper.html with style tags

We use css-inline to automatically convert style tags to html inline styles which is required when styling html emails