### PR TITLE
MAINT: add extra kwarg to style output

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -176,28 +176,42 @@ class QueryAPI:
         return self.output.to_props(self.results_container, flatten, groups)
 
     def to_string(
-        self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
+        self,
+        title: Optional[str] = None,
+        groups: Optional[List[str]] = None,
+        include_group_titles: bool = True,
+        **kwargs,
     ) -> str:
         """
         Public method to return results as table(s)
         :param title: an optional title for the table(s)
         :param groups: a list group to limit output by
+        :param include_group_titles: include group name as subtitle when printing groups
         :param kwargs: kwargs to pass to generate table
         """
         self.results_container.parse_results(self.parser.run_parser)
-        return self.output.to_string(self.results_container, title, groups, **kwargs)
+        return self.output.to_string(
+            self.results_container, title, groups, include_group_titles, **kwargs
+        )
 
     def to_html(
-        self, title: Optional[str] = None, groups: Optional[List[str]] = None, **kwargs
+        self,
+        title: Optional[str] = None,
+        groups: Optional[List[str]] = None,
+        include_group_titles: bool = True,
+        **kwargs,
     ) -> str:
         """
         Public method to return results as html table
         :param title: an optional title for the table(s) - will be converted to html automatically
         :param groups: a list group to limit output by
+        :param include_group_titles: include group name as subtitle when printing groups
         :param kwargs: kwargs to pass to generate table
         """
         self.results_container.parse_results(self.parser.run_parser)
-        return self.output.to_html(self.results_container, title, groups, **kwargs)
+        return self.output.to_html(
+            self.results_container, title, groups, include_group_titles, **kwargs
+        )
 
     def to_csv(self, dir_path: str) -> str:
         """

--- a/lib/openstack_query/docs/user_docs/API.md
+++ b/lib/openstack_query/docs/user_docs/API.md
@@ -463,6 +463,7 @@ def to_string(title: Optional[str] = None,
 
 - `title`: An optional title to print on top
 - `groups`: a list of group keys to limit output by - this will only work if `to_groups()` has been set - else it produces an error
+- `include_group_titles`: A boolean (Default True), if True, will print the group key as a subtitle before printing each selected group table, if False no subtitle will be printed.
 - `kwargs`: kwargs to pass to tabulate to tweak table generation
   - see [tabulate](https://pypi.org/project/tabulate/) for valid kwargs
   - note `to_string` calls tabulate with `tablefmt="plaintext"`
@@ -519,6 +520,7 @@ def to_html(title: Optional[str] = None,
 
 - `title`: An optional title to print on top
 - `groups`: a list of group keys to limit output by - this will only work if `to_groups()` has been set - else it produces an error
+- `include_group_titles`: A boolean (Default True), if True, will print the group key as a subtitle before printing each selected group table, if False no subtitle will be printed.
 - `kwargs`: kwargs to pass to tabulate to tweak table generation
   - see [tabulate](https://pypi.org/project/tabulate/) for valid kwargs
   - note `to_html` calls tabulate with `tablefmt="html"`

--- a/lib/openstack_query/query_blocks/query_output.py
+++ b/lib/openstack_query/query_blocks/query_output.py
@@ -102,6 +102,7 @@ class QueryOutput:
         results_container: ResultsContainer,
         title: str = None,
         groups: Optional[List[str]] = None,
+        include_group_titles: [bool] = True,
         **kwargs,
     ):
         """
@@ -109,6 +110,7 @@ class QueryOutput:
         :param results_container: container object which stores results
         :param title: an optional title for the table when it gets outputted
         :param groups: a list of groups to limit output by
+        :param include_group_titles: include group name as subtitle when printing groups
         :param kwargs: kwargs to pass to _generate_table method
         """
         results = results_container.to_props(*self.selected_props)
@@ -121,7 +123,7 @@ class QueryOutput:
                 output += self._generate_table(
                     results[group_title],
                     return_html=False,
-                    title=f"{group_title}:\n",
+                    title=f"{group_title}:\n" if include_group_titles else None,
                     **kwargs,
                 )
         else:
@@ -135,6 +137,7 @@ class QueryOutput:
         results_container: ResultsContainer,
         title: str = None,
         groups: Optional[List[str]] = None,
+        include_group_titles: bool = True,
         **kwargs,
     ) -> str:
         """
@@ -142,6 +145,7 @@ class QueryOutput:
         :param results_container: container object which stores results
         :param title: a title for the table(s) when it gets outputted
         :param groups: a list of groups to limit output by
+        :param include_group_titles: include group name as subtitle when printing groups
         :param kwargs: kwargs to pass to generate table
         """
         results = results_container.to_props(*self.selected_props)
@@ -153,7 +157,9 @@ class QueryOutput:
                 output += self._generate_table(
                     results[group_title],
                     return_html=True,
-                    title=f"<b> {group_title}: </b><br/> ",
+                    title=f"<b> {group_title}: </b><br/> "
+                    if include_group_titles
+                    else None,
                     **kwargs,
                 )
         else:

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -297,17 +297,24 @@ def test_to_string(instance):
     """
     mock_groups = NonCallableMock()
     mock_title = NonCallableMock()
+    mock_include_group_titles = NonCallableMock()
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
 
     # pylint: disable=protected-access
     instance.results_container = MagicMock()
 
-    res = instance.to_string(mock_title, mock_groups, **mock_kwargs)
+    res = instance.to_string(
+        mock_title, mock_groups, mock_include_group_titles, **mock_kwargs
+    )
     instance.results_container.parse_results.assert_called_once_with(
         instance.parser.run_parser
     )
     instance.output.to_string.assert_called_once_with(
-        instance.results_container, mock_title, mock_groups, **mock_kwargs
+        instance.results_container,
+        mock_title,
+        mock_groups,
+        mock_include_group_titles,
+        **mock_kwargs
     )
     assert res == instance.output.to_string.return_value
 
@@ -319,14 +326,21 @@ def test_to_html(instance):
     """
     mock_groups = NonCallableMock()
     mock_title = NonCallableMock()
+    mock_include_group_titles = NonCallableMock()
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
 
-    res = instance.to_html(mock_title, mock_groups, **mock_kwargs)
+    res = instance.to_html(
+        mock_title, mock_groups, mock_include_group_titles, **mock_kwargs
+    )
     instance.results_container.parse_results.assert_called_once_with(
         instance.parser.run_parser
     )
     instance.output.to_html.assert_called_once_with(
-        instance.results_container, mock_title, mock_groups, **mock_kwargs
+        instance.results_container,
+        mock_title,
+        mock_groups,
+        mock_include_group_titles,
+        **mock_kwargs
     )
     assert res == instance.output.to_html.return_value
 

--- a/tests/lib/openstack_query/query_blocks/test_query_output.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_output.py
@@ -296,6 +296,48 @@ def test_to_html_with_grouped_results(
 
 @patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
 @patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
+def test_to_html_grouped_no_subtitles(
+    mock_generate_table, mock_validate_groups, instance
+):
+    """
+    Tests that to_html function works expectedly - when results are grouped - outputted as a dict
+    method should call generate_table with return_html for each group
+    with include_group_titles = False
+    """
+
+    mock_results_container = MagicMock()
+    mock_title = "mock title"
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+
+    mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
+    mock_validate_groups.return_value = mocked_results
+    mock_generate_table.side_effect = ["1 out, ", "2 out"]
+
+    res = instance.to_html(
+        mock_results_container,
+        mock_title,
+        mock_groups,
+        include_group_titles=False,
+        **mock_kwargs
+    )
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+
+    mock_generate_table.assert_has_calls(
+        [
+            call(["obj1", "obj2"], return_html=True, title=None, **mock_kwargs),
+            call(["obj3", "obj4"], return_html=True, title=None, **mock_kwargs),
+        ]
+    )
+    assert res == "<b> mock title: </b><br/> 1 out, 2 out"
+
+
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
+@patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
 def test_to_string_with_list_results(
     mock_generate_table, mock_validate_groups, instance
 ):
@@ -357,8 +399,9 @@ def test_to_string_with_grouped_results(
     mock_generate_table, mock_validate_groups, instance
 ):
     """
-    Tests that to_html function works expectedly - when results are grouped - outputted as a dict
+    Tests that to_string function works expectedly - when results are grouped - outputted as a dict
     method should call generate_table with return_html for each group
+    with include_group_titles = True
     """
 
     mock_results_container = MagicMock()
@@ -383,6 +426,48 @@ def test_to_string_with_grouped_results(
         [
             call(["obj1", "obj2"], return_html=False, title="group1:\n", **mock_kwargs),
             call(["obj3", "obj4"], return_html=False, title="group2:\n", **mock_kwargs),
+        ]
+    )
+    assert "mock title:\n1 out, 2 out" == res
+
+
+@patch("openstack_query.query_blocks.query_output.QueryOutput._validate_groups")
+@patch("openstack_query.query_blocks.query_output.QueryOutput._generate_table")
+def test_to_string_grouped_no_subtitles(
+    mock_generate_table, mock_validate_groups, instance
+):
+    """
+    Tests that to_html function works expectedly - when results are grouped - outputted as a dict
+    method should call generate_table with return_html for each group
+    with include_group_titles = False
+    """
+
+    mock_results_container = MagicMock()
+    mock_title = "mock title"
+    mock_groups = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    instance.selected_props = ["prop1", "prop2", "prop3"]
+
+    mocked_results = {"group1": ["obj1", "obj2"], "group2": ["obj3", "obj4"]}
+    mock_validate_groups.return_value = mocked_results
+    mock_generate_table.side_effect = ["1 out, ", "2 out"]
+
+    res = instance.to_string(
+        mock_results_container,
+        mock_title,
+        mock_groups,
+        include_group_titles=False,
+        **mock_kwargs
+    )
+    mock_results_container.to_props.assert_called_once_with("prop1", "prop2", "prop3")
+    mock_validate_groups.assert_called_once_with(
+        mock_results_container.to_props.return_value, mock_groups
+    )
+
+    mock_generate_table.assert_has_calls(
+        [
+            call(["obj1", "obj2"], return_html=False, title=None, **mock_kwargs),
+            call(["obj3", "obj4"], return_html=False, title=None, **mock_kwargs),
         ]
     )
     assert "mock title:\n1 out, 2 out" == res


### PR DESCRIPTION
include_group_titles configures if we should print group titles when converting to string/html