### PR TITLE
BUG: fix issue with server search actions

### DIFF
--- a/actions/server.search.by.datetime.yaml
+++ b/actions/server.search.by.datetime.yaml
@@ -108,11 +108,16 @@ parameters:
     type: integer
     default: 0
     required: false
-  from_projects:
-    description: "(Optional) comma-spaced list of projects id/names to limit query to, if not provided, runs against all projects"
+  limit_by_projects:
+    description: "comma-spaced project to limit action to - incompatible with all_projects"
     type: array
     default: null
     required: false
+  all_projects:
+    type: boolean
+    description: "tick to search in all projects - default True"
+    required: true
+    default: true
   group_by:
     description: "(Optional) server property to group unique results by"
     type: string

--- a/actions/server.search.by.property.yaml
+++ b/actions/server.search.by.property.yaml
@@ -101,6 +101,11 @@ parameters:
     type: array
     default: null
     required: false
+  all_projects:
+    type: boolean
+    description: "tick to search in all projects - default True"
+    required: true
+    default: true
   group_by:
     description: "(Optional) server property to group unique results by"
     type: string

--- a/actions/server.search.by.regex.yaml
+++ b/actions/server.search.by.regex.yaml
@@ -93,6 +93,11 @@ parameters:
     type: array
     default: null
     required: false
+  all_projects:
+    type: boolean
+    description: "tick to search in all projects - default True"
+    required: true
+    default: true
   group_by:
     description: "(Optional) server property to group unique results by"
     type: string

--- a/lib/workflows/search_by_datetime.py
+++ b/lib/workflows/search_by_datetime.py
@@ -54,7 +54,7 @@ def search_by_datetime(
     query.where(
         preset=QueryPresetsDateTime.from_string(search_mode),
         prop=property_to_search_by,
-        args={
+        **{
             "days": days,
             "hours": hours,
             "minutes": minutes,

--- a/lib/workflows/search_by_property.py
+++ b/lib/workflows/search_by_property.py
@@ -47,7 +47,7 @@ def search_by_property(
     query.where(
         preset=QueryPresetsGeneric.from_string(search_mode),
         prop=property_to_search_by,
-        args={"values": values},
+        values=values,
     )
 
     if sort_by:

--- a/lib/workflows/search_by_regex.py
+++ b/lib/workflows/search_by_regex.py
@@ -39,7 +39,7 @@ def search_by_regex(
     query.where(
         preset=QueryPresetsString.MATCHES_REGEX,
         prop=property_to_search_by,
-        args={"value": pattern},
+        value=pattern,
     )
 
     if sort_by:

--- a/tests/lib/workflows/test_search_by_datetime.py
+++ b/tests/lib/workflows/test_search_by_datetime.py
@@ -35,7 +35,7 @@ def test_search_by_datetime_minimal(
     mock_query.where.assert_called_once_with(
         preset=mock_preset_enum.from_string.return_value,
         prop=params["property_to_search_by"],
-        args={
+        **{
             "days": 1,
             "hours": 0,
             "minutes": 0,
@@ -102,7 +102,7 @@ def test_search_by_datetime_all(mock_preset_enum, mock_openstack_query, output_t
     mock_query.where.assert_called_once_with(
         preset=mock_preset_enum.from_string.return_value,
         prop=params["property_to_search_by"],
-        args={
+        **{
             "days": 1,
             "hours": 0,
             "minutes": 0,

--- a/tests/lib/workflows/test_search_by_property.py
+++ b/tests/lib/workflows/test_search_by_property.py
@@ -35,7 +35,7 @@ def test_search_by_property_minimal(
     mock_query.where.assert_called_once_with(
         preset=mock_preset_enum.from_string.return_value,
         prop=params["property_to_search_by"],
-        args={"values": params["values"]},
+        values=params["values"],
     )
     mock_query.run.assert_called_once_with(mock_cloud_account)
 
@@ -98,7 +98,7 @@ def test_search_by_property_all(mock_preset_enum, mock_openstack_query, output_t
     mock_query.where.assert_called_once_with(
         preset=mock_preset_enum.from_string.return_value,
         prop=params["property_to_search_by"],
-        args={"values": params["values"]},
+        values=params["values"],
     )
     mock_query.sort_by.assert_called_once_with(
         *[(p, SortOrder.DESC) for p in params["sort_by"]]

--- a/tests/lib/workflows/test_search_by_regex.py
+++ b/tests/lib/workflows/test_search_by_regex.py
@@ -32,7 +32,7 @@ def test_search_by_regex_minimal(mock_openstack_query, output_type):
     mock_query.where.assert_called_once_with(
         preset=QueryPresetsString.MATCHES_REGEX,
         prop=params["property_to_search_by"],
-        args={"value": params["pattern"]},
+        value=params["pattern"],
     )
     mock_query.run.assert_called_once_with(mock_cloud_account)
 
@@ -78,7 +78,7 @@ def test_search_by_regex_all(mock_openstack_query, output_type):
     mock_query.where.assert_called_once_with(
         preset=QueryPresetsString.MATCHES_REGEX,
         prop=params["property_to_search_by"],
-        args={"value": params["pattern"]},
+        value=params["pattern"],
     )
     mock_query.sort_by.assert_called_once_with(
         *[(p, SortOrder.DESC) for p in params["sort_by"]]


### PR DESCRIPTION
These actions were not updated to using the latest API - `where()` calls were passing search params through an argument called `args`

We removed this and just pass search params as extra arguments using `**kwargs`. 

I also added an extra user-defined parameter `all_projects` that was missing - this is required to explicitly tell the action to search all projects rather than just the current `admin` project


 