### PR TITLE
Emailing users with errored VMs.

### DIFF
--- a/actions/email.users.with.errored.vms.yaml
+++ b/actions/email.users.with.errored.vms.yaml
@@ -1,0 +1,72 @@
+---
+description: Sends an email to inform users that they have VMs in Errored state
+enabled: true
+entry_point: src/workflow_actions.py
+name: email.users.with.errored.vms
+parameters:
+  timeout:
+    default: 5400
+  action_name:
+    default: send_errored_vm_email
+    immutable: true
+    type: string
+  subject:
+    type: string
+    description: "Subject to add to each email"
+    required: true
+    default: "STFC Cloud VMs in Error State"
+  smtp_account_name:
+    type: string
+    description: "Name of SMTP Account to use. Must be configured in the pack settings."
+    required: true
+    default: "default"
+  cloud_account:
+    description: "The clouds.yaml account to use whilst performing this action"
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  limit_by_projects:
+    type: array
+    description: "comma-spaced project to limit action to - incompatible with all_projects"
+    required: false
+    default: null
+  all_projects:
+    type: boolean
+    description: "tick to search in all projects - default True"
+    required: true
+    default: true
+  use_override:
+    type: boolean
+    description: "Set this flag so ALL emails will be redirected to override email"
+    required: true
+    default: False
+  as_html:
+    type: boolean
+    description: "Send email body as HTML"
+    required: true
+    default: true
+  send_email:
+    type: boolean
+    description: "Set this flag to actually send emails instead of printing what will be sent"
+    required: true
+    default: false
+  override_email_address:
+    type: string
+    description: "Set an email address to override where to send the emails generated"
+    required: true
+    default: false
+  cc_cloud_support:
+    type: boolean
+    description: "Flag if set, will cc in cloud-support@stfc.ac.uk automatically"
+    required: false
+    default: false
+  email_from:
+    type: string
+    description: "Email address to send email from"
+    required: true
+    default: "cloud-support@stfc.ac.uk"
+    immutable: true
+runner_type: python-script

--- a/actions/email.users.with.errored.vms.yaml
+++ b/actions/email.users.with.errored.vms.yaml
@@ -33,6 +33,11 @@ parameters:
     description: "comma-spaced project to limit action to - incompatible with all_projects"
     required: false
     default: null
+  search_by_time:
+    type: integer
+    description: "How old a VM needs to be to qualify in days - requires search_by_time to be true"
+    required: false
+    default: -1
   all_projects:
     type: boolean
     description: "tick to search in all projects - default True"

--- a/email_templates/html/errored_vm.html.j2
+++ b/email_templates/html/errored_vm.html.j2
@@ -1,0 +1,11 @@
+Dear Cloud User {{username}}, <br/><br/>
+
+We are writing to inform you one or more virtual machines (VMs) associated with your account are currently in an errored state and has not been restarted or deleted for the past {{days_threshold}} days. <br/>
+
+Please take a moment to review the list of affected VMs provided below and either restart them or delete them if they are no longer needed: <br/><br/><br/>
+
+<b> Shutoff VMs: </b><br/>
+
+<br/> {{error_table}}
+
+Please note that this is an automated notification. If you believe you received this email in error or have any concerns, please contact Cloud Operations Group for further assistance.<br/>

--- a/email_templates/plaintext/errored_vm.txt.j2
+++ b/email_templates/plaintext/errored_vm.txt.j2
@@ -1,0 +1,11 @@
+Dear Cloud User {{username}},
+
+We are writing to inform you one or more virtual machines (VMs) associated with your account are currently in an errored state and has not been restarted or deleted for the past {{days_threshold}} days.
+
+Please take a moment to review the list of affected VMs provided below and either restart them or delete them if they are no longer needed:
+
+Shutoff:
+
+{{error_table}}
+
+Please note that this is an automated notification. If you believe you received this email in error or have any concerns, please contact Cloud Operations Group for further assistance.

--- a/lib/workflows/send_errored_vm_email.py
+++ b/lib/workflows/send_errored_vm_email.py
@@ -1,0 +1,173 @@
+from typing import List, Optional, Union
+
+from email_api.emailer import Emailer
+from openstack_query import ServerQuery, UserQuery
+
+from enums.cloud_domains import CloudDomains
+from enums.query.props import ServerProperties
+from enums.query.query_presets import QueryPresetsGeneric
+
+from structs.email.email_params import EmailParams
+from structs.email.email_template_details import EmailTemplateDetails
+from structs.email.smtp_account import SMTPAccount
+
+
+def find_servers_with_errored_vms(
+    cloud_account: str, from_projects: Optional[List[str]] = None
+):
+    """
+    :param cloud_account: string represents cloud account to use
+    :param from_projects: A list of project identifiers to limit search in
+    """
+
+    server_query = ServerQuery()
+    server_query.where(
+        QueryPresetsGeneric.ANY_IN, ServerProperties.SERVER_STATUS, values=["ERROR"]
+    )
+    server_query.run(
+        cloud_account,
+        as_admin=False,
+        from_projects=from_projects if from_projects else None,
+        all_projects=not from_projects,
+    )
+
+    server_query.select("id", "name", "addresses")
+
+    if not server_query.to_props():
+        raise RuntimeError(
+            f"No servers found in [ERROR] state on projects "
+            f"{','.join(from_projects) if from_projects else '[all projects]'}"
+        )
+
+    server_query.append_from("PROJECT_QUERY", cloud_account, "name")
+    server_query.group_by("user_id")
+
+    return server_query
+
+
+def print_email_params(
+    email_addr: str, user_name: str, as_html: bool, error_table: str
+):
+    """
+    Print email params instead of sending the email
+    :param email_addr: email address to send to
+    :param user_name: name of user in openstack
+    :param as_html: A boolean which if selected will send an email, otherwise prints email details only
+    :param error_table: a table representing info found in openstack
+    about VMs in error state
+    """
+    print(
+        f"Send Email To: {email_addr}\n"
+        f"email_templates errored-email: username {user_name}\n"
+        f"send as html: {as_html}\n"
+        f"error table: {error_table}\n"
+    )
+
+
+def build_email_params(user_name: str, error_table: str, **email_kwargs):
+    """
+    build email params dataclass which will be used to configure how to send the email
+    :param user_name: name of user in openstack
+    :param error_table: a table representing info found in openstack about VMs
+        that are in errored state
+    :param email_kwargs: a set of email kwargs to pass to EmailParams
+    """
+    body = EmailTemplateDetails(
+        template_name="errored_vm",
+        template_params={
+            "username": user_name,
+            "error_table": error_table,
+        },
+    )
+
+    footer = EmailTemplateDetails(template_name="footer", template_params={})
+
+    return EmailParams(email_templates=[body, footer], **email_kwargs)
+
+
+def find_user_info(user_id, cloud_account, override_email_address):
+    """
+    run a UserQuery to find the email address and username associated for a user id.
+    :param user_id: the openstack user id to find email address for
+    :param cloud_account: string represents cloud account to use
+    :param override_email_address: email address to return if no email address found via UserQuery
+    """
+    user_query = UserQuery()
+    user_query.select("name", "email_address")
+    user_query.where("equal_to", "id", value=user_id)
+    user_query.run(cloud_account=cloud_account)
+    res = user_query.to_props(flatten=True)
+    if not res or not res["user_email"][0]:
+        return "", override_email_address
+    return res["user_name"][0], res["user_email"][0]
+
+
+# pylint:disable=too-many-arguments
+# pylint:disable=too-many-locals
+def send_errored_vm_email(
+    smtp_account: SMTPAccount,
+    cloud_account: Union[CloudDomains, str],
+    limit_by_projects: Optional[List[str]] = None,
+    all_projects: bool = False,
+    as_html: bool = False,
+    send_email: bool = False,
+    use_override: bool = False,
+    override_email_address: Optional[str] = "cloud-support@stfc.ac.uk",
+    cc_cloud_support: bool = False,
+    **email_params_kwargs,
+):
+    """
+    Sends an email to each user who owns one or more VMs that are in error state
+    This email will contain a notice to delete or rebuild the VM
+    :param smtp_account: (SMTPAccount): SMTP config
+    :param cloud_account: string represents cloud account to use
+    :param limit_by_projects: A list of project names or ids to limit search in
+    :param all_projects: A boolean which if selected will search in all projects
+    :param send_email: Actually send the email instead of printing what will be sent
+    :param as_html: Send email as html
+    :param use_override: flag if set will use override email address
+    :param override_email_address: an overriding email address to use if override_email set
+    :param cc_cloud_support: flag if set will cc cloud-support email address to each generated email
+    :param email_params_kwargs: see EmailParams dataclass class docstring
+    """
+    if limit_by_projects and all_projects:
+        raise RuntimeError(
+            "given both project list and all_projects flag - please choose only one"
+        )
+    if not (limit_by_projects or all_projects):
+        raise RuntimeError(
+            "please provide either a list of project identifiers or with flag 'all_projects' to run globally"
+        )
+
+    server_query = find_servers_with_errored_vms(cloud_account, limit_by_projects)
+
+    for user_id in server_query.to_props().keys():
+        user_name, email_addr = find_user_info(
+            user_id, cloud_account, override_email_address
+        )
+        send_to = [email_addr]
+        if use_override:
+            send_to = [override_email_address]
+
+        if as_html:
+            server_list = server_query.to_html(
+                groups=[user_id], include_group_titles=False
+            )
+        else:
+            server_list = server_query.to_string(
+                groups=[user_id], include_group_titles=False
+            )
+
+        if not send_email:
+            print_email_params(send_to[0], user_name, as_html, server_list)
+
+        else:
+            email_params = build_email_params(
+                user_name,
+                server_list,
+                email_to=send_to,
+                as_html=as_html,
+                email_cc=("cloud-support@stfc.ac.uk",) if cc_cloud_support else None,
+                **email_params_kwargs,
+            )
+            Emailer(smtp_account).send_emails([email_params])

--- a/lib/workflows/send_errored_vm_email.py
+++ b/lib/workflows/send_errored_vm_email.py
@@ -26,7 +26,7 @@ def find_servers_with_errored_vms(
     )
     server_query.run(
         cloud_account,
-        as_admin=False,
+        as_admin=True,
         from_projects=from_projects if from_projects else None,
         all_projects=not from_projects,
     )

--- a/lib/workflows/send_errored_vm_email.py
+++ b/lib/workflows/send_errored_vm_email.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 from email_api.emailer import Emailer
 from openstack_query import ServerQuery, UserQuery
@@ -14,10 +14,12 @@ from structs.email.smtp_account import SMTPAccount
 
 def find_servers_with_errored_vms(
     cloud_account: str, time_variable:int, from_projects: Optional[List[str]] = None
-):
+) -> ServerQuery:
     """
+    Search for machines that are in error state and return the user id, name and email address. 
     :param cloud_account: string represents cloud account to use
     :param from_projects: A list of project identifiers to limit search in
+    :param time_variable: An integer which specifies a minimum age of machine to search for when querying
     """
 
     server_query = ServerQuery()
@@ -68,7 +70,7 @@ def print_email_params(
     )
 
 
-def build_email_params(user_name: str, error_table: str, **email_kwargs):
+def build_email_params(user_name: str, error_table: str, **email_kwargs) -> EmailParams:
     """
     build email params dataclass which will be used to configure how to send the email
     :param user_name: name of user in openstack
@@ -89,7 +91,7 @@ def build_email_params(user_name: str, error_table: str, **email_kwargs):
     return EmailParams(email_templates=[body, footer], **email_kwargs)
 
 
-def find_user_info(user_id, cloud_account, override_email_address):
+def find_user_info(user_id, cloud_account, override_email_address) -> Dict:
     """
     run a UserQuery to find the email address and username associated for a user id.
     :param user_id: the openstack user id to find email address for

--- a/lib/workflows/send_errored_vm_email.py
+++ b/lib/workflows/send_errored_vm_email.py
@@ -126,6 +126,7 @@ def send_errored_vm_email(
     """
     Sends an email to each user who owns one or more VMs that are in error state
     This email will contain a notice to delete or rebuild the VM
+    
     :param smtp_account: (SMTPAccount): SMTP config
     :param cloud_account: string represents cloud account to use
     :param limit_by_projects: A list of project names or ids to limit search in
@@ -136,6 +137,7 @@ def send_errored_vm_email(
     :param override_email_address: an overriding email address to use if override_email set
     :param cc_cloud_support: flag if set will cc cloud-support email address to each generated email
     :param email_params_kwargs: see EmailParams dataclass class docstring
+    :param time_variable: An integer which specifies a minimum age of machine to search for when querying
     """
     if limit_by_projects and all_projects:
         raise RuntimeError(
@@ -167,14 +169,14 @@ def send_errored_vm_email(
 
         if not send_email:
             print_email_params(send_to[0], user_name, as_html, server_list)
+            continue
 
-        else:
-            email_params = build_email_params(
-                user_name,
-                server_list,
-                email_to=send_to,
-                as_html=as_html,
-                email_cc=("cloud-support@stfc.ac.uk",) if cc_cloud_support else None,
-                **email_params_kwargs,
+        email_params = build_email_params(
+            user_name,
+            server_list,
+            email_to=send_to,
+            as_html=as_html,
+            email_cc=("cloud-support@stfc.ac.uk",) if cc_cloud_support else None,
+            **email_params_kwargs,
             )
             Emailer(smtp_account).send_emails([email_params])

--- a/lib/workflows/send_errored_vm_email.py
+++ b/lib/workflows/send_errored_vm_email.py
@@ -13,7 +13,7 @@ from structs.email.smtp_account import SMTPAccount
 
 
 def find_servers_with_errored_vms(
-    cloud_account: str, timevar:int, from_projects: Optional[List[str]] = None
+    cloud_account: str, time_variable:int, from_projects: Optional[List[str]] = None
 ):
     """
     :param cloud_account: string represents cloud account to use
@@ -21,9 +21,9 @@ def find_servers_with_errored_vms(
     """
 
     server_query = ServerQuery()
-    if timevar > 0:
+    if time_variable > 0:
         server_query.where(
-            QueryPresetsDateTime.OLDER_THAN, ServerProperties.SERVER_LAST_UPDATED_DATE, days=timevar
+            QueryPresetsDateTime.OLDER_THAN, ServerProperties.SERVER_LAST_UPDATED_DATE, days=time_variable
         )
     server_query.where(
         QueryPresetsGeneric.ANY_IN, ServerProperties.SERVER_STATUS, values=["ERROR"]

--- a/tests/lib/workflows/test_send_errored_vm_email.py
+++ b/tests/lib/workflows/test_send_errored_vm_email.py
@@ -95,11 +95,11 @@ def test_find_servers_with_errored_vms_valid(mock_server_query):
     """
     mock_server_query_obj = mock_server_query.return_value
 
-    res = find_servers_with_errored_vms("test-cloud-account", ["project1", "project2"])
+    res = find_servers_with_errored_vms("test-cloud-account", -1,  ["project1", "project2"])
 
     mock_server_query_obj.run.assert_called_once_with(
         "test-cloud-account",
-        as_admin=False,
+        as_admin=True,
         from_projects=["project1", "project2"],
         all_projects=False,
     )
@@ -122,11 +122,11 @@ def test_find_servers_with_errored_vms_no_servers_found(mock_server_query):
     mock_server_query_obj.to_props.return_value = None
 
     with pytest.raises(RuntimeError):
-        find_servers_with_errored_vms("test-cloud-account", ["project1", "project2"])
+        find_servers_with_errored_vms("test-cloud-account", -1, ["project1", "project2"])
 
     mock_server_query_obj.run.assert_called_once_with(
         "test-cloud-account",
-        as_admin=False,
+        as_admin=True,
         from_projects=["project1", "project2"],
         all_projects=False,
     )
@@ -226,6 +226,7 @@ def test_send_errored_vm_email_send_plaintext(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
+        time_variable= -1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=False,
@@ -234,7 +235,7 @@ def test_send_errored_vm_email_send_plaintext(
         **mock_kwargs,
     )
 
-    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_find_servers.assert_called_once_with(cloud_account, -1, limit_by_projects)
     mock_query.to_props.assert_called_once()
     mock_find_user_info.assert_has_calls(
         [
@@ -316,6 +317,7 @@ def test_send_errored_vm_email_send_html(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
+        time_variable= -1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=True,
@@ -324,7 +326,7 @@ def test_send_errored_vm_email_send_html(
         **mock_kwargs,
     )
 
-    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_find_servers.assert_called_once_with(cloud_account, -1, limit_by_projects)
     mock_query.to_props.assert_called_once()
     mock_find_user_info.assert_has_calls(
         [
@@ -385,6 +387,7 @@ def test_send_errored_vm_email_print(
     """
     limit_by_projects = ["project1", "project2"]
     all_projects = False
+    time_variable = -1
     cloud_account = NonCallableMock()
     smtp_account = NonCallableMock()
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
@@ -404,6 +407,7 @@ def test_send_errored_vm_email_print(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
+        time_variable=-1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=False,
@@ -412,7 +416,7 @@ def test_send_errored_vm_email_print(
         **mock_kwargs,
     )
 
-    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_find_servers.assert_called_once_with(cloud_account, -1, limit_by_projects)
     mock_query.to_props.assert_called_once()
     mock_find_user_info.assert_has_calls(
         [
@@ -463,6 +467,7 @@ def test_send_errored_vm_email_use_override(
     limit_by_projects = ["project1", "project2"]
     all_projects = False
     cloud_account = NonCallableMock()
+    time_variable = -1
     smtp_account = NonCallableMock()
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
     override_email_address = "example@example.com"
@@ -482,6 +487,7 @@ def test_send_errored_vm_email_use_override(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
+        time_variable= -1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=False,
@@ -491,7 +497,7 @@ def test_send_errored_vm_email_use_override(
         **mock_kwargs,
     )
 
-    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_find_servers.assert_called_once_with(cloud_account, -1, limit_by_projects)
     mock_query.to_props.assert_called_once()
     mock_find_user_info.assert_has_calls(
         [

--- a/tests/lib/workflows/test_send_errored_vm_email.py
+++ b/tests/lib/workflows/test_send_errored_vm_email.py
@@ -412,7 +412,6 @@ def test_send_errored_vm_email_print(
     """
     limit_by_projects = ["project1", "project2"]
     all_projects = False
-    time_variable = -1
     cloud_account = NonCallableMock()
     smtp_account = NonCallableMock()
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
@@ -492,7 +491,6 @@ def test_send_errored_vm_email_use_override(
     limit_by_projects = ["project1", "project2"]
     all_projects = False
     cloud_account = NonCallableMock()
-    time_variable = -1
     smtp_account = NonCallableMock()
     mock_kwargs = {"arg1": "val1", "arg2": "val2"}
     override_email_address = "example@example.com"

--- a/tests/lib/workflows/test_send_errored_vm_email.py
+++ b/tests/lib/workflows/test_send_errored_vm_email.py
@@ -114,6 +114,31 @@ def test_find_servers_with_errored_vms_valid(mock_server_query):
 
 
 @patch("workflows.send_errored_vm_email.ServerQuery")
+def test_find_servers_with_errored_vms_valid_time(mock_server_query):
+    """
+    Tests find_servers_with_errored_vms() function when filtering by time
+    """
+    mock_server_query_obj = mock_server_query.return_value
+
+    res = find_servers_with_errored_vms("test-cloud-account", 10,  ["project1", "project2"])
+
+    mock_server_query_obj.run.assert_called_once_with(
+        "test-cloud-account",
+        as_admin=True,
+        from_projects=["project1", "project2"],
+        all_projects=False,
+    )
+    mock_server_query_obj.select.assert_called_once_with("id", "name", "addresses")
+    mock_server_query_obj.to_props.assert_called_once()
+
+    mock_server_query_obj.append_from.assert_called_once_with(
+        "PROJECT_QUERY", "test-cloud-account", "name"
+    )
+    mock_server_query_obj.group_by.assert_called_once_with("user_id")
+    assert res == mock_server_query_obj
+
+
+@patch("workflows.send_errored_vm_email.ServerQuery")
 def test_find_servers_with_errored_vms_no_servers_found(mock_server_query):
     """
     Tests that find_servers_with_errored_vms fails when provided

--- a/tests/lib/workflows/test_send_errored_vm_email.py
+++ b/tests/lib/workflows/test_send_errored_vm_email.py
@@ -1,0 +1,558 @@
+from unittest.mock import patch, call, NonCallableMock
+import pytest
+
+from workflows.send_shutoff_vm_email import (
+    find_servers_with_shutoff_vms,
+    print_email_params,
+    build_email_params,
+    find_user_info,
+    send_shutoff_vm_email,
+)
+
+
+@patch("workflows.send_shutoff_vm_email.UserQuery")
+def test_find_user_info_valid(mock_user_query):
+    """
+    Tests find_user_info where query is given a valid user id
+    """
+    mock_user_id = NonCallableMock()
+    mock_cloud_account = NonCallableMock()
+    mock_override_email = NonCallableMock()
+    mock_user_query.return_value.to_props.return_value = {
+        "user_name": ["foo"],
+        "user_email": ["foo@example.com"],
+    }
+    res = find_user_info(mock_user_id, mock_cloud_account, mock_override_email)
+    mock_user_query.assert_called_once()
+    mock_user_query.return_value.select.assert_called_once_with("name", "email_address")
+    mock_user_query.return_value.where.assert_called_once_with(
+        "equal_to", "id", value=mock_user_id
+    )
+    mock_user_query.return_value.run.assert_called_once_with(
+        cloud_account=mock_cloud_account
+    )
+    mock_user_query.return_value.to_props.assert_called_once_with(flatten=True)
+
+    assert res[0] == "foo"
+    assert res[1] == "foo@example.com"
+
+
+@patch("workflows.send_shutoff_vm_email.UserQuery")
+def test_find_user_info_invalid(mock_user_query):
+    """
+    Tests find_user_info where query is given an invalid user id
+    """
+    mock_user_id = NonCallableMock()
+    mock_cloud_account = NonCallableMock()
+    mock_override_email = NonCallableMock()
+    mock_user_query.return_value.to_props.return_value = []
+    res = find_user_info(mock_user_id, mock_cloud_account, mock_override_email)
+    mock_user_query.assert_called_once()
+    mock_user_query.return_value.select.assert_called_once_with("name", "email_address")
+    mock_user_query.return_value.where.assert_called_once_with(
+        "equal_to", "id", value=mock_user_id
+    )
+    mock_user_query.return_value.run.assert_called_once_with(
+        cloud_account=mock_cloud_account
+    )
+    mock_user_query.return_value.to_props.assert_called_once_with(flatten=True)
+
+    assert res[0] == ""
+    assert res[1] == mock_override_email
+
+
+@patch("workflows.send_shutoff_vm_email.UserQuery")
+def test_find_user_info_no_email_address(mock_user_query):
+    """
+    Tests find_user_info where query result contains no email address
+    """
+    mock_user_id = NonCallableMock()
+    mock_cloud_account = NonCallableMock()
+    mock_override_email = NonCallableMock()
+    mock_user_query.return_value.to_props.return_value = {
+        "user_id": ["foo"],
+        "user_email": [None],
+    }
+    res = find_user_info(mock_user_id, mock_cloud_account, mock_override_email)
+    mock_user_query.assert_called_once()
+    mock_user_query.return_value.select.assert_called_once_with("name", "email_address")
+    mock_user_query.return_value.where.assert_called_once_with(
+        "equal_to", "id", value=mock_user_id
+    )
+    mock_user_query.return_value.run.assert_called_once_with(
+        cloud_account=mock_cloud_account
+    )
+    mock_user_query.return_value.to_props.assert_called_once_with(flatten=True)
+
+    assert res[0] == ""
+    assert res[1] == mock_override_email
+
+
+@patch("workflows.send_shutoff_vm_email.ServerQuery")
+def test_find_servers_with_shutoff_vms_valid(mock_server_query):
+    """
+    Tests find_servers_with_shutoff_vms() function
+    """
+    mock_server_query_obj = mock_server_query.return_value
+
+    res = find_servers_with_shutoff_vms("test-cloud-account", ["project1", "project2"])
+
+    mock_server_query_obj.run.assert_called_once_with(
+        "test-cloud-account",
+        as_admin=False,
+        from_projects=["project1", "project2"],
+        all_projects=False,
+    )
+    mock_server_query_obj.select.assert_called_once_with("id", "name", "addresses")
+    mock_server_query_obj.to_props.assert_called_once()
+
+    mock_server_query_obj.append_from.assert_called_once_with(
+        "PROJECT_QUERY", "test-cloud-account", "name"
+    )
+    mock_server_query_obj.group_by.assert_called_once_with("user_id")
+    assert res == mock_server_query_obj
+
+
+@patch("workflows.send_shutoff_vm_email.ServerQuery")
+def test_find_servers_with_shutoff_vms_no_servers_found(mock_server_query):
+    """
+    Tests that find_servers_with_shutoff_vms fails when provided
+    """
+    mock_server_query_obj = mock_server_query.return_value
+    mock_server_query_obj.to_props.return_value = None
+
+    with pytest.raises(RuntimeError):
+        find_servers_with_shutoff_vms("test-cloud-account", ["project1", "project2"])
+
+    mock_server_query_obj.run.assert_called_once_with(
+        "test-cloud-account",
+        as_admin=False,
+        from_projects=["project1", "project2"],
+        all_projects=False,
+    )
+    mock_server_query_obj.select.assert_called_once_with("id", "name", "addresses")
+    mock_server_query_obj.to_props.assert_called_once()
+
+
+def test_print_email_params():
+    """
+    Test print_email_params() function simply prints values
+    """
+    email_addr = "test@example.com"
+    user_name = "John Doe"
+    as_html = True
+    shutoff_table = "Shutoff Table Content"
+
+    with patch("builtins.print") as mock_print:
+        print_email_params(email_addr, user_name, as_html, shutoff_table)
+
+    mock_print.assert_called_once_with(
+        f"Send Email To: {email_addr}\n"
+        f"email_templates shutoff-email: username {user_name}\n"
+        f"send as html: {as_html}\n"
+        f"shutoff table: {shutoff_table}\n"
+    )
+
+
+@patch("workflows.send_shutoff_vm_email.EmailTemplateDetails")
+@patch("workflows.send_shutoff_vm_email.EmailParams")
+def test_build_params(mock_email_params, mock_email_template_details):
+    """
+    Test build_params() function creates email params appropriately and returns them
+    """
+
+    user_name = "John Doe"
+    shutoff_table = "Shutoff Table Content"
+    email_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    res = build_email_params(user_name, shutoff_table, **email_kwargs)
+    mock_email_template_details.assert_has_calls(
+        [
+            call(
+                template_name="shutoff_vm",
+                template_params={
+                    "username": user_name,
+                    "shutoff_table": shutoff_table,
+                },
+            ),
+            call(template_name="footer", template_params={}),
+        ]
+    )
+
+    mock_email_params.assert_called_once_with(
+        email_templates=[
+            mock_email_template_details.return_value,
+            mock_email_template_details.return_value,
+        ],
+        arg1="val1",
+        arg2="val2",
+    )
+
+    assert res == mock_email_params.return_value
+
+
+# pylint:disable=too-many-arguments
+@patch("workflows.send_shutoff_vm_email.find_servers_with_shutoff_vms")
+@patch("workflows.send_shutoff_vm_email.find_user_info")
+@patch("workflows.send_shutoff_vm_email.build_email_params")
+@patch("workflows.send_shutoff_vm_email.Emailer")
+def test_send_shutoff_vm_email_send_plaintext(
+    mock_emailer,
+    mock_build_email_params,
+    mock_find_user_info,
+    mock_find_servers,
+):
+    """
+    Tests send_shutoff_vm_email() function actually sends email - as_html False
+    """
+    limit_by_projects = ["project1", "project2"]
+    all_projects = False
+    cloud_account = NonCallableMock()
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    mock_query = mock_find_servers.return_value
+
+    # doesn't matter what the values are here since we're just getting the keys
+    mock_query.to_props.return_value = {
+        "user_id1": [],
+        "user_id2": [],
+    }
+    mock_find_user_info.side_effect = [
+        ("user1", "user_email1"),
+        ("user2", "user_email2"),
+    ]
+
+    send_shutoff_vm_email(
+        smtp_account=smtp_account,
+        cloud_account=cloud_account,
+        limit_by_projects=limit_by_projects,
+        all_projects=all_projects,
+        as_html=False,
+        send_email=True,
+        use_override=False,
+        **mock_kwargs,
+    )
+
+    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_query.to_props.assert_called_once()
+    mock_find_user_info.assert_has_calls(
+        [
+            call("user_id1", cloud_account, "cloud-support@stfc.ac.uk"),
+            call("user_id2", cloud_account, "cloud-support@stfc.ac.uk"),
+        ]
+    )
+
+    mock_build_email_params.assert_has_calls(
+        [
+            call(
+                "user1",
+                mock_query.to_string.return_value,
+                email_to=["user_email1"],
+                as_html=False,
+                email_cc=None,
+                **mock_kwargs,
+            ),
+            call(
+                "user2",
+                mock_query.to_string.return_value,
+                email_to=["user_email2"],
+                as_html=False,
+                email_cc=None,
+                **mock_kwargs,
+            ),
+        ]
+    )
+
+    mock_query.to_string.assert_has_calls(
+        [
+            call(groups=["user_id1"], include_group_titles=False),
+            call(groups=["user_id2"], include_group_titles=False),
+        ]
+    )
+
+    mock_emailer.assert_has_calls(
+        [
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+        ]
+    )
+
+
+# pylint:disable=too-many-arguments
+@patch("workflows.send_shutoff_vm_email.find_servers_with_shutoff_vms")
+@patch("workflows.send_shutoff_vm_email.find_user_info")
+@patch("workflows.send_shutoff_vm_email.build_email_params")
+@patch("workflows.send_shutoff_vm_email.Emailer")
+def test_send_shutoff_vm_email_send_html(
+    mock_emailer,
+    mock_build_email_params,
+    mock_find_user_info,
+    mock_find_servers,
+):
+    """
+    Tests send_shutoff_vm_email() function actually sends email - as_html True
+    """
+    limit_by_projects = ["project1", "project2"]
+    all_projects = False
+    cloud_account = NonCallableMock()
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    mock_query = mock_find_servers.return_value
+
+    # doesn't matter what the values are here since we're just getting the keys
+    mock_query.to_props.return_value = {
+        "user_id1": [],
+        "user_id2": [],
+    }
+    mock_find_user_info.side_effect = [
+        ("user1", "user_email1"),
+        ("user2", "user_email2"),
+    ]
+
+    send_shutoff_vm_email(
+        smtp_account=smtp_account,
+        cloud_account=cloud_account,
+        limit_by_projects=limit_by_projects,
+        all_projects=all_projects,
+        as_html=True,
+        send_email=True,
+        use_override=False,
+        **mock_kwargs,
+    )
+
+    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_query.to_props.assert_called_once()
+    mock_find_user_info.assert_has_calls(
+        [
+            call("user_id1", cloud_account, "cloud-support@stfc.ac.uk"),
+            call("user_id2", cloud_account, "cloud-support@stfc.ac.uk"),
+        ]
+    )
+
+    mock_build_email_params.assert_has_calls(
+        [
+            call(
+                "user1",
+                mock_query.to_html.return_value,
+                email_to=["user_email1"],
+                as_html=True,
+                email_cc=None,
+                **mock_kwargs,
+            ),
+            call(
+                "user2",
+                mock_query.to_html.return_value,
+                email_to=["user_email2"],
+                as_html=True,
+                email_cc=None,
+                **mock_kwargs,
+            ),
+        ]
+    )
+
+    mock_query.to_html.assert_has_calls(
+        [
+            call(groups=["user_id1"], include_group_titles=False),
+            call(groups=["user_id2"], include_group_titles=False),
+        ]
+    )
+
+    mock_emailer.assert_has_calls(
+        [
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+        ]
+    )
+
+
+# pylint:disable=too-many-arguments
+@patch("workflows.send_shutoff_vm_email.find_servers_with_shutoff_vms")
+@patch("workflows.send_shutoff_vm_email.find_user_info")
+@patch("workflows.send_shutoff_vm_email.print_email_params")
+def test_send_shutoff_vm_email_print(
+    mock_print_email_params,
+    mock_find_user_info,
+    mock_find_servers,
+):
+    """
+    Tests send_shutoff_vm_email() function prints when send_email=False
+    """
+    limit_by_projects = ["project1", "project2"]
+    all_projects = False
+    cloud_account = NonCallableMock()
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    mock_query = mock_find_servers.return_value
+
+    # doesn't matter what the values are here since we're just getting the keys
+    mock_query.to_props.return_value = {
+        "user_id1": [],
+        "user_id2": [],
+    }
+    mock_find_user_info.side_effect = [
+        ("user1", "user_email1"),
+        ("user2", "user_email2"),
+    ]
+
+    send_shutoff_vm_email(
+        smtp_account=smtp_account,
+        cloud_account=cloud_account,
+        limit_by_projects=limit_by_projects,
+        all_projects=all_projects,
+        as_html=False,
+        send_email=False,
+        use_override=False,
+        **mock_kwargs,
+    )
+
+    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_query.to_props.assert_called_once()
+    mock_find_user_info.assert_has_calls(
+        [
+            call("user_id1", cloud_account, "cloud-support@stfc.ac.uk"),
+            call("user_id2", cloud_account, "cloud-support@stfc.ac.uk"),
+        ]
+    )
+
+    mock_print_email_params.assert_has_calls(
+        [
+            call(
+                "user_email1",
+                "user1",
+                False,
+                mock_query.to_string.return_value,
+            ),
+            call(
+                "user_email2",
+                "user2",
+                False,
+                mock_query.to_string.return_value,
+            ),
+        ]
+    )
+
+    mock_query.to_string.assert_has_calls(
+        [
+            call(groups=["user_id1"], include_group_titles=False),
+            call(groups=["user_id2"], include_group_titles=False),
+        ]
+    )
+
+
+# pylint:disable=too-many-arguments
+@patch("workflows.send_shutoff_vm_email.find_servers_with_shutoff_vms")
+@patch("workflows.send_shutoff_vm_email.find_user_info")
+@patch("workflows.send_shutoff_vm_email.build_email_params")
+@patch("workflows.send_shutoff_vm_email.Emailer")
+def test_send_shutoff_vm_email_use_override(
+    mock_emailer,
+    mock_build_email_params,
+    mock_find_user_info,
+    mock_find_servers,
+):
+    """
+    Tests send_shutoff_vm_email() function sends email to override email - when use_override set
+    """
+    limit_by_projects = ["project1", "project2"]
+    all_projects = False
+    cloud_account = NonCallableMock()
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+    override_email_address = "example@example.com"
+
+    mock_query = mock_find_servers.return_value
+
+    # doesn't matter what the values are here since we're just getting the keys
+    mock_query.to_props.return_value = {
+        "user_id1": [],
+        "user_id2": [],
+    }
+    mock_find_user_info.side_effect = [
+        ("user1", "user_email1"),
+        ("user2", "user_email2"),
+    ]
+
+    send_shutoff_vm_email(
+        smtp_account=smtp_account,
+        cloud_account=cloud_account,
+        limit_by_projects=limit_by_projects,
+        all_projects=all_projects,
+        as_html=False,
+        send_email=True,
+        use_override=True,
+        override_email_address=override_email_address,
+        **mock_kwargs,
+    )
+
+    mock_find_servers.assert_called_once_with(cloud_account, limit_by_projects)
+    mock_query.to_props.assert_called_once()
+    mock_find_user_info.assert_has_calls(
+        [
+            call("user_id1", cloud_account, override_email_address),
+            call("user_id2", cloud_account, override_email_address),
+        ]
+    )
+
+    mock_build_email_params.assert_has_calls(
+        [
+            call(
+                "user1",
+                mock_query.to_string.return_value,
+                email_to=[override_email_address],
+                as_html=False,
+                email_cc=None,
+                **mock_kwargs,
+            ),
+            call(
+                "user2",
+                mock_query.to_string.return_value,
+                email_to=[override_email_address],
+                as_html=False,
+                email_cc=None,
+                **mock_kwargs,
+            ),
+        ]
+    )
+
+    mock_query.to_string.assert_has_calls(
+        [
+            call(groups=["user_id1"], include_group_titles=False),
+            call(groups=["user_id2"], include_group_titles=False),
+        ]
+    )
+
+    mock_emailer.assert_has_calls(
+        [
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+        ]
+    )
+
+
+def test_raise_error_when_both_from_projects_all_projects():
+    """Tests that send_shutoff_vm_email raises error if both from_projects or all_projects given"""
+    with pytest.raises(RuntimeError):
+        send_shutoff_vm_email(
+            smtp_account="",
+            cloud_account="",
+            all_projects=True,
+            limit_by_projects=["proj1", "proj2"],
+        )
+
+
+def test_raise_error_when_neither_from_projects_all_projects():
+    """Tests that send_shutoff_vm_email raises error if neither from_projects nor all_projects given"""
+    with pytest.raises(RuntimeError):
+        send_shutoff_vm_email(
+            smtp_account="",
+            cloud_account="",
+        )

--- a/tests/lib/workflows/test_send_errored_vm_email.py
+++ b/tests/lib/workflows/test_send_errored_vm_email.py
@@ -6,7 +6,7 @@ from workflows.send_errored_vm_email import (
     print_email_params,
     build_email_params,
     find_user_info,
-    send_errored_vm_email
+    send_errored_vm_email,
 )
 
 
@@ -95,7 +95,9 @@ def test_find_servers_with_errored_vms_valid(mock_server_query):
     """
     mock_server_query_obj = mock_server_query.return_value
 
-    res = find_servers_with_errored_vms("test-cloud-account", -1,  ["project1", "project2"])
+    res = find_servers_with_errored_vms(
+        "test-cloud-account", -1, ["project1", "project2"]
+    )
 
     mock_server_query_obj.run.assert_called_once_with(
         "test-cloud-account",
@@ -120,7 +122,9 @@ def test_find_servers_with_errored_vms_valid_time(mock_server_query):
     """
     mock_server_query_obj = mock_server_query.return_value
 
-    res = find_servers_with_errored_vms("test-cloud-account", 10,  ["project1", "project2"])
+    res = find_servers_with_errored_vms(
+        "test-cloud-account", 10, ["project1", "project2"]
+    )
 
     mock_server_query_obj.run.assert_called_once_with(
         "test-cloud-account",
@@ -147,7 +151,9 @@ def test_find_servers_with_errored_vms_no_servers_found(mock_server_query):
     mock_server_query_obj.to_props.return_value = None
 
     with pytest.raises(RuntimeError):
-        find_servers_with_errored_vms("test-cloud-account", -1, ["project1", "project2"])
+        find_servers_with_errored_vms(
+            "test-cloud-account", -1, ["project1", "project2"]
+        )
 
     mock_server_query_obj.run.assert_called_once_with(
         "test-cloud-account",
@@ -251,7 +257,7 @@ def test_send_errored_vm_email_send_plaintext(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
-        time_variable= -1,
+        time_variable=-1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=False,
@@ -342,7 +348,7 @@ def test_send_errored_vm_email_send_html(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
-        time_variable= -1,
+        time_variable=-1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=True,
@@ -510,7 +516,7 @@ def test_send_errored_vm_email_use_override(
     send_errored_vm_email(
         smtp_account=smtp_account,
         cloud_account=cloud_account,
-        time_variable= -1,
+        time_variable=-1,
         limit_by_projects=limit_by_projects,
         all_projects=all_projects,
         as_html=False,


### PR DESCRIPTION
### Description:

<!--
Pull request that adds an action, workflow and set of tests that allow for emails to be sent to users that have errored VMs in their workspaces.
-->
---

### Submitter:

Have you (where applicable):

* [✔️] Added unit tests?
* [❌] Checked the latest commit runs on Dev?
* [❌] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
