### PR TITLE
BUG: fix datetime checks

### DIFF
--- a/lib/openstack_query/handlers/client_side_handler_datetime.py
+++ b/lib/openstack_query/handlers/client_side_handler_datetime.py
@@ -55,7 +55,7 @@ class ClientSideHandlerDateTime(ClientSideHandler):
             days, hours, minutes, seconds
         )
 
-        return prop_timestamp > given_timestamp
+        return prop_timestamp < given_timestamp
 
     @staticmethod
     def _prop_younger_than_or_equal_to(
@@ -84,7 +84,7 @@ class ClientSideHandlerDateTime(ClientSideHandler):
         given_timestamp = TimeUtils.get_timestamp_in_seconds(
             days, hours, minutes, seconds
         )
-        return prop_timestamp <= given_timestamp
+        return prop_timestamp >= given_timestamp
 
     @staticmethod
     def _prop_younger_than(
@@ -109,7 +109,7 @@ class ClientSideHandlerDateTime(ClientSideHandler):
         if prop is None:
             return False
         prop_datetime = datetime.strptime(prop, "%Y-%m-%dT%H:%M:%SZ").timestamp()
-        return prop_datetime < TimeUtils.get_timestamp_in_seconds(
+        return prop_datetime > TimeUtils.get_timestamp_in_seconds(
             days, hours, minutes, seconds
         )
 
@@ -137,6 +137,6 @@ class ClientSideHandlerDateTime(ClientSideHandler):
         if prop is None:
             return False
         prop_datetime = datetime.strptime(prop, "%Y-%m-%dT%H:%M:%SZ").timestamp()
-        return prop_datetime >= TimeUtils.get_timestamp_in_seconds(
+        return prop_datetime <= TimeUtils.get_timestamp_in_seconds(
             days, hours, minutes, seconds
         )

--- a/tests/lib/openstack_query/handlers/test_client_side_handler_datetime.py
+++ b/tests/lib/openstack_query/handlers/test_client_side_handler_datetime.py
@@ -82,9 +82,10 @@ def test_check_supported_all_presets(instance):
 def test_prop_older_than(run_prop_test_case):
     """
     Tests prop_older_than client-side-filter with different values
-    This essentially compares two numbers (number of seconds) and if the prop value is higher, it returns True
+    This essentially compares two numbers (number of seconds) and if the prop value is lower, it returns True
+    because older timestamps have fewer seconds passed since 1970 than newer ones
     """
-    for i, expected in [(200, True), (400, False), (300, False)]:
+    for i, expected in [(200, False), (400, True), (300, False)]:
         assert run_prop_test_case(QueryPresetsDateTime.OLDER_THAN, 300, i) == expected
 
 
@@ -92,8 +93,9 @@ def test_prop_younger_than(run_prop_test_case):
     """
     Tests younger_than client-side-filter with different values
     This essentially compares two numbers (number of seconds) and if the prop value is lower, it returns True
+    because newer timestamps have more seconds passed since 1970 than older ones
     """
-    for i, expected in [(200, False), (400, True), (300, False)]:
+    for i, expected in [(200, True), (400, False), (300, False)]:
         assert run_prop_test_case(QueryPresetsDateTime.YOUNGER_THAN, 300, i) == expected
 
 
@@ -102,7 +104,7 @@ def test_prop_younger_than_or_equal_to(run_prop_test_case):
     Tests prop_younger_than_or_equal_to client-side-filter with different values
     Same as prop_younger_than, but if equal will also return True
     """
-    for i, expected in [(200, False), (400, True), (300, True)]:
+    for i, expected in [(200, True), (400, False), (300, True)]:
         assert (
             run_prop_test_case(QueryPresetsDateTime.YOUNGER_THAN_OR_EQUAL_TO, 300, i)
             == expected
@@ -114,7 +116,7 @@ def test_prop_older_than_or_equal_to(run_prop_test_case):
     Tests prop_older_than_or_equal_to client-side-filter with different values
     Same as prop_older_than, but if equal will also return True
     """
-    for i, expected in [(200, True), (400, False), (300, True)]:
+    for i, expected in [(200, False), (400, True), (300, True)]:
         assert (
             run_prop_test_case(QueryPresetsDateTime.OLDER_THAN_OR_EQUAL_TO, 300, i)
             == expected


### PR DESCRIPTION
these were the wrong way round - older timestamps (in seconds) are smaller than newer ones so the comparison was wrong.