### PR TITLE
BUG: remove requirement for flavor to be public

### DIFF
--- a/lib/workflows/send_decom_flavor_email.py
+++ b/lib/workflows/send_decom_flavor_email.py
@@ -67,9 +67,6 @@ def find_servers_with_decom_flavors(
 
     flavor_query = FlavorQuery()
     flavor_query.where(
-        QueryPresetsGeneric.EQUAL_TO, FlavorProperties.FLAVOR_IS_PUBLIC, value=True
-    )
-    flavor_query.where(
         QueryPresetsGeneric.ANY_IN,
         FlavorProperties.FLAVOR_NAME,
         values=flavor_name_list,

--- a/tests/lib/workflows/test_send_decom_flavor_email.py
+++ b/tests/lib/workflows/test_send_decom_flavor_email.py
@@ -176,11 +176,6 @@ def test_find_users_with_decom_flavor_valid(mock_flavor_query):
 
     mock_flavor_query.assert_called_once()
     mock_flavor_query_obj.where.assert_any_call(
-        QueryPresetsGeneric.EQUAL_TO,
-        FlavorProperties.FLAVOR_IS_PUBLIC,
-        value=True,
-    )
-    mock_flavor_query_obj.where.assert_any_call(
         QueryPresetsGeneric.ANY_IN,
         FlavorProperties.FLAVOR_NAME,
         values=["flavor1", "flavor2"],
@@ -228,11 +223,6 @@ def test_find_users_with_decom_flavor_invalid_flavor(mock_flavor_query):
 
     mock_flavor_query.assert_called_once()
     mock_flavor_query_obj.where.assert_any_call(
-        QueryPresetsGeneric.EQUAL_TO,
-        FlavorProperties.FLAVOR_IS_PUBLIC,
-        value=True,
-    )
-    mock_flavor_query_obj.where.assert_any_call(
         QueryPresetsGeneric.ANY_IN,
         FlavorProperties.FLAVOR_NAME,
         values=["invalid-flavor"],
@@ -259,11 +249,6 @@ def test_find_users_with_decom_flavor_no_servers_found(mock_flavor_query):
         )
 
     mock_flavor_query.assert_called_once()
-    mock_flavor_query_obj.where.assert_any_call(
-        QueryPresetsGeneric.EQUAL_TO,
-        FlavorProperties.FLAVOR_IS_PUBLIC,
-        value=True,
-    )
     mock_flavor_query_obj.where.assert_any_call(
         QueryPresetsGeneric.ANY_IN,
         FlavorProperties.FLAVOR_NAME,


### PR DESCRIPTION
flavor for send_decom_flavor_email workflow script no longer requires the specified flavor to be public
