### PR TITLE
TST: refactor server-side-handler test

### DIFF
--- a/lib/custom_types/openstack_query/aliases.py
+++ b/lib/custom_types/openstack_query/aliases.py
@@ -33,7 +33,9 @@ ServerSideFilter = Dict[str, PropValue]
 ServerSideFilters = List[ServerSideFilter]
 
 # A type alias for a function that takes a number of filter params and returns a set of server-side filters
-ServerSideFilterFunc = Callable[[FilterParams], ServerSideFilters]
+ServerSideFilterFunc = Callable[
+    [FilterParams], Union[ServerSideFilters, ServerSideFilter]
+]
 
 # type aliases for mapping server side filter functions to a corresponding preset-property pairs
 PropToServerSideFilterFunc = Dict[PropEnum, ServerSideFilterFunc]

--- a/tests/lib/openstack_query/handlers/test_server_side_handler.py
+++ b/tests/lib/openstack_query/handlers/test_server_side_handler.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, NonCallableMock
 
 import pytest
 
@@ -8,25 +8,31 @@ from tests.lib.openstack_query.mocks.mocked_props import MockProperties
 from tests.lib.openstack_query.mocks.mocked_query_presets import MockQueryPresets
 
 
-# pylint:disable=protected-access, unnecessary-lambda-assignment
+@pytest.fixture(name="mock_server_side_mappings")
+def server_side_mapping_fixture():
+    """
+    Sets up a set of mock mappings between a preset-prop pair and
+     a set of server side filters
+    """
+
+    return {
+        MockQueryPresets.ITEM_1: {
+            MockProperties.PROP_1: MagicMock(),
+            MockProperties.PROP_2: MagicMock(),
+        },
+        MockQueryPresets.ITEM_2: {
+            MockProperties.PROP_3: MagicMock(),
+            MockProperties.PROP_4: MagicMock(),
+        },
+    }
 
 
 @pytest.fixture(name="instance")
-def instance_fixture():
+def instance_fixture(mock_server_side_mappings):
     """
     Prepares an instance to be used in tests
     """
-    server_side_function_mappings = {
-        MockQueryPresets.ITEM_1: {
-            MockProperties.PROP_1: "item1-prop1-kwarg",
-            MockProperties.PROP_2: "item2-prop2-kwarg",
-        },
-        MockQueryPresets.ITEM_2: {
-            MockProperties.PROP_3: "item2-prop3-kwarg",
-            MockProperties.PROP_4: "item2-prop4-kwarg",
-        },
-    }
-    return ServerSideHandler(server_side_function_mappings)
+    return ServerSideHandler(mock_server_side_mappings)
 
 
 def test_check_supported_true(instance):
@@ -58,164 +64,131 @@ def test_get_supported_props(instance):
     assert instance.get_supported_props(MockQueryPresets.ITEM_1)
 
 
-def test_get_mapping_valid(instance):
+@pytest.fixture(name="get_filters_runner")
+def get_filters_runner_fixture(mock_server_side_mappings, instance):
     """
-    Tests that get_mapping method works expectedly
-    returns server-side filter func if Prop Enum and Preset Enum are supported
+    Fixture to setup and test get_filters function
     """
-    assert (
-        instance._get_mapping(MockQueryPresets.ITEM_1, MockProperties.PROP_1)
-        == "item1-prop1-kwarg"
-    )
 
+    def _get_filters_runner(preset, prop, filter_func_output, expected_out):
+        mock_filter_func = mock_server_side_mappings[preset][prop]
+        mock_filter_func.return_value = filter_func_output
+        mock_params = {"arg1": "val1", "arg2": "val2"}
 
-def test_get_mapping_invalid(instance):
-    """
-    Tests that get_mapping method works expectedly
-    returns None if Prop Enum and Preset Enum are not supported or don't have a mapping
-    """
-    # when preset is not supported
-    assert instance._get_mapping(MockQueryPresets.ITEM_3, MockProperties.PROP_1) is None
-
-    # when preset found, but prop is not supported
-    assert instance._get_mapping(MockQueryPresets.ITEM_1, MockProperties.PROP_3) is None
-
-
-@patch(
-    "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
-)
-@patch("openstack_query.handlers.server_side_handler.ServerSideHandler._get_mapping")
-def test_get_filters_valid_list(mock_get_mapping, mock_check_filter_mapping, instance):
-    """
-    Tests that get_filters method works expectedly - filters returned are a list
-    returns server-side filters as a set of kwargs
-        - Prop Enum and Preset Enum are supported
-        - and filter_params are valid
-    """
-    mock_params = {"arg1": "val1", "arg2": "val2"}
-    mock_filter_func = MagicMock()
-
-    mock_filters = ["filter1", "filter2"]
-    mock_filter_func.return_value = mock_filters
-
-    mock_check_filter_mapping.return_value = True, ""
-    mock_get_mapping.return_value = mock_filter_func
-
-    res = instance.get_filters(
-        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
-    )
-
-    mock_check_filter_mapping.assert_called_once_with(mock_filter_func, mock_params)
-    mock_filter_func.assert_called_once_with(**mock_params)
-    assert res == mock_filters
-
-
-@patch(
-    "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
-)
-@patch("openstack_query.handlers.server_side_handler.ServerSideHandler._get_mapping")
-def test_get_filters_valid_not_list(
-    mock_get_mapping, mock_check_filter_mapping, instance
-):
-    """
-    Tests that get_filters method works expectedly - filters returned are a not a list
-    returns server-side filters as a set of kwargs
-        - Prop Enum and Preset Enum are supported
-        - and filter_params are valid
-    """
-    mock_params = {"arg1": "val1", "arg2": "val2"}
-    mock_filter_func = MagicMock()
-
-    mock_filters = "filter1"
-    mock_filter_func.return_value = mock_filters
-
-    mock_check_filter_mapping.return_value = True, ""
-    mock_get_mapping.return_value = mock_filter_func
-
-    res = instance.get_filters(
-        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
-    )
-
-    mock_check_filter_mapping.assert_called_once_with(mock_filter_func, mock_params)
-    mock_filter_func.assert_called_once_with(**mock_params)
-    assert res == [mock_filters]
-
-
-@patch(
-    "openstack_query.handlers.server_side_handler.ServerSideHandler._check_filter_mapping"
-)
-def test_get_filters_invalid(mock_check_filter_mapping, instance):
-    """
-    Tests that get_filters method works expectedly
-    raises QueryPresetMappingError if:
-        - Prop Enum and Preset Enum are not supported
-        - or filter_params is not valid
-    """
-    mock_params = {"arg1": "val1", "arg2": "val2"}
-
-    # when preset/prop not supported
-    res = instance.get_filters(
-        MockQueryPresets.ITEM_3, MockProperties.PROP_1, mock_params
-    )
-    assert res is None
-
-    # when preset/prop are supported, but wrong filter_params
-    mock_check_filter_mapping.return_value = False, "some-reason"
-    with pytest.raises(QueryPresetMappingError):
-        instance.get_filters(
+        res = instance.get_filters(
             MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
         )
 
+        mock_filter_func.assert_called_once_with(**mock_params)
+        assert res == expected_out
 
-@pytest.mark.parametrize(
-    "valid_params_to_test",
-    [
-        # "required args only",
-        {"arg1": 12},
-        # "required and default"
-        {"arg1": 12, "arg2": "non-default"},
-        # "required and kwarg"
-        {"arg1": 12, "some_kwarg": "some-val"},
-        # "all possible"
-        {"arg1": 12, "arg2": "non-default", "some_kwarg": "some-val"},
-        # "different order"
-        {"arg2": "non-default", "some_kwarg": "some-val", "arg1": 12},
-    ],
-)
-def test_check_filter_mapping_valid(valid_params_to_test, instance):
-    """
-    Tests that check_filter_mapping method works expectedly - valid
-    returns True only if args match expected args required by filter function lambda
-    """
-    mock_server_side_mapping = lambda arg1, arg2="some-default", **kwargs: {
-        "kwarg1": "val1"
-    }
-    assert instance._check_filter_mapping(
-        mock_server_side_mapping, filter_params=valid_params_to_test
-    )[0]
+    return _get_filters_runner
 
 
-def test_check_filter_mapping_invalid_positional(instance):
+def test_get_filters_return_single_filter(get_filters_runner):
     """
-    Tests that check_filter_mapping method works expectedly - invalid positional args
-    returns False if args don't match expected positional args required by filter function lambda
+    Tests that get_filters method, where a single set of server-side filters
+    is returned appropriately for valid preset-property pair. Should return as a singleton list
     """
-    mock_server_side_mapping = lambda arg1: {"kwarg1": "val1"}
-    assert not (
-        instance._check_filter_mapping(
-            mock_server_side_mapping, filter_params={"arg2": "val2"}
-        )[0]
+    mock_filter_return = NonCallableMock()
+    get_filters_runner(
+        MockQueryPresets.ITEM_1,
+        MockProperties.PROP_1,
+        mock_filter_return,
+        [mock_filter_return],
     )
 
 
-def test_check_filter_mapping_invalid_kwargs(instance):
+def test_get_filters_return_multi_filter(get_filters_runner):
     """
-    Tests that check_filter_mapping method works expectedly - invalid key-word args
-    returns False if kwargs is passed and is used that is required
+    Tests that get_filters method, where a list of server-side filters returned
+    is returned appropriately for valid preset-property pair. Should return as is
     """
-    mock_server_side_mapping = lambda **kwargs: {"arg": kwargs["val1"]}
-    assert not (
-        instance._check_filter_mapping(
-            mock_server_side_mapping, filter_params={"arg2": "val2"}
-        )[0]
+    mock_filter_return = [NonCallableMock()]
+    get_filters_runner(
+        MockQueryPresets.ITEM_1,
+        MockProperties.PROP_1,
+        mock_filter_return,
+        mock_filter_return,
     )
+
+
+def test_get_filters_no_mapping(instance):
+    """
+    Tests get_filters method, where there is no mapping for preset-property pair given
+    """
+    # preset has mappings, but property not compatible
+    assert (
+        instance.get_filters(
+            MockQueryPresets.ITEM_1, MockProperties.PROP_4, {"arg1": "val1"}
+        )
+        is None
+    )
+
+    # preset does not have mappings
+    assert (
+        instance.get_filters(
+            MockQueryPresets.ITEM_3, MockProperties.PROP_4, {"arg1": "val1"}
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("error_type", [KeyError, TypeError])
+def test_get_filters_filter_func_raises_error(
+    error_type, mock_server_side_mappings, instance
+):
+    """
+    Tests get_filters method, when trying to run the function to get server-side filters
+    returns an error indicating that required parameters were missing/malformed. In this case, we should raise a
+    QueryPresetMappingError
+    """
+
+    mock_filter_func = mock_server_side_mappings[MockQueryPresets.ITEM_1][
+        MockProperties.PROP_1
+    ]
+    mock_filter_func.side_effect = error_type
+    with pytest.raises(QueryPresetMappingError):
+        instance.get_filters(
+            MockQueryPresets.ITEM_1, MockProperties.PROP_1, {"arg1": "val1"}
+        )
+
+
+def test_get_filters_valid_not_list(mock_server_side_mappings, instance):
+    """
+    Tests that get_filters method, server-side filters returned appropriately for valid
+    preset-property pair
+    """
+    mock_params = {"arg1": "val1", "arg2": "val2"}
+    mock_filter = NonCallableMock()
+    mock_filter_func = mock_server_side_mappings[MockQueryPresets.ITEM_1][
+        MockProperties.PROP_1
+    ]
+    mock_filter_func.return_value = mock_filter
+
+    res = instance.get_filters(
+        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
+    )
+
+    mock_filter_func.assert_called_once_with(**mock_params)
+    assert res == [mock_filter]
+
+
+def test_get_filters_valid_list(mock_server_side_mappings, instance):
+    """
+    Tests that get_filters method, server-side filters returned appropriately for valid
+    preset-property pair where filters returned by filter_func is a list
+    """
+    mock_params = {"arg1": "val1", "arg2": "val2"}
+    mock_filter = NonCallableMock()
+    mock_filter_func = mock_server_side_mappings[MockQueryPresets.ITEM_1][
+        MockProperties.PROP_1
+    ]
+    mock_filter_func.return_value = [mock_filter]
+
+    res = instance.get_filters(
+        MockQueryPresets.ITEM_1, MockProperties.PROP_1, mock_params
+    )
+
+    mock_filter_func.assert_called_once_with(**mock_params)
+    assert res == [mock_filter]

--- a/tests/lib/openstack_query/mappings/test_server_mapping.py
+++ b/tests/lib/openstack_query/mappings/test_server_mapping.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 from enums.query.props.flavor_properties import FlavorProperties
 from enums.query.props.image_properties import ImageProperties
@@ -107,13 +107,8 @@ def test_server_side_handler_mappings_older_than_or_equal_to(
         mappings,
     )
 
-    # filter_func is evaluated twice
-    # - once when actually returning filters - at _get_filters
-    # - once to check params via a "dry-run" in _check_filter_mapping
-    assert mock_time_utils.convert_to_timestamp.call_args_list == [
-        call(value="test"),
-        call(value="test"),
-    ]
+    # filter_func is evaluated twice, but convert_to_timestamp is only called once
+    mock_time_utils.convert_to_timestamp.assert_called_once_with(value="test")
 
 
 @patch("openstack_query.mappings.server_mapping.TimeUtils")
@@ -135,13 +130,8 @@ def test_server_side_handler_mappings_younger_than_or_equal_to(
         mappings,
     )
 
-    # filter_func is evaluated twice
-    # - once when actually returning filters - at _get_filters
-    # - once to check params via a "dry-run" in _check_filter_mapping
-    assert mock_time_utils.convert_to_timestamp.call_args_list == [
-        call(value="test"),
-        call(value="test"),
-    ]
+    # filter_func is evaluated twice, but convert_to_timestamp is only called once
+    mock_time_utils.convert_to_timestamp.assert_called_once_with(value="test")
 
 
 def test_client_side_handlers_generic(client_side_test_mappings):


### PR DESCRIPTION
refactor server-side-handler tests to remove need for accessing protected methods

Also remove function to check filter function arguments - in favor of EAFP