### PR TITLE
MAINT: update append_from function signature

### DIFF
--- a/lib/openstack_query/api/query_api.py
+++ b/lib/openstack_query/api/query_api.py
@@ -243,7 +243,7 @@ class QueryAPI:
         self,
         query_type: Union[str, "QueryTypes"],
         cloud_account: Union[str, CloudDomains],
-        *props: PropEnum,
+        props: List[PropEnum],
     ):
         """
         Public method to append specific properties from other queries to the output
@@ -259,7 +259,7 @@ class QueryAPI:
         :param props: list of props from new queries to get
         """
         link_prop, results = self.chainer.run_append_from_query(
-            self, query_type, cloud_account, *props
+            self, query_type, cloud_account, props
         )
         self.results_container.apply_forwarded_results(link_prop, results)
         return self

--- a/lib/openstack_query/query_blocks/query_chainer.py
+++ b/lib/openstack_query/query_blocks/query_chainer.py
@@ -136,7 +136,7 @@ class QueryChainer:
         current_query,
         query_type: Union[str, QueryTypes],
         cloud_account: Union[str, CloudDomains],
-        *props: PropEnum,
+        props: List[PropEnum],
     ):
         """
         Public static method to run query from an append_from call - and return result

--- a/lib/workflows/send_decom_flavor_email.py
+++ b/lib/workflows/send_decom_flavor_email.py
@@ -100,7 +100,7 @@ def find_servers_with_decom_flavors(
         )
 
     server_query.append_from(
-        "PROJECT_QUERY", cloud_account, ProjectProperties.PROJECT_NAME
+        "PROJECT_QUERY", cloud_account, [ProjectProperties.PROJECT_NAME]
     )
     server_query.group_by(ServerProperties.USER_ID)
 

--- a/lib/workflows/send_decom_image_email.py
+++ b/lib/workflows/send_decom_image_email.py
@@ -137,7 +137,7 @@ def find_servers_with_decom_images(
             f"{','.join(from_projects) if from_projects else '[all projects]'}"
         )
 
-    server_query.append_from("PROJECT_QUERY", cloud_account, "name")
+    server_query.append_from("PROJECT_QUERY", cloud_account, ["name"])
     server_query.group_by("user_id")
     return server_query
 

--- a/tests/lib/openstack_query/api/test_query_api.py
+++ b/tests/lib/openstack_query/api/test_query_api.py
@@ -403,10 +403,10 @@ def test_append_from(instance):
     )
 
     res = instance.append_from(
-        mock_query_type, mock_cloud_account, mock_prop1, mock_prop2
+        mock_query_type, mock_cloud_account, [mock_prop1, mock_prop2]
     )
     instance.chainer.run_append_from_query.assert_called_once_with(
-        instance, mock_query_type, mock_cloud_account, mock_prop1, mock_prop2
+        instance, mock_query_type, mock_cloud_account, [mock_prop1, mock_prop2]
     )
     instance.results_container.apply_forwarded_results(
         mock_link_prop, mock_new_query_results

--- a/tests/lib/openstack_query/query_blocks/test_query_chainer.py
+++ b/tests/lib/openstack_query/query_blocks/test_query_chainer.py
@@ -238,7 +238,7 @@ def test_run_append_from_query(mock_query_types, instance):
     mock_new_query = mock_current_query.then.return_value
 
     res = instance.run_append_from_query(
-        mock_current_query, query_type, mock_cloud_account, *mock_props
+        mock_current_query, query_type, mock_cloud_account, mock_props
     )
 
     mock_query_types.from_string.assert_called_once_with(query_type)

--- a/tests/lib/workflows/test_send_decom_flavor_email.py
+++ b/tests/lib/workflows/test_send_decom_flavor_email.py
@@ -203,7 +203,7 @@ def test_find_users_with_decom_flavor_valid(mock_flavor_query):
     mock_server_query_obj.to_props.assert_called_once()
 
     mock_server_query_obj.append_from.assert_called_once_with(
-        "PROJECT_QUERY", "test-cloud-account", ProjectProperties.PROJECT_NAME
+        "PROJECT_QUERY", "test-cloud-account", [ProjectProperties.PROJECT_NAME]
     )
 
     mock_server_query_obj.group_by.assert_called_once_with(ServerProperties.USER_ID)

--- a/tests/lib/workflows/test_send_decom_image_email.py
+++ b/tests/lib/workflows/test_send_decom_image_email.py
@@ -221,7 +221,7 @@ def test_find_servers_with_decom_images_valid(mock_list_to_regex, mock_image_que
     mock_server_query_obj.to_props.assert_called_once()
 
     mock_server_query_obj.append_from.assert_called_once_with(
-        "PROJECT_QUERY", "test-cloud-account", "name"
+        "PROJECT_QUERY", "test-cloud-account", ["name"]
     )
     mock_server_query_obj.group_by.assert_called_once_with("user_id")
     assert res == mock_server_query_obj


### PR DESCRIPTION
previously append_from would work like this:
```
query.append_from("project", cloud_account="prod", "project_id", "project_name")
```

now it works like this
```
query.append_from("project", cloud_account="prod", props=["project_id", "project_name"])
```
which is more intuitive and fits python conventions