### PR TITLE
BUG: error triggered when query returns no results

### DIFF
--- a/lib/openstack_query/query_blocks/results_container.py
+++ b/lib/openstack_query/query_blocks/results_container.py
@@ -1,6 +1,5 @@
 from typing import Union, List, Dict, Callable
 from enums.query.props.prop_enum import PropEnum
-from exceptions.query_chaining_error import QueryChainingError
 from openstack_query.query_blocks.result import Result
 from custom_types.openstack_query.aliases import OpenstackResourceObj, PropValue
 

--- a/lib/openstack_query/query_blocks/results_container.py
+++ b/lib/openstack_query/query_blocks/results_container.py
@@ -72,9 +72,8 @@ class ResultsContainer:
         """
 
         if not self._results:
-            raise QueryChainingError(
-                "Query Chaining Error: Tried to apply a set of forwarded results when query has not been run yet"
-            )
+            # no info to chain since there's no results
+            return
 
         for item in self._results:
             prop_val = item.get_prop(link_prop)

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -228,6 +228,15 @@ def test_apply_forwarded_result(mock_get_forwarded_result, setup_instance_with_r
     res2.update_forwarded_properties(mock_get_forwarded_result.return_value)
 
 
+def test_apply_forwarded_result_empty():
+    """
+    Test apply_forwarded_results when no results set - do nothing
+    """
+    instance = ResultsContainer(NonCallableMock())
+    instance.apply_forwarded_results(NonCallableMock(), NonCallableMock())
+    assert instance.to_props() == []
+
+
 def test_get_forwarded_results_many_to_one():
     """
     Tests get_forwarded_results static method, where forwarded results contains

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -200,15 +200,6 @@ def test_store_query_results(mock_results):
     )
 
 
-def test_apply_forwarded_result_empty():
-    """
-    Test apply_forwarded_results when no results set - raise error
-    """
-    instance = ResultsContainer(NonCallableMock())
-    with pytest.raises(QueryChainingError):
-        instance.apply_forwarded_results(NonCallableMock(), NonCallableMock())
-
-
 @patch(
     "openstack_query.query_blocks.results_container.ResultsContainer._get_forwarded_result"
 )

--- a/tests/lib/openstack_query/query_blocks/test_result_container.py
+++ b/tests/lib/openstack_query/query_blocks/test_result_container.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch, call, NonCallableMock
 import pytest
 
-from exceptions.query_chaining_error import QueryChainingError
 from openstack_query.query_blocks.results_container import ResultsContainer
 from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 


### PR DESCRIPTION
when chaining, if the chaining results in no values found, then this error is triggered - instead we should just return nothing - as there's no values to append previous query values to. 
If this is unexpected, its up to user scripts to handle the error