### PR TITLE
BUG: set specific branch of stackstorm to run tests with

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ REPO_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 export ST2_REPO_PATH="/tmp/st2"
 if [ ! -d "$ST2_REPO_PATH" ]; then
-    git clone --depth=1 https://github.com/stackstorm/st2.git "$ST2_REPO_PATH"
+    git clone --depth=1 https://github.com/stackstorm/st2.git --branch v3.8 "$ST2_REPO_PATH"
 fi
 
 # Monkey patch nose to pytest until upstream has switched


### PR DESCRIPTION
recent changes to stackstorm testing breaks our workflow - revert to using a stable tag
