### PR TITLE
BUG: fix external project action network config

### DIFF
--- a/actions/workflow.project.create.external.yaml
+++ b/actions/workflow.project.create.external.yaml
@@ -34,12 +34,12 @@ parameters:
     type: string
   admin_user_list:
     required: false
-    default: null
+    default: []
     type: array
     description: List of Users (IDs or Names) to give administrator access
   stfc_user_list:
     required: false
-    default: null
+    default: []
     type: array
     description: List of Users (stfc domain) (IDs or Names) to give local user access
   network_name:

--- a/actions/workflow.project.create.internal.yaml
+++ b/actions/workflow.project.create.internal.yaml
@@ -44,9 +44,4 @@ parameters:
     default: []
     type: array
     description: List of Users (stfc domain) (IDs or Names) to give local user access
-  network_name:
-    required: true
-    type: string
-    description: Network to allow access to (e.g. Internal or External)
-    default: Internal
 runner_type: orquesta

--- a/actions/workflow.project.defaults.set.yaml
+++ b/actions/workflow.project.defaults.set.yaml
@@ -1,0 +1,19 @@
+---
+description: Set project defaults after creation orquesta workflow. (Do not use this action from Web UI)
+enabled: true
+entry_point: workflows/project.defaults.set.yaml
+name: workflow.project.defaults.set
+parameters:
+  cloud_account:
+    description: The clouds.yaml account to use whilst performing this action
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  project_uuid:
+    required: true
+    type: string
+    description: Project ID to use
+runner_type: orquesta

--- a/actions/workflows/project.create.external.yaml
+++ b/actions/workflows/project.create.external.yaml
@@ -30,43 +30,26 @@ vars:
   - network_uuid: null
   - stderr: null
 
-output:
-  - project_id: <% ctx().project_uuid %>
-  - project_name: <% ctx().project_name %>
-  - project_description: <% ctx().project_description %>
-  - router_id: <% ctx().router_uuid %>
-  - subnet_id: <% ctx().subnet_uuid %>
-  - network_id: <% ctx().network_uuid %>
-  - stderr: <% ctx().stderr %>
-
 tasks:
   create_internal_project:
-    action: stackstorm_openstack.workflow.project.create.internal
+    action: stackstorm_openstack.project.create
       cloud_account=<% ctx().cloud_account %>
-      project_name=<% ctx().project_name %>
-      project_email=<% ctx().project_email %>
-      project_description=<% ctx().project_description %>
-      project_immutable=<% ctx().project_immutable %>
+      name=<% ctx().project_name %>
+      email=<% ctx().project_email %>
+      description=<% ctx().project_description %>
+      immutable=<% ctx().project_immutable %>
       parent_id=<% ctx().parent_id %>
-      admin_user_list=<% ctx().admin_user_list %>
-      stfc_user_list=<% ctx().stfc_user_list %>
-      network_name="External"
     next:
       - when: <% succeeded() %>
         publish:
-          - project_uuid: <% task(create_internal_project).result.output.project_id %>
+          - project_uuid: <% result().result.id %>
         do:
-          - allocate_floating_ips
           - create_network
           - create_router
-          - set_default_quota
-
-  allocate_floating_ips:
-    action: stackstorm_openstack.floating.ip_addr.create
-      cloud_account=<% ctx().cloud_account %>
-      network_identifier="External"
-      project_identifier=<% ctx().project_uuid %>
-      number_to_create=<% ctx().number_of_floating_ips %>
+          - allocate_floating_ips
+          - set_project_defaults
+          - create_stfc_roles
+          - create_admin_roles
 
   create_network:
     action: stackstorm_openstack.network.create
@@ -89,15 +72,22 @@ tasks:
     action: stackstorm_openstack.network.rbac.create
       cloud_account=<% ctx().cloud_account %>
       rbac_action="shared"
-      network_identifier="<% ctx().network_name %>"
+      network_identifier="<% ctx().network_uuid %>"
       project_identifier=<% ctx().project_uuid %>
+
+  allocate_floating_ips:
+    action: stackstorm_openstack.floating.ip_addr.create
+      cloud_account=<% ctx().cloud_account %>
+      network_identifier="External"
+      project_identifier=<% ctx().project_uuid %>
+      number_to_create=<% ctx().number_of_floating_ips %>
 
   create_subnet:
     action: stackstorm_openstack.subnet.create
       cloud_account=<% ctx().cloud_account %>
       subnet_name=<% ctx().subnet_name %>
       subnet_description=<% ctx().subnet_description %>
-      network=<% ctx().network_name %>
+      network=<% ctx().network_uuid %>
       dhcp_enabled=True
     next:
       - when: <% succeeded() %>
@@ -127,9 +117,34 @@ tasks:
       subnet_identifier=<% ctx().subnet_uuid %>
     join: all
 
-  set_default_quota:
-    action: stackstorm_openstack.quota.set
+  set_project_defaults:
+    action: stackstorm_openstack.workflow.project.defaults.set
       cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_name %>
-      num_security_group_rules=200
-      num_floating_ips=<% ctx().number_of_floating_ips %>
+      project_uuid=<% ctx().project_uuid %>
+
+  create_admin_roles:
+    with: <% ctx(admin_user_list) %>
+    action: stackstorm_openstack.role.add
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      role="admin"
+      user_identifier=<% item() %>
+      user_domain="default"
+
+  create_stfc_roles:
+    with: <% ctx(stfc_user_list) %>
+    action: stackstorm_openstack.role.add
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      role="user"
+      user_identifier=<% item() %>
+      user_domain="stfc"
+
+output:
+  - project_id: <% ctx().project_uuid %>
+  - project_name: <% ctx().project_name %>
+  - project_description: <% ctx().project_description %>
+  - router_id: <% ctx().router_uuid %>
+  - subnet_id: <% ctx().subnet_uuid %>
+  - network_id: <% ctx().network_uuid %>
+  - stderr: <% ctx().stderr %>

--- a/actions/workflows/project.create.internal.yaml
+++ b/actions/workflows/project.create.internal.yaml
@@ -11,7 +11,6 @@ input:
   - parent_id
   - admin_user_list
   - stfc_user_list
-  - network_name: "Internal"
 
 vars:
   - project_uuid: null
@@ -31,122 +30,22 @@ tasks:
         publish:
           - project_uuid: <% result().result.id %>
         do:
-          - wait_for_default_security_group
-          - create_security_group_http
-          - create_security_group_https
+          - set_project_defaults
           - create_rbac_policy
-          - create_admin_roles
           - create_stfc_roles
+          - create_admin_roles
 
   create_rbac_policy:
     action: stackstorm_openstack.network.rbac.create
       cloud_account=<% ctx().cloud_account %>
       rbac_action="shared"
-      network_identifier="<% ctx().network_name %>"
+      network_identifier="Internal"
       project_identifier=<% ctx().project_uuid %>
 
-  wait_for_default_security_group:
-    # We need to force Openstack to resync between the
-    # DB and Neutron by querying. This avoids the default
-    # SC not appearing until someone goes onto the web UI
-    action: stackstorm_openstack.security.group.list
+  set_project_defaults:
+    action: stackstorm_openstack.workflow.project.defaults.set
       cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_name %>
-    next:
-      - when: <% succeeded() %>
-        do:
-          - allow_all_icmp_by_default
-          - allow_ssh_by_default
-          - allow_aquilon_notify_by_default
-
-  allow_all_icmp_by_default:
-    action: stackstorm_openstack.security.group.rule.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      security_group_identifier="default"
-      direction="ingress"
-      ether_type="IPV4"
-      protocol="ICMP"
-      start_port="*"
-      end_port="*"
-
-  allow_ssh_by_default:
-    action: stackstorm_openstack.security.group.rule.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      security_group_identifier="default"
-      direction="ingress"
-      ether_type="IPV4"
-      protocol="TCP"
-      start_port="22"
-      end_port="22"
-
-  allow_aquilon_notify_by_default:
-    action: stackstorm_openstack.security.group.rule.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      security_group_identifier="default"
-      direction="ingress"
-      ether_type="IPV4"
-      protocol="UDP"
-      start_port="7777"
-      end_port="7777"
-
-  create_security_group_http:
-    action: stackstorm_openstack.security.group.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      group_name="HTTP"
-      group_description="Rules allowing HTTP traffic ingress"
-    next:
-      - when: <% succeeded() %>
-        do: allow_http_traffic
-
-  allow_http_traffic:
-    action: stackstorm_openstack.security.group.rule.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      security_group_identifier="HTTP"
-      direction="ingress"
-      ether_type="IPV4"
-      protocol="TCP"
-      start_port="80"
-      end_port="80"
-
-  create_security_group_https:
-    action: stackstorm_openstack.security.group.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      group_name="HTTPS"
-      group_description="Rules allowing HTTPS traffic ingress"
-    next:
-      - when: <% succeeded() %>
-        do:
-          - allow_https_traffic
-          - allow_https_HTTP3_traffic
-
-  allow_https_traffic:
-    action: stackstorm_openstack.security.group.rule.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      security_group_identifier="HTTPS"
-      direction="ingress"
-      ether_type="IPV4"
-      protocol="TCP"
-      start_port="443"
-      end_port="443"
-
-  allow_https_HTTP3_traffic:
-    # HTTP3 runs over UDP (aka QUIC protocol)
-    action: stackstorm_openstack.security.group.rule.create
-      cloud_account=<% ctx().cloud_account %>
-      project_identifier=<% ctx().project_uuid %>
-      security_group_identifier="HTTPS"
-      direction="ingress"
-      ether_type="IPV4"
-      protocol="UDP"
-      start_port="443"
-      end_port="443"
+      project_uuid=<% ctx().project_uuid %>
 
   create_admin_roles:
     with: <% ctx(admin_user_list) %>

--- a/actions/workflows/project.defaults.set.yaml
+++ b/actions/workflows/project.defaults.set.yaml
@@ -1,0 +1,126 @@
+version: 1.0
+
+description: Set Project Defaults Workflow
+
+input:
+  - cloud_account
+  - project_uuid
+
+vars:
+  - stderr: null
+
+tasks:
+  set_project_defaults:
+    action: core.noop
+    next:
+      - do:
+        - wait_for_default_security_group
+        - create_security_group_http
+        - create_security_group_https
+
+  wait_for_default_security_group:
+    # We need to force Openstack to resync between the
+    # DB and Neutron by querying. This avoids the default
+    # SC not appearing until someone goes onto the web UI
+    action: stackstorm_openstack.security.group.list
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+    next:
+      - when: <% succeeded() %>
+        do:
+          - allow_all_icmp_by_default
+          - allow_ssh_by_default
+          - allow_aquilon_notify_by_default
+
+  allow_all_icmp_by_default:
+    action: stackstorm_openstack.security.group.rule.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      security_group_identifier="default"
+      direction="ingress"
+      ether_type="IPV4"
+      protocol="ICMP"
+      start_port="*"
+      end_port="*"
+
+  allow_ssh_by_default:
+    action: stackstorm_openstack.security.group.rule.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      security_group_identifier="default"
+      direction="ingress"
+      ether_type="IPV4"
+      protocol="TCP"
+      start_port="22"
+      end_port="22"
+
+  allow_aquilon_notify_by_default:
+    action: stackstorm_openstack.security.group.rule.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      security_group_identifier="default"
+      direction="ingress"
+      ether_type="IPV4"
+      protocol="UDP"
+      start_port="7777"
+      end_port="7777"
+
+  create_security_group_http:
+    action: stackstorm_openstack.security.group.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      group_name="HTTP"
+      group_description="Rules allowing HTTP traffic ingress"
+    next:
+      - when: <% succeeded() %>
+        do: allow_http_traffic
+
+  allow_http_traffic:
+    action: stackstorm_openstack.security.group.rule.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      security_group_identifier="HTTP"
+      direction="ingress"
+      ether_type="IPV4"
+      protocol="TCP"
+      start_port="80"
+      end_port="80"
+
+  create_security_group_https:
+    action: stackstorm_openstack.security.group.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      group_name="HTTPS"
+      group_description="Rules allowing HTTPS traffic ingress"
+    next:
+      - when: <% succeeded() %>
+        do:
+          - allow_https_traffic
+          - allow_https_HTTP3_traffic
+
+  allow_https_traffic:
+    action: stackstorm_openstack.security.group.rule.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      security_group_identifier="HTTPS"
+      direction="ingress"
+      ether_type="IPV4"
+      protocol="TCP"
+      start_port="443"
+      end_port="443"
+
+  allow_https_HTTP3_traffic:
+    # HTTP3 runs over UDP (aka QUIC protocol)
+    action: stackstorm_openstack.security.group.rule.create
+      cloud_account=<% ctx().cloud_account %>
+      project_identifier=<% ctx().project_uuid %>
+      security_group_identifier="HTTPS"
+      direction="ingress"
+      ether_type="IPV4"
+      protocol="UDP"
+      start_port="443"
+      end_port="443"
+
+output:
+  - stderr: <% ctx().stderr %>
+  - project_id: <% ctx().project_uuid %>


### PR DESCRIPTION
moved "shared" actions between internal and external project creation out into another workflow.

Fixed issue where we hardcoded "External" on the rbac instead of using network name