### PR TITLE
BUG: Routers not created in HA Mode

### DIFF
--- a/actions/router.create.yaml
+++ b/actions/router.create.yaml
@@ -36,8 +36,4 @@ parameters:
     description: The distributed state of the router, which is distributed True or not False
     type: boolean
     default: False
-  is_ha:
-    description: The highly-available state of the router, which is highly available True or not False.
-    type: boolean
-    default: False
 runner_type: python-script

--- a/actions/src/router_actions.py
+++ b/actions/src/router_actions.py
@@ -30,7 +30,6 @@ class RouterActions(OpenstackAction):
         router_description: str,
         external_gateway: str,
         is_distributed: bool,
-        is_ha: bool,
     ) -> Tuple[bool, Router]:
         """
         Create openstack router for project
@@ -39,7 +38,6 @@ class RouterActions(OpenstackAction):
         :param router_name: The new router name
         :param router_description: The new router's description
         :param is_distributed: Is the new router distributed
-        :param is_ha: Is the new router high availability
         :param external_gateway: Name or ID of the external gateway the router should use
         :return: Status, new router object
         """
@@ -51,7 +49,6 @@ class RouterActions(OpenstackAction):
                 router_description=router_description,
                 external_gateway=external_gateway,
                 is_distributed=is_distributed,
-                is_ha=is_ha,
             ),
         )
         return bool(router), router

--- a/lib/openstack_api/openstack_network.py
+++ b/lib/openstack_api/openstack_network.py
@@ -248,7 +248,7 @@ class OpenstackNetwork(OpenstackWrapperBase):
                 description=details.router_description,
                 external_gateway_info={"network_id": external_network.id},
                 is_distributed=details.is_distributed,
-                is_ha=details.is_ha,
+                is_ha=True,
             )
 
     def get_router(

--- a/lib/structs/router_details.py
+++ b/lib/structs/router_details.py
@@ -9,4 +9,3 @@ class RouterDetails:
     router_description: str
     external_gateway: str
     is_distributed: bool
-    is_ha: bool

--- a/tests/actions/test_router_actions.py
+++ b/tests/actions/test_router_actions.py
@@ -30,11 +30,8 @@ class TestRouterActions(OpenstackActionTestBase):
         """
         cloud, project = NonCallableMock(), NonCallableMock()
         name, description = NonCallableMock(), NonCallableMock()
-        gateway, distributed, ha = (
-            NonCallableMock(),
-            NonCallableMock(),
-            NonCallableMock(),
-        )
+        gateway, distributed = NonCallableMock(), NonCallableMock()
+
         returned = self.action.router_create(
             cloud,
             project_identifier=project,
@@ -42,11 +39,10 @@ class TestRouterActions(OpenstackActionTestBase):
             router_description=description,
             external_gateway=gateway,
             is_distributed=distributed,
-            is_ha=ha,
         )
 
         self.network_mock.create_router.assert_called_once_with(
-            cloud, RouterDetails(project, name, description, gateway, distributed, ha)
+            cloud, RouterDetails(project, name, description, gateway, distributed)
         )
         expected = self.network_mock.create_router.return_value
         assert returned == (True, expected)

--- a/tests/lib/test_openstack_network.py
+++ b/tests/lib/test_openstack_network.py
@@ -357,7 +357,7 @@ class OpenstackNetworkTests(unittest.TestCase):
                 "network_id": self.instance.find_network.return_value.id
             },
             is_distributed=details.is_distributed,
-            is_ha=details.is_ha,
+            is_ha=True,
         )
         assert returned == self.network_api.create_router.return_value
 


### PR DESCRIPTION


### Description:

Routers for new projects have not been created in HA Mode as the default was False. Remove the handling since there isn't really any reason not to deploy HA routers and it's a potential thing to go wrong

### Special Notes:

This removes a param from the .yaml, so we'll need to explicitly install and restart St2 to detect it

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
