### PR TITLE
MAINT: refactor QueryParser

### DIFF
--- a/lib/openstack_query/query_blocks/query_grouper.py
+++ b/lib/openstack_query/query_blocks/query_grouper.py
@@ -1,0 +1,127 @@
+from typing import List, Dict, Optional
+import logging
+from collections import OrderedDict
+from openstack_query.query_blocks.result import Result
+from enums.query.props.prop_enum import PropEnum
+from custom_types.openstack_query.aliases import GroupMappings, GroupRanges, PropValue
+from exceptions.parse_query_error import ParseQueryError
+
+logger = logging.getLogger(__name__)
+
+
+class QueryGrouper:
+    """
+    Helper class for implementing grouping on query outputs
+    """
+
+    def __init__(self, prop_enum_cls):
+        self._prop_enum_cls = prop_enum_cls
+        self._group_by = None
+        self._group_mappings = {}
+
+    def _build_unique_val_groups(
+        self,
+        obj_list: List,
+    ) -> GroupMappings:
+        """
+        helper method to find all unique values for a given property in query results, and then,
+        for each unique value, create a group mapping
+        :param obj_list: A list of openstack objects to build unique groups for
+        """
+        prop_func = self._prop_enum_cls.get_prop_mapping(self._group_by)
+        # ordered dict to mimic ordered set
+        # this is to preserve order we see unique values in - in case a sort has been done already
+        unique_vals = OrderedDict({prop_func(obj): None for obj in obj_list})
+        logger.debug(
+            "unique values found %s - each will become a group",
+            ",".join(f"{val}" for val in unique_vals),
+        )
+        group_mappings = {}
+        # build groups
+        for val in unique_vals.keys():
+            group_key = val
+            group_mappings[group_key] = (
+                lambda obj, test_val=val: prop_func(obj) == test_val
+            )
+        return group_mappings
+
+    def _add_include_missing_group(self, group_ranges: GroupRanges):
+        """
+        Helper method used to add an extra group for group_by which includes
+        all resource values not already included in any defined mappings
+        :param group_ranges: A set of predefined group ranges to check against
+        """
+        # if ungrouped group wanted - filter for all not in any range specified
+        all_prop_list = set()
+        for _, prop_list in group_ranges.items():
+            all_prop_list.update(set(prop_list))
+
+        prop_func = self._prop_enum_cls.get_prop_mapping(self._group_by)
+        logger.debug("creating filter function for ungrouped group")
+        self._group_mappings["ungrouped results"] = (
+            lambda obj: prop_func(obj) not in all_prop_list
+        )
+
+    def _parse_group_ranges(self, group_ranges: Optional[Dict[str, List[PropValue]]]):
+        """
+        helper method for parsing group ranges
+        :param group_ranges: a dictionary containing names of the group and list of prop values
+        to select for that group
+        """
+        logger.debug("creating filter functions for specified group ranges")
+        prop_func = self._prop_enum_cls.get_prop_mapping(self._group_by)
+        for name, prop_list in group_ranges.items():
+            group_vals = tuple(prop_list)
+            self._group_mappings[name] = (
+                lambda obj, lst=group_vals: prop_func(obj) in lst
+            )
+
+    def run_group_by(self, obj_list: List[Result]) -> Dict[str, List[Result]]:
+        """
+        method apply a set of group mappings onto a list of openstack objects. Returns a dictionary of grouped
+        values where the key is the group name and value is a list of result objects that belong to that group
+        :param obj_list: a list of Result objects containing query results to group by
+        """
+
+        # if group mappings not specified - make a group for each unique value found for prop
+        if not self._group_mappings:
+            logger.info(
+                "no group ranges specified - grouping by unique values of %s property",
+                self._group_by.name,
+            )
+            self._group_mappings = self._build_unique_val_groups(
+                [item.as_object() for item in obj_list]
+            )
+
+        return {
+            name: [item for item in obj_list if map_func(item.as_object())]
+            for name, map_func in self._group_mappings.items()
+        }
+
+    def parse_group_by(
+        self,
+        group_by: PropEnum,
+        group_ranges: Optional[GroupRanges] = None,
+        include_missing: Optional[bool] = False,
+    ) -> None:
+        """
+        Public method used to configure grouping results.
+        :param group_by: name of the property to group by
+        :param group_ranges: a dictionary containing names of the group and list of prop values
+        to select for that group
+        :param include_missing: a flag which, if set, will include an extra grouping for values
+        that don't fall into any group specified in group_ranges
+        """
+
+        if group_by not in self._prop_enum_cls:
+            raise ParseQueryError(
+                f"Error: Given property to group by: {group_by.name} is not supported by query"
+            )
+
+        self._group_by = group_by
+        self._group_mappings = {}
+        if group_ranges:
+            self._parse_group_ranges(group_ranges)
+
+        if include_missing:
+            self._add_include_missing_group(group_ranges)

--- a/lib/openstack_query/query_blocks/query_grouper.py
+++ b/lib/openstack_query/query_blocks/query_grouper.py
@@ -53,7 +53,7 @@ class QueryGrouper:
         """
         # if ungrouped group wanted - filter for all not in any range specified
         all_prop_list = set()
-        for _, prop_list in group_ranges.items():
+        for prop_list in group_ranges.values():
             all_prop_list.update(set(prop_list))
 
         prop_func = self._prop_enum_cls.get_prop_mapping(self._group_by)
@@ -86,19 +86,18 @@ class QueryGrouper:
         # if group mappings not specified - make a group for each unique value found for prop
         if not self._group_mappings:
             logger.info(
-                "no group ranges specified - grouping by unique values of %s property",
-                self._group_by.name,
+                f"no group ranges specified - grouping by unique values of {self._group_by.name} property",
             )
             self._group_mappings = self._build_unique_val_groups(
                 [item.as_object() for item in obj_list]
             )
 
-        return {
-            name: [item for item in obj_list if map_func(item.as_object())]
-            for name, map_func in self._group_mappings.items()
-        }
+        res = {}
+        for name, map_func in self._group_mappings.items():
+            res[name] = [item for item in obj_list if map_func(item.as_object())]
+        return res
 
-    def _parse_group_by_inputs(self, prop):
+    def _parse_group_by_inputs(self, prop: Union[str, PropEnum]) -> PropEnum:
         """
         Converts list of select() 'prop' user inputs into Enums, any string aliases will be converted into Enums
         :param prop: property to group by
@@ -112,7 +111,7 @@ class QueryGrouper:
         group_by: Union[str, PropEnum],
         group_ranges: Optional[GroupRanges] = None,
         include_missing: Optional[bool] = False,
-    ) -> None:
+    ):
         """
         Public method used to configure grouping results.
         :param group_by: name of the property to group by

--- a/lib/openstack_query/query_blocks/query_grouper.py
+++ b/lib/openstack_query/query_blocks/query_grouper.py
@@ -86,7 +86,8 @@ class QueryGrouper:
         # if group mappings not specified - make a group for each unique value found for prop
         if not self._group_mappings:
             logger.info(
-                f"no group ranges specified - grouping by unique values of {self._group_by.name} property",
+                "no group ranges specified - grouping by unique values of %s property",
+                self._group_by.name,
             )
             self._group_mappings = self._build_unique_val_groups(
                 [item.as_object() for item in obj_list]

--- a/lib/openstack_query/query_blocks/query_grouper.py
+++ b/lib/openstack_query/query_blocks/query_grouper.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 import logging
 from collections import OrderedDict
 from openstack_query.query_blocks.result import Result
@@ -98,9 +98,18 @@ class QueryGrouper:
             for name, map_func in self._group_mappings.items()
         }
 
+    def _parse_group_by_inputs(self, prop):
+        """
+        Converts list of select() 'prop' user inputs into Enums, any string aliases will be converted into Enums
+        :param prop: property to group by
+        """
+        if isinstance(prop, str):
+            prop = self._prop_enum_cls.from_string(prop)
+        return prop
+
     def parse_group_by(
         self,
-        group_by: PropEnum,
+        group_by: Union[str, PropEnum],
         group_ranges: Optional[GroupRanges] = None,
         include_missing: Optional[bool] = False,
     ) -> None:
@@ -112,6 +121,7 @@ class QueryGrouper:
         :param include_missing: a flag which, if set, will include an extra grouping for values
         that don't fall into any group specified in group_ranges
         """
+        group_by = self._parse_group_by_inputs(group_by)
 
         if group_by not in self._prop_enum_cls:
             raise ParseQueryError(

--- a/lib/openstack_query/query_blocks/query_parser.py
+++ b/lib/openstack_query/query_blocks/query_parser.py
@@ -25,7 +25,9 @@ class QueryParser:
         self._sort = False
         self._group = False
 
-    def parse_sort_by(self, *sort_by: Tuple[PropEnum, SortOrder]):
+    def parse_sort_by(
+        self, *sort_by: Tuple[Union[PropEnum, str], Union[SortOrder, str]]
+    ):
         """
         public method to set sorting parameters. Forwards onto sorter.parse_sort_by
         :param sort_by: one or more tuples of property name to sort by and order enum
@@ -35,7 +37,7 @@ class QueryParser:
 
     def parse_group_by(
         self,
-        group_by: PropEnum,
+        group_by: Union[str, PropEnum],
         group_ranges: Optional[GroupRanges] = None,
         include_missing: Optional[bool] = False,
     ):

--- a/lib/openstack_query/query_blocks/query_parser.py
+++ b/lib/openstack_query/query_blocks/query_parser.py
@@ -1,17 +1,13 @@
-from typing import List, Dict, Tuple, Union, Optional, Type
+from typing import List, Dict, Union, Type, Tuple, Optional
 import logging
-from collections import OrderedDict
 
+from custom_types.openstack_query.aliases import GroupRanges
+
+from enums.query.sort_order import SortOrder
+from openstack_query.query_blocks.query_grouper import QueryGrouper
+from openstack_query.query_blocks.query_sorter import QuerySorter
 from openstack_query.query_blocks.result import Result
 from enums.query.props.prop_enum import PropEnum
-from enums.query.sort_order import SortOrder
-from custom_types.openstack_query.aliases import (
-    OpenstackResourceObj,
-    PropValue,
-    GroupMappings,
-    GroupRanges,
-)
-from exceptions.parse_query_error import ParseQueryError
 
 logger = logging.getLogger(__name__)
 
@@ -23,175 +19,35 @@ class QueryParser:
     """
 
     def __init__(self, prop_enum_cls: Type[PropEnum]):
-        self._prop_enum_cls = prop_enum_cls
-        self._sort_by = {}
-        self._group_by = None
-        self._group_mappings = {}
+        self.sorter = QuerySorter(prop_enum_cls)
+        self.grouper = QueryGrouper(prop_enum_cls)
+        self._sort = False
+        self._group = False
 
-    @property
-    def group_by(self):
+    def parse_sort_by(self, *sort_by: Tuple[PropEnum, SortOrder]):
         """
-        a getter method to return group_by prop enum
+        public method to set sorting parameters. Forwards onto sorter.parse_sort_by
+        :param sort_by: one or more tuples of property name to sort by and order enum
         """
-        return self._group_by
-
-    @group_by.setter
-    def group_by(self, prop: PropEnum):
-        """
-        a setter method to set group_by prop enum
-        :param prop: prop enum to group by
-        """
-        self._group_by = prop
-
-    @property
-    def sort_by(self):
-        """
-        a getter method to return sort_by options
-        """
-        return self._sort_by
-
-    @sort_by.setter
-    def sort_by(self, sort_by: Dict[PropEnum, bool]):
-        """
-        a setter method to set sort_by options
-        :param sort_by: a dictionary of prop enum to sort by mapped to order
-        (True for Descending, False of Ascending)
-        """
-        self._sort_by = sort_by
-
-    @property
-    def group_mappings(self):
-        """
-        a getter method to set group_mappings options
-        """
-        return self._group_mappings
-
-    @group_mappings.setter
-    def group_mappings(self, group_mappings: GroupMappings):
-        """
-        a setter method to set group_mapping options
-        :param group_mappings: a dictionary of group name to a list of
-        property values that belong to that group
-        """
-        self._group_mappings = group_mappings
-
-    def _parse_sort_by_inputs(
-        self, *sort_by: Tuple[Union[PropEnum, str], Union[SortOrder, str]]
-    ) -> List[Tuple[PropEnum, SortOrder]]:
-        """
-        Converts list of sort_by() user inputs into Enums, any string aliases will be converted into Enums
-        :param sort_by: one or more tuples of property Enum/String alias to sort by and order Enum/string alias
-        """
-        parsed_sort_by = []
-        for prop, order in sort_by:
-            if isinstance(prop, str):
-                prop = self._prop_enum_cls.from_string(prop)
-            if isinstance(order, str):
-                order = SortOrder.from_string(order)
-            parsed_sort_by.append((prop, order))
-        return parsed_sort_by
-
-    def parse_sort_by(
-        self, *sort_by: Tuple[Union[PropEnum, str], Union[SortOrder, str]]
-    ) -> None:
-        """
-        Public method used to configure sorting results
-        :param sort_by: one or more tuples of property Enum/String alias to sort by and order enum/string alias
-        e.g. ("server_name", "asc") or (ServerProperties.SERVER_NAME", SortOrder.ASC) - both parsed the same
-        """
-        sort_by = self._parse_sort_by_inputs(*sort_by)
-
-        sort_by_dict = {}
-        for user_selected_prop, _ in sort_by:
-            if user_selected_prop not in self._prop_enum_cls:
-                raise ParseQueryError(
-                    f"Error: Given property to sort by: {user_selected_prop.name} is not supported by query"
-                )
-
-        for prop, order in sort_by:
-            order_log_str = "DESC" if order.value else "ASC"
-            logging.debug(
-                "adding sorting params: %s, order: %s", prop.name, order_log_str
-            )
-            sort_by_dict.update({prop: order.value})
-
-        self.sort_by = sort_by_dict
-
-        logging.debug(
-            "sort params: %s",
-            "\n\t".join(
-                f"{prop}, order: {'DESC' if order else 'ASC'}"
-                for prop, order in self.sort_by.items()
-            ),
-        )
-
-    def _parse_group_by_inputs(self, prop):
-        """
-        Converts list of select() 'prop' user inputs into Enums, any string aliases will be converted into Enums
-        :param prop: property to group by
-        """
-        if isinstance(prop, str):
-            prop = self._prop_enum_cls.from_string(prop)
-        return prop
+        self.sorter.parse_sort_by(*sort_by)
+        self._sort = True
 
     def parse_group_by(
         self,
         group_by: Union[PropEnum, str],
         group_ranges: Optional[GroupRanges] = None,
         include_missing: Optional[bool] = False,
-    ) -> None:
+    ):
         """
-        Public method used to configure grouping results.
-        :param group_by: Enum/string alias of the property to group by
+        public method to set grouping parameters. Forwards onto grouper.parse_group_by
+        :param group_by: one or more tuples of property name to sort by and order enum
         :param group_ranges: a dictionary containing names of the group and list of prop values
         to select for that group
         :param include_missing: a flag which, if set, will include an extra grouping for values
         that don't fall into any group specified in group_ranges
         """
-        group_by = self._parse_group_by_inputs(group_by)
-        if group_by not in self._prop_enum_cls:
-            raise ParseQueryError(
-                f"Error: Given property to group by: {group_by.name} is not supported by query"
-            )
-
-        self.group_by = group_by
-        self.group_mappings = {}
-        if group_ranges:
-            self._parse_group_ranges(group_ranges)
-
-        if include_missing:
-            self._add_include_missing_group(group_ranges)
-
-    def _parse_group_ranges(self, group_ranges: Optional[Dict[str, List[PropValue]]]):
-        """
-        helper method for parsing group ranges
-        :param group_ranges: a dictionary containing names of the group and list of prop values
-        to select for that group
-        """
-        logger.debug("creating filter functions for specified group ranges")
-        prop_func = self._prop_enum_cls.get_prop_mapping(self.group_by)
-        for name, prop_list in group_ranges.items():
-            group_vals = tuple(prop_list)
-            self.group_mappings[name] = (
-                lambda obj, lst=group_vals: prop_func(obj.as_object()) in lst
-            )
-
-    def _add_include_missing_group(self, group_ranges: GroupRanges):
-        """
-        Helper method used to add an extra group for group_by which includes
-        all resource values not already included in any defined mappings
-        :param group_ranges: A set of predefined group ranges to check against
-        """
-        # if ungrouped group wanted - filter for all not in any range specified
-        all_prop_list = set()
-        for _, prop_list in group_ranges.items():
-            all_prop_list.update(set(prop_list))
-
-        prop_func = self._prop_enum_cls.get_prop_mapping(self.group_by)
-        logger.debug("creating filter function for ungrouped group")
-        self.group_mappings["ungrouped results"] = (
-            lambda obj: prop_func(obj.as_object()) not in all_prop_list
-        )
+        self.grouper.parse_group_by(group_by, group_ranges, include_missing)
+        self._group = True
 
     def run_parser(
         self, obj_list: List[Result]
@@ -201,84 +57,12 @@ class QueryParser:
         :param obj_list: a list of Result objects containing query results to parse
         (runs both sorting and grouping)
         """
-        if not obj_list:
-            return obj_list
 
         # we sort first - assuming sorting is commutative to grouping
-        if self.sort_by:
-            obj_list = self._run_sort(obj_list)
+        if self._sort:
+            obj_list = self.sorter.run_sort_by(obj_list)
 
-        if self.group_by:
-            obj_list = self._run_group_by(obj_list)
+        if self._group:
+            obj_list = self.grouper.run_group_by(obj_list)
 
         return obj_list
-
-    def _run_sort(self, obj_list: List[Result]) -> List[Result]:
-        """
-        method which sorts a list of query results based on a dictionary of sort_by specs
-        :param obj_list: a list of Result objects containing query results to sort
-        """
-
-        logger.debug("running multi-sort")
-        sort_num = len(self.sort_by)
-        for i, (sort_key, reverse) in enumerate(
-            reversed(tuple(self.sort_by.items())), 1
-        ):
-            logger.debug("running sort %s / %s", i, sort_num)
-            logger.debug("sorting by: %s, reverse=%s", sort_key, reverse)
-            prop_func = self._prop_enum_cls.get_prop_mapping(sort_key)
-            obj_list.sort(
-                key=lambda x, fn=prop_func: fn(x.as_object()), reverse=reverse
-            )
-        return obj_list
-
-    def _build_unique_val_groups(
-        self,
-        obj_list: List[OpenstackResourceObj],
-    ) -> GroupMappings:
-        """
-        helper method to find all unique values for a given property in query results, and then,
-        for each unique value, create a group mapping
-        :param obj_list: A list of openstack objects to build unique groups for
-        """
-        prop_func = self._prop_enum_cls.get_prop_mapping(self.group_by)
-        # ordered dict to mimic ordered set
-        # this is to preserve order we see unique values in - in case a sort has been done already
-        unique_vals = OrderedDict({prop_func(obj): None for obj in obj_list})
-        logger.debug(
-            "unique values found %s - each will become a group",
-            ",".join(f"{val}" for val in unique_vals),
-        )
-
-        group_mappings = {}
-
-        # build groups
-        for val in unique_vals.keys():
-            group_key = val
-            group_mappings[group_key] = (
-                lambda obj, test_val=val: prop_func(obj) == test_val
-            )
-
-        return group_mappings
-
-    def _run_group_by(self, obj_list: List[Result]) -> Dict[str, List[Result]]:
-        """
-        helper method apply a set of group mappings onto a list of openstack objects. Returns a dictionary of grouped
-        values where the key is the group name and value is a list of result objects that belong to that group
-        :param obj_list: a list of Result objects containing query results to group by
-        """
-
-        # if group mappings not specified - make a group for each unique value found for prop
-        if not self.group_mappings:
-            logger.info(
-                "no group ranges specified - grouping by unique values of %s property",
-                self.group_by.name,
-            )
-            self.group_mappings = self._build_unique_val_groups(
-                [item.as_object() for item in obj_list]
-            )
-
-        return {
-            name: [item for item in obj_list if map_func(item.as_object())]
-            for name, map_func in self.group_mappings.items()
-        }

--- a/lib/openstack_query/query_blocks/query_parser.py
+++ b/lib/openstack_query/query_blocks/query_parser.py
@@ -4,10 +4,11 @@ import logging
 from custom_types.openstack_query.aliases import GroupRanges
 
 from enums.query.sort_order import SortOrder
+from enums.query.props.prop_enum import PropEnum
+
 from openstack_query.query_blocks.query_grouper import QueryGrouper
 from openstack_query.query_blocks.query_sorter import QuerySorter
 from openstack_query.query_blocks.result import Result
-from enums.query.props.prop_enum import PropEnum
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class QueryParser:
 
     def parse_group_by(
         self,
-        group_by: Union[PropEnum, str],
+        group_by: PropEnum,
         group_ranges: Optional[GroupRanges] = None,
         include_missing: Optional[bool] = False,
     ):

--- a/lib/openstack_query/query_blocks/query_sorter.py
+++ b/lib/openstack_query/query_blocks/query_sorter.py
@@ -76,9 +76,8 @@ class QuerySorter:
 
         logger.debug("running multi-sort")
         sort_num = len(self._sort_by)
-        for i, (sort_key, reverse) in enumerate(
-            reversed(tuple(self._sort_by.items())), 1
-        ):
+        obj_iter = enumerate(reversed(tuple(self._sort_by.items())), 1)
+        for i, (sort_key, reverse) in obj_iter:
             logger.debug("running sort %s / %s", i, sort_num)
             logger.debug("sorting by: %s, reverse=%s", sort_key, reverse)
             prop_func = self._prop_enum_cls.get_prop_mapping(sort_key)

--- a/lib/openstack_query/query_blocks/query_sorter.py
+++ b/lib/openstack_query/query_blocks/query_sorter.py
@@ -1,0 +1,68 @@
+from typing import List, Tuple
+import logging
+
+from openstack_query.query_blocks.result import Result
+
+from enums.query.sort_order import SortOrder
+from enums.query.props.prop_enum import PropEnum
+from exceptions.parse_query_error import ParseQueryError
+
+logger = logging.getLogger(__name__)
+
+
+class QuerySorter:
+    """
+    Helper class for implementing sorting on query outputs
+    """
+
+    def __init__(self, prop_enum_cls):
+        self._prop_enum_cls = prop_enum_cls
+        self._sort_by = {}
+
+    def parse_sort_by(self, *sort_by: Tuple[PropEnum, SortOrder]) -> None:
+        """
+        Public method used to configure sorting results
+        :param sort_by: one or more tuples of property name to sort by and order enum
+        """
+        sort_by_dict = {}
+        for user_selected_prop, _ in sort_by:
+            if user_selected_prop not in self._prop_enum_cls:
+                raise ParseQueryError(
+                    f"Error: Given property to sort by: {user_selected_prop.name} is not supported by query"
+                )
+
+        for prop, order in sort_by:
+            order_log_str = "DESC" if order.value else "ASC"
+            logging.debug(
+                "adding sorting params: %s, order: %s", prop.name, order_log_str
+            )
+            sort_by_dict.update({prop: order.value})
+
+            self._sort_by = sort_by_dict
+
+            logging.debug(
+                "sort params: %s",
+                "\n\t".join(
+                    f"{prop}, order: {'DESC' if order else 'ASC'}"
+                    for prop, order in self._sort_by.items()
+                ),
+            )
+
+    def run_sort_by(self, obj_list: List[Result]) -> List[Result]:
+        """
+        method which sorts a list of query results based on a dictionary of sort_by specs
+        :param obj_list: a list of Result objects containing query results to sort
+        """
+
+        logger.debug("running multi-sort")
+        sort_num = len(self._sort_by)
+        for i, (sort_key, reverse) in enumerate(
+            reversed(tuple(self._sort_by.items())), 1
+        ):
+            logger.debug("running sort %s / %s", i, sort_num)
+            logger.debug("sorting by: %s, reverse=%s", sort_key, reverse)
+            prop_func = self._prop_enum_cls.get_prop_mapping(sort_key)
+            obj_list.sort(
+                key=lambda x, fn=prop_func: fn(x.as_object()), reverse=reverse
+            )
+        return obj_list

--- a/tests/lib/openstack_query/query_blocks/conftest.py
+++ b/tests/lib/openstack_query/query_blocks/conftest.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+import pytest
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(scope="function", name="mock_results_container")
+def results_container_fixture():
+    """
+    Returns a list of mock results with each as_object return value set to
+    given values
+    """
+
+    def _setup_results_container(mock_as_objects):
+        """
+        function which sets up a list of mock Result objects each with
+        a different as_object return value - as specified by mock_as_objects input
+        :param mock_as_objects: a list of values that is to be assigned as the
+         return_value for each mock Result object
+        """
+        mock_results = [MagicMock() for _ in mock_as_objects]
+        for i, mock_result in enumerate(mock_results):
+            mock_result.as_object.return_value = mock_as_objects[i]
+        return mock_results
+
+    return _setup_results_container
+
+
+@pytest.fixture(scope="function", name="mock_get_prop_mapping")
+def get_prop_mapping_fixture():
+    """
+    Returns a mocked get_prop_mapping function
+    """
+
+    def _mock_get_prop_mapping(mock_prop: MockProperties):
+        """
+        Stubs the get_prop_mapping method - it now takes a property enum and returns <prop_enum>.name.lower()
+        :param mock_prop: property enum passed to get_prop_mapping
+        """
+        return MagicMock(wraps=lambda obj, prop=mock_prop: obj[prop.name.lower()])
+
+    return _mock_get_prop_mapping

--- a/tests/lib/openstack_query/query_blocks/test_query_grouper.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_grouper.py
@@ -1,0 +1,140 @@
+from unittest.mock import MagicMock, call, patch
+import pytest
+
+from openstack_query.query_blocks.query_grouper import QueryGrouper
+from enums.query.sort_order import SortOrder
+from enums.query.props.server_properties import ServerProperties
+
+from exceptions.parse_query_error import ParseQueryError
+
+
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(name="instance")
+def instance_fixture():
+    """
+    Returns an instance with mocked prop_enum_cls inject
+    """
+    mock_prop_enum_cls = MockProperties
+    return QueryGrouper(prop_enum_cls=mock_prop_enum_cls)
+
+
+@pytest.fixture(name="run_group_by_runner")
+def run_group_by_runner_fixture(instance, mock_get_prop_mapping):
+    """
+    A fixture to test run_group_by method
+    """
+
+    def _run_group_by_runner(
+        mock_group_by,
+        mock_group_ranges,
+        mock_include_missing,
+        mock_obj_list,
+        expected_out,
+    ):
+        """
+        runs run_group_by method with different test arts
+        """
+        with patch.object(
+            MockProperties, "get_prop_mapping", wraps=mock_get_prop_mapping
+        ) as mock_get_prop_func:
+            instance.parse_group_by(
+                mock_group_by, mock_group_ranges, mock_include_missing
+            )
+            res = instance.run_group_by(mock_obj_list)
+            if mock_include_missing:
+                mock_get_prop_func.assert_has_calls(
+                    [call(mock_group_by), call(mock_group_by)]
+                )
+            else:
+                mock_get_prop_func.assert_called_once_with(mock_group_by)
+
+        for key, vals in res.items():
+            assert key in res.keys()
+            assert expected_out[key] == [i.as_object() for i in vals]
+
+    return _run_group_by_runner
+
+
+def test_parse_group_by_invalid(instance):
+    """
+    Tests parse_group_by - when given an invalid group by prop
+    """
+    with pytest.raises(ParseQueryError):
+        instance.parse_group_by(ServerProperties.SERVER_ID)
+
+
+def test_run_group_by_no_group_mappings(run_group_by_runner, mock_results_container):
+    """
+    Tests run_group_by when given no group mappings
+    """
+    mock_as_object_vals = [
+        {"prop_1": "a", "prop_2": 1},
+        {"prop_1": "a", "prop_2": 2},
+        {"prop_1": "b", "prop_2": 3},
+        {"prop_1": "b", "prop_2": 4},
+    ]
+
+    expected_out = {
+        "a": [{"prop_1": "a", "prop_2": 1}, {"prop_1": "a", "prop_2": 2}],
+        "b": [{"prop_1": "b", "prop_2": 3}, {"prop_1": "b", "prop_2": 4}],
+    }
+
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+
+    run_group_by_runner(MockProperties.PROP_1, None, False, mock_obj_list, expected_out)
+
+
+def test_run_group_by_with_group_mappings(run_group_by_runner, mock_results_container):
+    """
+    Tests run_group_by when given group mappings
+    """
+    mock_as_object_vals = [
+        {"prop_1": "a", "prop_2": 1},
+        {"prop_1": "b", "prop_2": 2},
+        {"prop_1": "c", "prop_2": 3},
+        {"prop_1": "d", "prop_2": 4},
+    ]
+
+    mock_group_mappings = {"mapping_1": ["a", "c"], "mapping_2": ["b"]}
+
+    expected_out = {
+        "mapping_1": [{"prop_1": "a", "prop_2": 1}, {"prop_1": "c", "prop_2": 3}],
+        "mapping_2": [{"prop_1": "b", "prop_2": 2}],
+    }
+
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+
+    run_group_by_runner(
+        MockProperties.PROP_1, mock_group_mappings, False, mock_obj_list, expected_out
+    )
+
+
+def test_run_group_by_with_include_missing(run_group_by_runner, mock_results_container):
+    """
+    Tests run_group_by when given group mappings and include_missing=True
+    """
+    mock_as_object_vals = [
+        {"prop_1": "a", "prop_2": 1},
+        {"prop_1": "b", "prop_2": 2},
+        {"prop_1": "c", "prop_2": 3},
+        {"prop_1": "d", "prop_2": 4},
+    ]
+
+    mock_group_mappings = {
+        "mapping_1": ["a", "c"],
+        "mapping_2": ["b"],
+    }
+
+    expected_out = {
+        "mapping_1": [{"prop_1": "a", "prop_2": 1}, {"prop_1": "c", "prop_2": 3}],
+        "mapping_2": [{"prop_1": "b", "prop_2": 2}],
+        "ungrouped results": [{"prop_1": "d", "prop_2": 4}],
+    }
+
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+
+    run_group_by_runner(
+        MockProperties.PROP_1, mock_group_mappings, True, mock_obj_list, expected_out
+    )

--- a/tests/lib/openstack_query/query_blocks/test_query_grouper.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_grouper.py
@@ -64,6 +64,31 @@ def test_parse_group_by_invalid(instance):
         instance.parse_group_by(ServerProperties.SERVER_ID)
 
 
+def test_parse_group_by_with_string_aliases(mock_results_container):
+    """
+    Tests parse_group_by accepts string aliases
+    """
+    mock_as_object_vals = [
+        {"name": "a", "id": 1},
+        {"name": "a", "id": 2},
+        {"name": "b", "id": 3},
+        {"name": "b", "id": 4},
+    ]
+
+    expected_out = {
+        "a": [{"name": "a", "id": 1}, {"name": "a", "id": 2}],
+        "b": [{"name": "b", "id": 3}, {"name": "b", "id": 4}],
+    }
+
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+    instance = QueryGrouper(prop_enum_cls=ServerProperties)
+    instance.parse_group_by(ServerProperties.SERVER_NAME)
+    res = instance.run_group_by(mock_obj_list)
+    for key, vals in res.items():
+        assert key in res.keys()
+        assert expected_out[key] == [i.as_object() for i in vals]
+
+
 def test_run_group_by_no_group_mappings(run_group_by_runner, mock_results_container):
     """
     Tests run_group_by when given no group mappings

--- a/tests/lib/openstack_query/query_blocks/test_query_grouper.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_grouper.py
@@ -1,8 +1,7 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 import pytest
 
 from openstack_query.query_blocks.query_grouper import QueryGrouper
-from enums.query.sort_order import SortOrder
 from enums.query.props.server_properties import ServerProperties
 
 from exceptions.parse_query_error import ParseQueryError

--- a/tests/lib/openstack_query/query_blocks/test_query_parser.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_parser.py
@@ -1,572 +1,87 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch, NonCallableMock
 import pytest
 
-from enums.query.props.server_properties import ServerProperties
-from enums.query.sort_order import SortOrder
 from openstack_query.query_blocks.query_parser import QueryParser
-from exceptions.parse_query_error import ParseQueryError
-
-from tests.lib.openstack_query.mocks.mocked_props import MockProperties
-
-
-@pytest.fixture(name="mock_results_container")
-def results_container_fixture():
-    """
-    Returns a list of mock results with each as_object return value set to
-    given values
-    """
-
-    def _setup_results_container(mock_as_objects):
-        """
-        function which sets up a list of mock Result objects each with
-        a different as_object return value - as specified by mock_as_objects input
-        :param mock_as_objects: a list of values that is to be assigned as the
-         return_value for each mock Result object
-        """
-        mock_results = [MagicMock() for _ in mock_as_objects]
-        for i, mock_result in enumerate(mock_results):
-            mock_result.as_object.return_value = mock_as_objects[i]
-        return mock_results
-
-    return _setup_results_container
 
 
 @pytest.fixture(name="instance")
-def instance_fixture():
+@patch("openstack_query.query_blocks.query_parser.QueryGrouper")
+@patch("openstack_query.query_blocks.query_parser.QuerySorter")
+def instance_fixture(mock_sorter, mock_grouper):
     """
-    Returns an instance with mocked prop_enum_cls inject
+    Returns an instance of QueryParser with mocked injects
     """
-    mock_prop_enum_cls = MockProperties
-    return QueryParser(prop_enum_cls=mock_prop_enum_cls)
+    mock_prop_enum_cls = NonCallableMock()
+    parser = QueryParser(mock_prop_enum_cls)
+    mock_sorter.assert_called_once_with(mock_prop_enum_cls)
+    mock_grouper.assert_called_once_with(mock_prop_enum_cls)
+    return parser
 
 
-@pytest.fixture(name="mock_get_prop_mapping")
-def get_prop_mapping_fixture():
+def test_parse_group_by(instance):
     """
-    Returns a mocked get_prop_mapping function
+    Tests parse_group_by method forwards onto grouper
     """
-
-    def _mock_get_prop_mapping(mock_prop: MockProperties):
-        """
-        Stubs the get_prop_mapping method - it now takes a property enum and returns <prop_enum>.name.lower()
-        :param mock_prop: property enum passed to get_prop_mapping
-        """
-        return MagicMock(wraps=lambda obj, prop=mock_prop: obj[prop.name.lower()])
-
-    return _mock_get_prop_mapping
-
-
-@pytest.fixture(name="run_sort_by_tests")
-def run_sort_by_tests_fixture(instance, mock_get_prop_mapping):
-    """
-    Fixture which runs sort_by with different test cases
-    """
-
-    def _run_sort_by_tests(obj_list, sort_by_specs, expected_list):
-        """
-        Method which runs sort_by with different inputs
-        """
-        instance.sort_by = sort_by_specs
-        with patch.object(
-            MockProperties, "get_prop_mapping", wraps=mock_get_prop_mapping
-        ) as mock_get_prop_func:
-            # pylint:disable=protected-access
-            res = instance._run_sort(obj_list)
-            # test that res object list is sorted properly
-            assert [item.as_object() for item in res] == expected_list
-            mock_get_prop_func.assert_has_calls(
-                [call(sort_key) for sort_key in reversed(sort_by_specs.keys())]
-            )
-
-    return _run_sort_by_tests
-
-
-def test_group_by(instance):
-    """
-    Tests that property functions group_by work
-    """
-    instance.group_by = MockProperties.PROP_1
-    assert instance.group_by == MockProperties.PROP_1
-
-
-def test_sort_by(instance):
-    """
-    Tests that property functions sort_by work
-    """
-    instance.sort_by = {MockProperties.PROP_1: True}
-    assert instance.sort_by == {MockProperties.PROP_1: True}
-
-
-def test_parse_sort_by_one_key(instance):
-    """
-    Tests parse_sort_by method works expectedly - one sort-by key
-    should call check_prop_valid and add it to sort_by attribute
-    """
-    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.ASC))
-    assert instance.sort_by == {MockProperties.PROP_1: False}
-
-
-def test_parse_sort_by_many_keys(instance):
-    """
-    Tests parse_sort_by method works expectedly - two sort-by keys
-    should call check_prop_valid and add it to sort_by attribute
-    """
-    instance.parse_sort_by(
-        (MockProperties.PROP_1, SortOrder.ASC), (MockProperties.PROP_2, SortOrder.DESC)
-    )
-    assert instance.sort_by == {
-        MockProperties.PROP_1: False,
-        MockProperties.PROP_2: True,
-    }
-
-
-def test_parse_sort_by_invalid(instance):
-    """
-    Tests parse_sort_by method works expectedly - raise error if property is invalid
-    should raise ParseQueryError
-    """
-    with pytest.raises(ParseQueryError):
-        instance.parse_sort_by((ServerProperties.SERVER_ID, True))
-
-
-def test_parse_sort_by_with_string_aliases():
-    """
-    Tests that parse_sort_by method can handle string aliases as well as enums
-    """
-    # we create a new local instance since MockProperties doesn't implement the from_string method
-    mock_prop_enum_cls = ServerProperties
-    instance = QueryParser(prop_enum_cls=mock_prop_enum_cls)
-
-    instance.parse_sort_by(("server_id", "asc"), ("server_name", "descending"))
-    assert instance.sort_by == {
-        ServerProperties.SERVER_ID: False,
-        ServerProperties.SERVER_NAME: True,
-    }
-
-
-def test_parse_group_by_invalid(instance):
-    """
-    Tests parse_group_by - when given an invalid group by prop
-    """
-    with pytest.raises(ParseQueryError):
-        # we gave an unexpected enum value (sort-order) that's not supported
-        instance.parse_group_by(SortOrder.DESC)
-
-
-def test_parse_group_by_no_ranges(instance):
-    """
-    Tests parse_group_by functions expectedly - with no ranges
-    Should simply set the group_by property as prop given
-    """
-    instance.parse_group_by(MockProperties.PROP_1)
-    assert instance.group_by == MockProperties.PROP_1
-
-
-@patch("openstack_query.query_blocks.query_parser.QueryParser._parse_group_ranges")
-def test_parse_group_by_with_group_ranges(mock_parse_group_ranges, instance):
-    """
-    Tests parse_group_by functions expectedly - with group ranges
-    Should set group_by and call parse_group_ranges
-    """
-    mock_group_ranges = {"group1": ["val1", "val2", "val3"], "group2": ["val4"]}
-    instance.parse_group_by(MockProperties.PROP_1, mock_group_ranges)
-    assert instance.group_by == MockProperties.PROP_1
-    mock_parse_group_ranges.assert_called_once_with(mock_group_ranges)
-
-
-@patch("openstack_query.query_blocks.query_parser.QueryParser._parse_group_ranges")
-@patch(
-    "openstack_query.query_blocks.query_parser.QueryParser._add_include_missing_group"
-)
-def test_parse_group_by_with_group_ranges_and_include_missing(
-    mock_add_include_missing_group, mock_parse_group_ranges, instance
-):
-    """
-    Tests parse_group_by functions expectedly - with group ranges
-    Should set group_by and call parse_group_ranges
-    """
-    mock_group_ranges = {"group1": ["val1", "val2", "val3"], "group2": ["val4"]}
-    instance.parse_group_by(
-        MockProperties.PROP_1, mock_group_ranges, include_missing=True
-    )
-    assert instance.group_by == MockProperties.PROP_1
-    mock_parse_group_ranges.assert_called_once_with(mock_group_ranges)
-    mock_add_include_missing_group.assert_called_once_with(mock_group_ranges)
-
-
-def test_parse_group_by_with_string_aliases():
-    """
-    Tests that parse_group_by method can handle string aliases as well as enums
-    """
-    # we create a new local instance since MockProperties doesn't implement the from_string method
-    mock_prop_enum_cls = ServerProperties
-    instance = QueryParser(prop_enum_cls=mock_prop_enum_cls)
-
-    instance.parse_group_by("server_id")
-    assert instance.group_by == ServerProperties.SERVER_ID
-
-
-def test_run_parse_group_ranges(instance, mock_get_prop_mapping):
-    """
-    Tests parse_group_ranges functions expectedly
-    Should setup groups based on given group mappings
-    """
-    mock_group_by = MockProperties.PROP_1
-    instance.group_by = mock_group_by
-    mock_group_ranges = {"group1": ["val1", "val2", "val3"], "group2": ["val4"]}
-
-    with patch.object(
-        MockProperties, "get_prop_mapping", wraps=mock_get_prop_mapping
-    ) as mock_get_prop_func:
-        # pylint:disable=protected-access
-        instance._parse_group_ranges(group_ranges=mock_group_ranges)
-        mock_get_prop_func.assert_called_once_with(mock_group_by)
-
-    assert instance.group_mappings
-
-    prop_to_check = MagicMock()
-    prop_to_check.as_object.return_value = {"prop_1": "val1"}
-
-    assert instance.group_mappings["group1"](prop_to_check)
-    assert not instance.group_mappings["group2"](prop_to_check)
-
-
-def test_add_include_missing_group(
-    instance, mock_get_prop_mapping, mock_results_container
-):
-    """
-    Tests add_include_missing_group functions expectedly
-    Should create an extra "ungrouped results" group which includes values
-    not already specified in any other group
-    """
-    mock_group_by = MockProperties.PROP_1
-    instance.group_by = mock_group_by
-    mock_group_ranges = {"group1": ["val1", "val2", "val3"], "group2": ["val4"]}
-
-    with patch.object(
-        MockProperties, "get_prop_mapping", wraps=mock_get_prop_mapping
-    ) as mock_get_prop_func:
-        # pylint:disable=protected-access
-        instance._add_include_missing_group(mock_group_ranges)
-        mock_get_prop_func.assert_called_once_with(mock_group_by)
-
-    results_to_check = mock_results_container(
-        [{"prop_1": "val5"}, {"prop_1": "val1"}, {"prop_1": "val4"}]
+    mock_group_by = NonCallableMock()
+    mock_group_ranges = NonCallableMock()
+    mock_include_missing = NonCallableMock()
+    instance.parse_group_by(mock_group_by, mock_group_ranges, mock_include_missing)
+    instance.grouper.parse_group_by.assert_called_once_with(
+        mock_group_by, mock_group_ranges, mock_include_missing
     )
 
-    assert instance.group_mappings["ungrouped results"](results_to_check[0])
-    assert not instance.group_mappings["ungrouped results"](results_to_check[1])
-    assert not instance.group_mappings["ungrouped results"](results_to_check[2])
 
-
-@patch("openstack_query.query_blocks.query_parser.QueryParser._run_sort")
-def test_run_parser_with_sort_by(mock_run_sort, instance):
+def test_parse_sort_by(instance):
     """
-    Tests that run_parser functions expectedly - when giving only sort_by
-    Should call run_sort method, and return result
+    Tests parse_sort_by method forwards onto sorter
     """
-    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.DESC))
+    mock_sort_by = NonCallableMock()
+    instance.parse_sort_by(mock_sort_by)
+    instance.sorter.parse_sort_by(mock_sort_by)
 
-    mock_run_sort.return_value = "sort-out"
-    mock_obj_list = ["obj1", "obj2", "obj3"]
+
+def test_run_parser_sort_by_only(instance):
+    """
+    Tests run_parser method with only sort_by being set
+    """
+    instance.parse_sort_by(NonCallableMock())
+    mock_obj_list = NonCallableMock()
     res = instance.run_parser(mock_obj_list)
+    instance.sorter.run_sort_by.assert_called_once_with(mock_obj_list)
+    assert res == instance.sorter.run_sort_by.return_value
 
-    assert res == "sort-out"
-    mock_run_sort.assert_called_once_with(mock_obj_list)
 
-
-@patch("openstack_query.query_blocks.query_parser.QueryParser._run_group_by")
-def test_run_parser_no_sort_with_group_mappings(mock_run_group_by, instance):
+def test_run_parser_group_by_only(instance):
     """
-    Tests that run_parser functions expectedly - when giving group_mappings
-    Should call run_group_by with group mappings and return
+    Tests run_parser method with only group_by being set
     """
-    instance.parse_group_by(MockProperties.PROP_1)
-
-    mock_obj_list = ["obj1", "obj2", "obj3"]
-    mock_run_group_by.return_value = "group-out"
-    instance.group_by = MockProperties.PROP_1
-
+    instance.parse_group_by(NonCallableMock())
+    mock_obj_list = NonCallableMock()
     res = instance.run_parser(mock_obj_list)
-    assert res == "group-out"
-    mock_run_group_by.assert_called_once_with(mock_obj_list)
+    instance.grouper.run_group_by.assert_called_once_with(mock_obj_list)
+    assert res == instance.grouper.run_group_by.return_value
 
 
-@patch("openstack_query.query_blocks.query_parser.QueryParser._run_sort")
-@patch("openstack_query.query_blocks.query_parser.QueryParser._run_group_by")
-def test_run_parser_with_sort_and_group(mock_run_group_by, mock_run_sort, instance):
+def test_run_parser_both_group_and_sort(instance):
     """
-    Tests that run_parser functions expectedly - when giving both group_by and sort_by
-    Should call run_sort method and then run_group_by on that output, then return
+    Tests run_parser method with sort_by and group_by being set
     """
-    instance.parse_sort_by((MockProperties.PROP_1, SortOrder.DESC))
-    instance.parse_group_by(MockProperties.PROP_1)
+    instance.parse_sort_by(NonCallableMock())
+    instance.parse_group_by(NonCallableMock())
 
-    mock_obj_list = ["obj1", "obj2", "obj3"]
-    mock_run_group_by.return_value = "group-out"
-    mock_run_sort.return_value = "sort-out"
-
+    mock_obj_list = NonCallableMock()
     res = instance.run_parser(mock_obj_list)
-    assert res == "group-out"
-    mock_run_sort.assert_called_once_with(mock_obj_list)
-    mock_run_group_by.assert_called_once_with("sort-out")
-
-
-def test_run_parser_empty_list(instance):
-    """
-    Tests run_parser - when given empty list - output empty list
-    """
-    assert instance.run_parser([]) == []
-
-
-@pytest.mark.parametrize(
-    "mock_sort_by_specs",
-    [
-        {MockProperties.PROP_1: False},
-        {MockProperties.PROP_1: True},
-        {MockProperties.PROP_2: False},
-        {MockProperties.PROP_2: True},
-    ],
-)
-def test_run_sort_with_one_key(
-    mock_sort_by_specs, run_sort_by_tests, mock_results_container
-):
-    """
-    Tests that run_sort functions expectedly - with one sorting key
-    Should call run_sort method which should get the appropriate sorting
-    key lambda function and sort dict accordingly
-    """
-    mock_as_object_vals = [
-        {"prop_1": "a", "prop_2": 2},
-        {"prop_1": "c", "prop_2": 4},
-        {"prop_1": "d", "prop_2": 3},
-        {"prop_1": "b", "prop_2": 1},
-    ]
-
-    mock_obj_list = mock_results_container(mock_as_object_vals)
-
-    # sorting by only one property so get first key in sort specs
-    mock_enum = list(mock_sort_by_specs.keys())[0]
-    reverse = mock_sort_by_specs[mock_enum]
-    mock_prop_name = mock_enum.name.lower()
-    expected_list = sorted(
-        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
+    instance.sorter.run_sort_by.assert_called_once_with(mock_obj_list)
+    instance.grouper.run_group_by.assert_called_once_with(
+        instance.sorter.run_sort_by.return_value
     )
-    run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
+    assert res == instance.grouper.run_group_by.return_value
 
 
-@pytest.mark.parametrize(
-    "mock_sort_by_specs, expected_list",
-    [
-        (
-            {MockProperties.PROP_1: False, MockProperties.PROP_2: True},
-            [
-                {"prop_1": "a", "prop_2": 2},
-                {"prop_1": "a", "prop_2": 1},
-                {"prop_1": "b", "prop_2": 2},
-                {"prop_1": "b", "prop_2": 1},
-            ],
-        ),
-        (
-            {MockProperties.PROP_1: True, MockProperties.PROP_2: False},
-            [
-                {"prop_1": "b", "prop_2": 1},
-                {"prop_1": "b", "prop_2": 2},
-                {"prop_1": "a", "prop_2": 1},
-                {"prop_1": "a", "prop_2": 2},
-            ],
-        ),
-        (
-            {MockProperties.PROP_2: False, MockProperties.PROP_1: True},
-            [
-                {"prop_1": "b", "prop_2": 1},
-                {"prop_1": "a", "prop_2": 1},
-                {"prop_1": "b", "prop_2": 2},
-                {"prop_1": "a", "prop_2": 2},
-            ],
-        ),
-        (
-            {MockProperties.PROP_2: True, MockProperties.PROP_1: False},
-            [
-                {"prop_1": "a", "prop_2": 2},
-                {"prop_1": "b", "prop_2": 2},
-                {"prop_1": "a", "prop_2": 1},
-                {"prop_1": "b", "prop_2": 1},
-            ],
-        ),
-    ],
-)
-def test_run_sort_with_multiple_key(
-    mock_sort_by_specs, expected_list, run_sort_by_tests, mock_results_container
-):
+def test_run_parser_neither_set(instance):
     """
-    Tests that run_sort functions expectedly - with one sorting key
-    Should call run_sort method which should get the appropriate sorting
-    key lambda function and sort dict accordingly
+    Tests run_parser method with neither sort_by or group_by being set
     """
-    mock_as_object_vals = [
-        {"prop_1": "a", "prop_2": 1},
-        {"prop_1": "b", "prop_2": 1},
-        {"prop_1": "a", "prop_2": 2},
-        {"prop_1": "b", "prop_2": 2},
-    ]
-    mock_obj_list = mock_results_container(mock_as_object_vals)
-    run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
-
-
-@pytest.mark.parametrize(
-    "mock_sort_by_specs",
-    [{MockProperties.PROP_1: False}, {MockProperties.PROP_1: True}],
-)
-def test_run_sort_with_boolean(
-    mock_sort_by_specs, instance, run_sort_by_tests, mock_results_container
-):
-    """
-    Tests that run_sort functions expectedly - sorting by boolean
-    Should call run_sort method which should get the appropriate sorting
-    key lambda function and sort dict accordingly
-    """
-    mock_as_object_vals = [{"prop_1": False}, {"prop_1": True}]
-    mock_obj_list = mock_results_container(mock_as_object_vals)
-    instance.sort_by = mock_sort_by_specs
-    mock_enum = list(mock_sort_by_specs.keys())[0]
-    reverse = mock_sort_by_specs[mock_enum]
-    mock_prop_name = mock_enum.name.lower()
-
-    expected_list = sorted(
-        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
-    )
-    run_sort_by_tests(mock_obj_list, mock_sort_by_specs, expected_list)
-
-
-@pytest.mark.parametrize(
-    "mock_group_by, expected_out",
-    [
-        (
-            MockProperties.PROP_1,
-            {
-                "a": [
-                    {"prop_1": "a", "prop_2": 1},
-                    {"prop_1": "a", "prop_2": 3},
-                ],
-                "b": [{"prop_1": "b", "prop_2": 2}],
-            },
-        ),
-        (
-            MockProperties.PROP_2,
-            {
-                1: [{"prop_1": "a", "prop_2": 1}],
-                2: [{"prop_1": "b", "prop_2": 2}],
-                3: [{"prop_1": "a", "prop_2": 3}],
-            },
-        ),
-    ],
-)
-def test_build_unique_val_groups(
-    mock_group_by, expected_out, instance, mock_get_prop_mapping
-):
-    """
-    Tests that build_unique_val_groups method functions expectedly
-    method should find all unique values for a test object list for a given property and create appropriate
-    group_ranges to be used for group-by
-    """
-
-    obj_list = [
-        {"prop_1": "a", "prop_2": 1},
-        {"prop_1": "b", "prop_2": 2},
-        {"prop_1": "a", "prop_2": 3},
-    ]
-    instance.group_by = mock_group_by
-
-    with patch.object(
-        MockProperties, "get_prop_mapping", wraps=mock_get_prop_mapping
-    ) as mock_get_prop_func:
-        # pylint:disable=protected-access
-        res = instance._build_unique_val_groups(obj_list)
-        assert res.keys() == expected_out.keys()
-        mock_get_prop_func.assert_called_once_with(mock_group_by)
-
-    # now that we have the group mappings - check that using them produces expected results
-    grouped_out = {
-        name: [item for item in obj_list if map_func(item)]
-        for name, map_func in res.items()
-    }
-    assert grouped_out == expected_out
-
-
-@patch("openstack_query.query_blocks.query_parser.QueryParser._build_unique_val_groups")
-def test_run_group_by_no_group_mappings(
-    mock_build_unique_val_groups, instance, mock_results_container
-):
-    """
-    Tests run group_by method functions expectedly - when using no group mappings
-    Should call build_unique_val_group and use the mappings returned to apply onto given object list
-    """
-    instance.group_mappings = {}
-    instance.group_by = MockProperties.PROP_1
-
-    mock_group_mappings = {
-        "group1": lambda obj: obj["prop_1"] == "a",
-        "group2": lambda obj: obj["prop_1"] == "b",
-        "group3": lambda obj: obj["prop_1"] == "c",
-    }
-    mock_build_unique_val_groups.return_value = mock_group_mappings
-
-    mock_as_object_vals = [
-        {"prop_1": "a", "prop_2": 1},
-        {"prop_1": "b", "prop_2": 2},
-        {"prop_1": "c", "prop_2": 3},
-    ]
-    mock_obj_list = mock_results_container(mock_as_object_vals)
-    # pylint:disable=protected-access
-    res = instance._run_group_by(mock_obj_list)
-    mock_build_unique_val_groups.assert_called_once_with(
-        [item.as_object() for item in mock_obj_list]
-    )
-
-    assert [item.as_object() for item in res["group1"]] == [
-        {"prop_1": "a", "prop_2": 1}
-    ]
-    assert [item.as_object() for item in res["group2"]] == [
-        {"prop_1": "b", "prop_2": 2}
-    ]
-    assert [item.as_object() for item in res["group3"]] == [
-        {"prop_1": "c", "prop_2": 3}
-    ]
-
-
-@patch("openstack_query.query_blocks.query_parser.QueryParser._build_unique_val_groups")
-def test_run_group_by_with_group_mappings(
-    mock_build_unique_val_groups, instance, mock_results_container
-):
-    """
-    Tests run group_by method functions expectedly - when using group mappings
-    Should use the preset mappings and apply them onto given object list
-    """
-    instance.group_by = MockProperties.PROP_1
-
-    mock_group_mappings = {
-        "group1": lambda obj: obj["prop_2"] in [1, 2],
-        "group2": lambda obj: obj["prop_2"] in [3],
-    }
-    instance.group_mappings = mock_group_mappings
-
-    mock_as_object_vals = [
-        {"prop_1": "a", "prop_2": 1},
-        {"prop_1": "b", "prop_2": 2},
-        {"prop_1": "c", "prop_2": 3},
-    ]
-    mock_obj_list = mock_results_container(mock_as_object_vals)
-
-    # pylint:disable=protected-access
-    res = instance._run_group_by(mock_obj_list)
-    mock_build_unique_val_groups.assert_not_called()
-
-    assert [item.as_object() for item in res["group1"]] == [
-        {"prop_1": "a", "prop_2": 1},
-        {"prop_1": "b", "prop_2": 2},
-    ]
-
-    assert [item.as_object() for item in res["group2"]] == [
-        {"prop_1": "c", "prop_2": 3}
-    ]
+    mock_obj_list = NonCallableMock()
+    res = instance.run_parser(mock_obj_list)
+    assert res == mock_obj_list

--- a/tests/lib/openstack_query/query_blocks/test_query_sorter.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_sorter.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 import pytest
 
 from enums.query.props.server_properties import ServerProperties
@@ -166,7 +166,7 @@ def test_run_sort_with_multiple_key(
     ],
 )
 def test_run_sort_with_boolean(
-    mock_sort_by_specs, instance, run_sort_by_runner, mock_results_container
+    mock_sort_by_specs, run_sort_by_runner, mock_results_container
 ):
     """
     Tests that run_sort functions expectedly - sorting by boolean

--- a/tests/lib/openstack_query/query_blocks/test_query_sorter.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_sorter.py
@@ -1,0 +1,185 @@
+from unittest.mock import MagicMock, call, patch
+import pytest
+
+from enums.query.props.server_properties import ServerProperties
+from enums.query.sort_order import SortOrder
+from exceptions.parse_query_error import ParseQueryError
+
+from openstack_query.query_blocks.query_sorter import QuerySorter
+from tests.lib.openstack_query.mocks.mocked_props import MockProperties
+
+
+@pytest.fixture(name="instance")
+def instance_fixture():
+    """
+    Returns an instance with mocked prop_enum_cls inject
+    """
+    mock_prop_enum_cls = MockProperties
+    return QuerySorter(prop_enum_cls=mock_prop_enum_cls)
+
+
+def test_parse_sort_by_invalid(instance):
+    """
+    Tests parse_sort_by method works expectedly - raise error if property is invalid
+    should raise ParseQueryError
+    """
+    with pytest.raises(ParseQueryError):
+        instance.parse_sort_by((ServerProperties.SERVER_ID, SortOrder.DESC))
+
+
+@pytest.fixture(name="run_sort_by_runner")
+def run_sort_by_runner_fixture(instance, mock_get_prop_mapping):
+    """
+    Fixture which runs run_sort_by with different test cases
+    """
+
+    def _run_sort_by_runner(obj_list, sort_by_specs, expected_list):
+        """
+        Method which runs sort_by with different inputs
+        """
+        instance.parse_sort_by(*sort_by_specs)
+        with patch.object(
+            MockProperties, "get_prop_mapping", wraps=mock_get_prop_mapping
+        ) as mock_get_prop_func:
+            res = instance.run_sort_by(obj_list)
+            assert [item.as_object() for item in res] == expected_list
+            mock_get_prop_func.assert_has_calls(
+                [call(sort_key) for sort_key, _ in reversed(sort_by_specs)]
+            )
+
+    return _run_sort_by_runner
+
+
+@pytest.mark.parametrize(
+    "mock_sort_by_specs",
+    [
+        [(MockProperties.PROP_1, SortOrder.ASC)],
+        [(MockProperties.PROP_2, SortOrder.ASC)],
+        [(MockProperties.PROP_1, SortOrder.DESC)],
+        [(MockProperties.PROP_2, SortOrder.DESC)],
+    ],
+)
+def test_run_sort_with_one_key(
+    mock_sort_by_specs, run_sort_by_runner, mock_results_container
+):
+    """
+    Tests that run_sort functions expectedly - with one sorting key
+    Should call run_sort method which should get the appropriate sorting
+    key lambda function and sort dict accordingly
+    """
+    mock_as_object_vals = [
+        {"prop_1": "a", "prop_2": 2},
+        {"prop_1": "c", "prop_2": 4},
+        {"prop_1": "d", "prop_2": 3},
+        {"prop_1": "b", "prop_2": 1},
+    ]
+
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+
+    # sorting by only one property so get first key in sort specs
+    mock_enum = mock_sort_by_specs[0][0]
+    reverse = mock_sort_by_specs[0][1].value
+    mock_prop_name = mock_enum.name.lower()
+
+    expected_list = sorted(
+        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
+    )
+    run_sort_by_runner(mock_obj_list, mock_sort_by_specs, expected_list)
+
+
+@pytest.mark.parametrize(
+    "mock_sort_by_specs, expected_list",
+    [
+        (
+            [
+                (MockProperties.PROP_1, SortOrder.ASC),
+                (MockProperties.PROP_2, SortOrder.DESC),
+            ],
+            [
+                {"prop_1": "a", "prop_2": 2},
+                {"prop_1": "a", "prop_2": 1},
+                {"prop_1": "b", "prop_2": 2},
+                {"prop_1": "b", "prop_2": 1},
+            ],
+        ),
+        (
+            [
+                (MockProperties.PROP_1, SortOrder.DESC),
+                (MockProperties.PROP_2, SortOrder.ASC),
+            ],
+            [
+                {"prop_1": "b", "prop_2": 1},
+                {"prop_1": "b", "prop_2": 2},
+                {"prop_1": "a", "prop_2": 1},
+                {"prop_1": "a", "prop_2": 2},
+            ],
+        ),
+        (
+            [
+                (MockProperties.PROP_2, SortOrder.ASC),
+                (MockProperties.PROP_1, SortOrder.DESC),
+            ],
+            [
+                {"prop_1": "b", "prop_2": 1},
+                {"prop_1": "a", "prop_2": 1},
+                {"prop_1": "b", "prop_2": 2},
+                {"prop_1": "a", "prop_2": 2},
+            ],
+        ),
+        (
+            [
+                (MockProperties.PROP_2, SortOrder.DESC),
+                (MockProperties.PROP_1, SortOrder.ASC),
+            ],
+            [
+                {"prop_1": "a", "prop_2": 2},
+                {"prop_1": "b", "prop_2": 2},
+                {"prop_1": "a", "prop_2": 1},
+                {"prop_1": "b", "prop_2": 1},
+            ],
+        ),
+    ],
+)
+def test_run_sort_with_multiple_key(
+    mock_sort_by_specs, expected_list, run_sort_by_runner, mock_results_container
+):
+    """
+    Tests that run_sort functions expectedly - with one sorting key
+    Should call run_sort method which should get the appropriate sorting
+    key lambda function and sort dict accordingly
+    """
+    mock_as_object_vals = [
+        {"prop_1": "a", "prop_2": 1},
+        {"prop_1": "b", "prop_2": 1},
+        {"prop_1": "a", "prop_2": 2},
+        {"prop_1": "b", "prop_2": 2},
+    ]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+    run_sort_by_runner(mock_obj_list, mock_sort_by_specs, expected_list)
+
+
+@pytest.mark.parametrize(
+    "mock_sort_by_specs",
+    [
+        [(MockProperties.PROP_1, SortOrder.ASC)],
+        [(MockProperties.PROP_1, SortOrder.DESC)],
+    ],
+)
+def test_run_sort_with_boolean(
+    mock_sort_by_specs, instance, run_sort_by_runner, mock_results_container
+):
+    """
+    Tests that run_sort functions expectedly - sorting by boolean
+    Should call run_sort method which should get the appropriate sorting
+    key lambda function and sort dict accordingly
+    """
+    mock_as_object_vals = [{"prop_1": False}, {"prop_1": True}]
+    mock_obj_list = mock_results_container(mock_as_object_vals)
+    mock_enum = mock_sort_by_specs[0][0]
+    reverse = mock_sort_by_specs[0][1].value
+    mock_prop_name = mock_enum.name.lower()
+
+    expected_list = sorted(
+        mock_as_object_vals, key=lambda k: k[mock_prop_name], reverse=reverse
+    )
+    run_sort_by_runner(mock_obj_list, mock_sort_by_specs, expected_list)


### PR DESCRIPTION
split up QueryParser into QueryGrouper and QuerySorter. 
simplifies QueryParser class which was growing unwieldy

Also removes need for protected-access in tests