### PR TITLE
PROTO: project creation scripts without orquesta

### DIFF
--- a/lib/openstack_api/openstack_security_groups.py
+++ b/lib/openstack_api/openstack_security_groups.py
@@ -287,6 +287,59 @@ def create_external_security_group_rules(
     return results
 
 
+def create_internal_security_group_rules(
+    conn: Connection, project_identifier: str, security_group_identifier: str
+):
+    """
+    Sets internal security group rules
+    :param conn: openstack connection object
+    :param project_identifier: the name or the Openstack ID of the associated project
+    :param security_group_identifier: The name or the Openstack ID of the associated security group
+    """
+
+    # allow all icmp by default
+    _create_security_group_rule(
+        conn,
+        SecurityGroupRuleDetails(
+            project_identifier=project_identifier,
+            security_group_identifier=security_group_identifier,
+            direction=NetworkDirection.INGRESS,
+            ip_version=IPVersion.IPV4,
+            protocol=Protocol.ICMP,
+            remote_ip_cidr="0.0.0.0/0",
+            port_range=("*", "*"),
+        ),
+    )
+
+    # allow ssh by default
+    _create_security_group_rule(
+        conn,
+        SecurityGroupRuleDetails(
+            project_identifier=project_identifier,
+            security_group_identifier=security_group_identifier,
+            direction=NetworkDirection.INGRESS,
+            ip_version=IPVersion.IPV4,
+            protocol=Protocol.TCP,
+            remote_ip_cidr="0.0.0.0/0",
+            port_range=("22", "22"),
+        ),
+    )
+
+    # allow aquilon notify by default
+    _create_security_group_rule(
+        conn,
+        SecurityGroupRuleDetails(
+            project_identifier=project_identifier,
+            security_group_identifier=security_group_identifier,
+            direction=NetworkDirection.INGRESS,
+            ip_version=IPVersion.IPV4,
+            protocol=Protocol.UDP,
+            remote_ip_cidr="0.0.0.0/0",
+            port_range=("7777", "7777"),
+        ),
+    )
+
+
 def refresh_security_groups(
     conn: Connection, project_identifier: str
 ) -> List[SecurityGroup]:

--- a/lib/workflows/create_external_project.py
+++ b/lib/workflows/create_external_project.py
@@ -1,0 +1,170 @@
+from typing import Optional, List
+
+from enums.network_providers import NetworkProviders
+from enums.rbac_network_actions import RbacNetworkActions
+from enums.user_domains import UserDomains
+
+from openstack.connection import Connection
+
+from openstack_api.openstack_network import (
+    create_network,
+    create_network_rbac,
+    allocate_floating_ips,
+)
+from openstack_api.openstack_project import create_project
+from openstack_api.openstack_router import create_router, add_interface_to_router
+from openstack_api.openstack_security_groups import (
+    refresh_security_groups,
+    create_https_security_group,
+    create_http_security_group,
+    create_external_security_group_rules,
+)
+from openstack_api.openstack_roles import assign_role_to_user
+from openstack_api.openstack_subnet import create_subnet
+from structs.network_details import NetworkDetails
+from structs.network_rbac import NetworkRbac
+
+from structs.project_details import ProjectDetails
+from structs.role_details import RoleDetails
+from structs.router_details import RouterDetails
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+def create_external_project(
+    conn: Connection,
+    project_name: str,
+    project_email: str,
+    project_description: str,
+    external_network_name: str,
+    external_network_description: str,
+    external_subnet_name: str,
+    external_subnet_description: str,
+    external_router_name: str,
+    external_router_description: str,
+    floating_ip_num: int = 1,
+    project_immutable: Optional[bool] = None,
+    parent_id: Optional[str] = None,
+    admin_user_list: Optional[List[str]] = None,
+    stfc_user_list: Optional[List[str]] = None,
+):
+    """
+    create an external project
+    :param conn: Openstack connection object
+    :param project_name: A string for project name
+    :param project_email: A string for email associated with the project
+    :param project_description: A string for project description
+    :param external_network_name: A string for external network name
+    :param external_network_description: A string for external network description
+    :param external_subnet_name: A string for external subnet name
+    :param external_subnet_description: A string for external subnet description
+    :param external_router_name: A string for external router name
+    :param external_router_description: A string for external router description
+    :param floating_ip_num: Number of floating ips to assign to project (default=1)
+    :param project_immutable: (Optional) A boolean representing if project is immutable (True) or not (False)
+    :param parent_id: (Optional) A string for parent project
+    :param admin_user_list: (Optional) A list of strings to add as admins to the project
+    :param stfc_user_list: (Optional) A list of strings to add as regular users (stfc domain)
+    """
+    if not admin_user_list:
+        admin_user_list = []
+
+    if not stfc_user_list:
+        stfc_user_list = []
+
+    project = create_project(
+        conn,
+        ProjectDetails(
+            name=project_name,
+            email=project_email,
+            description=project_description,
+            immutable=project_immutable,
+            parent_id=parent_id,
+        ),
+    )
+
+    network = create_network(
+        conn,
+        NetworkDetails(
+            name=external_network_name,
+            description=external_network_description,
+            project_identifier=project["id"],
+            provider_network_type=NetworkProviders.VXLAN,
+            port_security_enabled=True,
+            has_external_router=False,
+        ),
+    )
+
+    router = create_router(
+        conn,
+        RouterDetails(
+            router_name=external_router_name,
+            router_description=external_router_description,
+            project_identifier=project["id"],
+            external_gateway="External",
+            is_distributed=False,
+        ),
+    )
+
+    subnet = create_subnet(
+        conn,
+        network_identifier=network["id"],
+        subnet_name=external_subnet_name,
+        subnet_description=external_subnet_description,
+        dhcp_enabled=True,
+    )
+
+    add_interface_to_router(
+        conn,
+        project_identifier=project["id"],
+        router_identifier=router["id"],
+        subnet_identifier=subnet["id"],
+    )
+
+    # wait for default security group
+    refresh_security_groups(conn, project["id"])
+
+    # create default security group rules
+    create_external_security_group_rules(
+        conn, project_identifier=project["id"], security_group_identifier="default"
+    )
+    create_http_security_group(conn, project_identifier=project["id"])
+    create_https_security_group(conn, project_identifier=project["id"])
+
+    create_network_rbac(
+        conn,
+        NetworkRbac(
+            project_identifier=project["id"],
+            network_identifier=network["id"],
+            action=RbacNetworkActions.SHARED,
+        ),
+    )
+
+    allocate_floating_ips(
+        conn,
+        network_identifier=network["id"],
+        project_identifier=project["id"],
+        number_to_create=floating_ip_num,
+    )
+
+    for admin_user in admin_user_list:
+        assign_role_to_user(
+            conn,
+            RoleDetails(
+                user_identifier=admin_user,
+                user_domain=UserDomains.DEFAULT,
+                project_identifier=project["id"],
+                role_identifier="admin",
+            ),
+        )
+
+    for stfc_user in stfc_user_list:
+        assign_role_to_user(
+            conn,
+            RoleDetails(
+                user_identifier=stfc_user,
+                user_domain=UserDomains.STFC,
+                project_identifier=project["id"],
+                role_identifier="user",
+            ),
+        )

--- a/lib/workflows/create_external_project.py
+++ b/lib/workflows/create_external_project.py
@@ -37,11 +37,8 @@ def create_external_project(
     project_email: str,
     project_description: str,
     external_network_name: str,
-    external_network_description: str,
     external_subnet_name: str,
-    external_subnet_description: str,
     external_router_name: str,
-    external_router_description: str,
     floating_ip_num: int = 1,
     project_immutable: Optional[bool] = None,
     parent_id: Optional[str] = None,
@@ -55,11 +52,8 @@ def create_external_project(
     :param project_email: A string for email associated with the project
     :param project_description: A string for project description
     :param external_network_name: A string for external network name
-    :param external_network_description: A string for external network description
     :param external_subnet_name: A string for external subnet name
-    :param external_subnet_description: A string for external subnet description
     :param external_router_name: A string for external router name
-    :param external_router_description: A string for external router description
     :param floating_ip_num: Number of floating ips to assign to project (default=1)
     :param project_immutable: (Optional) A boolean representing if project is immutable (True) or not (False)
     :param parent_id: (Optional) A string for parent project
@@ -87,7 +81,7 @@ def create_external_project(
         conn,
         NetworkDetails(
             name=external_network_name,
-            description=external_network_description,
+            description="",
             project_identifier=project["id"],
             provider_network_type=NetworkProviders.VXLAN,
             port_security_enabled=True,
@@ -99,7 +93,7 @@ def create_external_project(
         conn,
         RouterDetails(
             router_name=external_router_name,
-            router_description=external_router_description,
+            router_description="",
             project_identifier=project["id"],
             external_gateway="External",
             is_distributed=False,
@@ -110,7 +104,7 @@ def create_external_project(
         conn,
         network_identifier=network["id"],
         subnet_name=external_subnet_name,
-        subnet_description=external_subnet_description,
+        subnet_description="",
         dhcp_enabled=True,
     )
 

--- a/lib/workflows/create_internal_project.py
+++ b/lib/workflows/create_internal_project.py
@@ -1,0 +1,98 @@
+from typing import Optional, List
+
+from enums.rbac_network_actions import RbacNetworkActions
+from enums.user_domains import UserDomains
+
+from openstack.connection import Connection
+
+from openstack_api.openstack_network import create_network_rbac
+from openstack_api.openstack_project import create_project
+from openstack_api.openstack_security_groups import (
+    refresh_security_groups,
+    create_https_security_group,
+    create_http_security_group,
+    create_internal_security_group_rules,
+)
+from openstack_api.openstack_roles import assign_role_to_user
+
+from structs.network_rbac import NetworkRbac
+from structs.project_details import ProjectDetails
+from structs.role_details import RoleDetails
+
+
+# pylint: disable=too-many-arguments
+def create_internal_project(
+    conn: Connection,
+    project_name: str,
+    project_email: str,
+    project_description: str,
+    project_immutable: Optional[bool] = None,
+    parent_id: Optional[str] = None,
+    admin_user_list: Optional[List[str]] = None,
+    stfc_user_list: Optional[List[str]] = None,
+):
+    """
+    create an internal project
+    :param conn: Openstack Connection object
+    :param project_name: A string for project name
+    :param project_email: A string for email associated with the project
+    :param project_description: A string for project description
+    :param project_immutable: A boolean representing if project is immutable (True) or not (False)
+    :param parent_id: (Optional) A string for parent project
+    :param admin_user_list: (Optional) A list of strings to add as admins to the project
+    :param stfc_user_list: (Optional) A list of strings to add as regular users (stfc domain)
+    """
+    if not admin_user_list:
+        admin_user_list = []
+
+    if not stfc_user_list:
+        stfc_user_list = []
+
+    project = create_project(
+        conn,
+        ProjectDetails(
+            name=project_name,
+            email=project_email,
+            description=project_description,
+            immutable=project_immutable,
+            parent_id=parent_id,
+        ),
+    )
+
+    # wait for default security group
+    refresh_security_groups(conn, project["id"])
+
+    create_internal_security_group_rules(conn, project["id"], "default")
+    create_http_security_group(conn, project_identifier=project["id"])
+    create_https_security_group(conn, project_identifier=project["id"])
+
+    create_network_rbac(
+        conn,
+        NetworkRbac(
+            project_identifier=project["id"],
+            network_identifier="Internal",
+            action=RbacNetworkActions.SHARED,
+        ),
+    )
+
+    for admin_user in admin_user_list:
+        assign_role_to_user(
+            conn,
+            RoleDetails(
+                user_identifier=admin_user,
+                user_domain=UserDomains.DEFAULT,
+                project_identifier=project["id"],
+                role_identifier="admin",
+            ),
+        )
+
+    for stfc_user in stfc_user_list:
+        assign_role_to_user(
+            conn,
+            RoleDetails(
+                user_identifier=stfc_user,
+                user_domain=UserDomains.STFC,
+                project_identifier=project["id"],
+                role_identifier="user",
+            ),
+        )

--- a/tests/lib/workflows/test_create_external_project.py
+++ b/tests/lib/workflows/test_create_external_project.py
@@ -51,11 +51,8 @@ def test_create_external_project(
     project_email = "test@example.com"
     project_description = "Test Description"
     external_network_name = "External Network"
-    external_network_description = "External Network Description"
     external_subnet_name = "External Subnet"
-    external_subnet_description = "External Subnet Description"
     external_router_name = "External Router"
-    external_router_description = "External Router Description"
     floating_ip_num = 2
     project_immutable = True
     parent_id = "parent-id"
@@ -69,11 +66,8 @@ def test_create_external_project(
         project_email,
         project_description,
         external_network_name,
-        external_network_description,
         external_subnet_name,
-        external_subnet_description,
         external_router_name,
-        external_router_description,
         floating_ip_num,
         project_immutable,
         parent_id,
@@ -97,7 +91,7 @@ def test_create_external_project(
         mock_conn,
         NetworkDetails(
             name=external_network_name,
-            description=external_network_description,
+            description="",
             project_identifier="project-id",
             provider_network_type=NetworkProviders.VXLAN,
             port_security_enabled=True,
@@ -109,7 +103,7 @@ def test_create_external_project(
         mock_conn,
         RouterDetails(
             router_name=external_router_name,
-            router_description=external_router_description,
+            router_description="",
             project_identifier="project-id",
             external_gateway="External",
             is_distributed=False,
@@ -119,7 +113,7 @@ def test_create_external_project(
         mock_conn,
         network_identifier="network-id",
         subnet_name=external_subnet_name,
-        subnet_description=external_subnet_description,
+        subnet_description="",
         dhcp_enabled=True,
     )
     mock_add_interface_to_router.assert_called_once_with(

--- a/tests/lib/workflows/test_create_external_project.py
+++ b/tests/lib/workflows/test_create_external_project.py
@@ -1,0 +1,198 @@
+from unittest.mock import patch, MagicMock
+
+from enums.network_providers import NetworkProviders
+from enums.rbac_network_actions import RbacNetworkActions
+from enums.user_domains import UserDomains
+from structs.network_details import NetworkDetails
+from structs.network_rbac import NetworkRbac
+from structs.project_details import ProjectDetails
+from structs.role_details import RoleDetails
+from structs.router_details import RouterDetails
+from workflows.create_external_project import create_external_project
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+@patch("workflows.create_external_project.create_project")
+@patch("workflows.create_external_project.create_network")
+@patch("workflows.create_external_project.create_router")
+@patch("workflows.create_external_project.create_subnet")
+@patch("workflows.create_external_project.add_interface_to_router")
+@patch("workflows.create_external_project.refresh_security_groups")
+@patch("workflows.create_external_project.create_external_security_group_rules")
+@patch("workflows.create_external_project.create_http_security_group")
+@patch("workflows.create_external_project.create_https_security_group")
+@patch("workflows.create_external_project.create_network_rbac")
+@patch("workflows.create_external_project.allocate_floating_ips")
+@patch("workflows.create_external_project.assign_role_to_user")
+def test_create_external_project(
+    mock_assign_role_to_user,
+    mock_allocate_floating_ips,
+    mock_create_network_rbac,
+    mock_create_https_security_group,
+    mock_create_http_security_group,
+    mock_create_external_security_group_rules,
+    mock_refresh_security_groups,
+    mock_add_interface_to_router,
+    mock_create_subnet,
+    mock_create_router,
+    mock_create_network,
+    mock_create_project,
+):
+    # Mock the return values for project, network, router, and subnet
+    mock_create_project.return_value = {"id": "project-id"}
+    mock_create_network.return_value = {"id": "network-id"}
+    mock_create_router.return_value = {"id": "router-id"}
+    mock_create_subnet.return_value = {"id": "subnet-id"}
+
+    # Test data
+    mock_conn = MagicMock()
+    project_name = "Test Project"
+    project_email = "test@example.com"
+    project_description = "Test Description"
+    external_network_name = "External Network"
+    external_network_description = "External Network Description"
+    external_subnet_name = "External Subnet"
+    external_subnet_description = "External Subnet Description"
+    external_router_name = "External Router"
+    external_router_description = "External Router Description"
+    floating_ip_num = 2
+    project_immutable = True
+    parent_id = "parent-id"
+    admin_user_list = ["admin1", "admin2"]
+    stfc_user_list = ["user1", "user2"]
+
+    # Call the function
+    create_external_project(
+        mock_conn,
+        project_name,
+        project_email,
+        project_description,
+        external_network_name,
+        external_network_description,
+        external_subnet_name,
+        external_subnet_description,
+        external_router_name,
+        external_router_description,
+        floating_ip_num,
+        project_immutable,
+        parent_id,
+        admin_user_list,
+        stfc_user_list,
+    )
+
+    # Assertions to ensure the functions were called with correct parameters
+    mock_create_project.assert_called_once_with(
+        mock_conn,
+        ProjectDetails(
+            name=project_name,
+            email=project_email,
+            description=project_description,
+            immutable=project_immutable,
+            parent_id=parent_id,
+        ),
+    )
+
+    mock_create_network.assert_called_once_with(
+        mock_conn,
+        NetworkDetails(
+            name=external_network_name,
+            description=external_network_description,
+            project_identifier="project-id",
+            provider_network_type=NetworkProviders.VXLAN,
+            port_security_enabled=True,
+            has_external_router=False,
+        ),
+    )
+
+    mock_create_router.assert_called_once_with(
+        mock_conn,
+        RouterDetails(
+            router_name=external_router_name,
+            router_description=external_router_description,
+            project_identifier="project-id",
+            external_gateway="External",
+            is_distributed=False,
+        ),
+    )
+    mock_create_subnet.assert_called_once_with(
+        mock_conn,
+        network_identifier="network-id",
+        subnet_name=external_subnet_name,
+        subnet_description=external_subnet_description,
+        dhcp_enabled=True,
+    )
+    mock_add_interface_to_router.assert_called_once_with(
+        mock_conn,
+        project_identifier="project-id",
+        router_identifier="router-id",
+        subnet_identifier="subnet-id",
+    )
+    mock_refresh_security_groups.assert_called_once_with(mock_conn, "project-id")
+    mock_create_external_security_group_rules.assert_called_once_with(
+        mock_conn, project_identifier="project-id", security_group_identifier="default"
+    )
+    mock_create_http_security_group.assert_called_once_with(
+        mock_conn, project_identifier="project-id"
+    )
+    mock_create_https_security_group.assert_called_once_with(
+        mock_conn, project_identifier="project-id"
+    )
+    mock_create_network_rbac.assert_called_once_with(
+        mock_conn,
+        NetworkRbac(
+            project_identifier="project-id",
+            network_identifier="network-id",
+            action=RbacNetworkActions.SHARED,
+        ),
+    )
+    mock_allocate_floating_ips.assert_called_once_with(
+        mock_conn,
+        network_identifier="network-id",
+        project_identifier="project-id",
+        number_to_create=floating_ip_num,
+    )
+
+    # Assert that roles were assigned to the admins
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="admin1",
+            user_domain=UserDomains.DEFAULT,
+            project_identifier="project-id",
+            role_identifier="admin",
+        ),
+    )
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="admin2",
+            user_domain=UserDomains.DEFAULT,
+            project_identifier="project-id",
+            role_identifier="admin",
+        ),
+    )
+
+    # Assert that roles were assigned to the stfc users
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="user1",
+            user_domain=UserDomains.STFC,
+            project_identifier="project-id",
+            role_identifier="user",
+        ),
+    )
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="user2",
+            user_domain=UserDomains.STFC,
+            project_identifier="project-id",
+            role_identifier="user",
+        ),
+    )
+
+    # Verify assign_role_to_user was called four times
+    # (two for admin, two for stfc users)
+    assert mock_assign_role_to_user.call_count == 4

--- a/tests/lib/workflows/test_create_internal_project.py
+++ b/tests/lib/workflows/test_create_internal_project.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch, MagicMock
+
+from enums.rbac_network_actions import RbacNetworkActions
+from enums.user_domains import UserDomains
+
+from structs.network_rbac import NetworkRbac
+from structs.project_details import ProjectDetails
+from structs.role_details import RoleDetails
+
+from workflows.create_internal_project import create_internal_project
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
+@patch("workflows.create_internal_project.create_project")
+@patch("workflows.create_internal_project.refresh_security_groups")
+@patch("workflows.create_internal_project.create_internal_security_group_rules")
+@patch("workflows.create_internal_project.create_http_security_group")
+@patch("workflows.create_internal_project.create_https_security_group")
+@patch("workflows.create_internal_project.create_network_rbac")
+@patch("workflows.create_internal_project.assign_role_to_user")
+def test_create_internal_project(
+    mock_assign_role_to_user,
+    mock_create_network_rbac,
+    mock_create_https_security_group,
+    mock_create_http_security_group,
+    mock_create_internal_security_group_rules,
+    mock_refresh_security_groups,
+    mock_create_project,
+):
+    # Mock the return value of create_project
+    mock_create_project.return_value = {"id": "project-id"}
+
+    # Test data
+    mock_conn = MagicMock()
+    project_name = "Test Project"
+    project_email = "test@example.com"
+    project_description = "Test Description"
+    project_immutable = True
+    parent_id = "parent-id"
+    admin_user_list = ["admin1", "admin2"]
+    stfc_user_list = ["user1", "user2"]
+
+    # Call the function
+    create_internal_project(
+        mock_conn,
+        project_name,
+        project_email,
+        project_description,
+        project_immutable,
+        parent_id,
+        admin_user_list,
+        stfc_user_list,
+    )
+
+    mock_create_project.assert_called_once_with(
+        mock_conn,
+        ProjectDetails(
+            name=project_name,
+            email=project_email,
+            description=project_description,
+            immutable=project_immutable,
+            parent_id=parent_id,
+        ),
+    )
+    mock_refresh_security_groups.assert_called_once_with(mock_conn, "project-id")
+    mock_create_internal_security_group_rules.assert_called_once_with(
+        mock_conn, "project-id", "default"
+    )
+    mock_create_http_security_group.assert_called_once_with(
+        mock_conn, project_identifier="project-id"
+    )
+    mock_create_https_security_group.assert_called_once_with(
+        mock_conn, project_identifier="project-id"
+    )
+    mock_create_network_rbac.assert_called_once_with(
+        mock_conn,
+        NetworkRbac(
+            project_identifier="project-id",
+            network_identifier="Internal",
+            action=RbacNetworkActions.SHARED,
+        ),
+    )
+
+    # Assert that roles were assigned to the admins
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="admin1",
+            user_domain=UserDomains.DEFAULT,
+            project_identifier="project-id",
+            role_identifier="admin",
+        ),
+    )
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="admin2",
+            user_domain=UserDomains.DEFAULT,
+            project_identifier="project-id",
+            role_identifier="admin",
+        ),
+    )
+
+    # Assert that roles were assigned to the stfc users
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="user1",
+            user_domain=UserDomains.STFC,
+            project_identifier="project-id",
+            role_identifier="user",
+        ),
+    )
+    mock_assign_role_to_user.assert_any_call(
+        mock_conn,
+        RoleDetails(
+            user_identifier="user2",
+            user_domain=UserDomains.STFC,
+            project_identifier="project-id",
+            role_identifier="user",
+        ),
+    )
+
+    # Verify assign_role_to_user was called four times
+    # (two for admin, two for stfc users)
+    assert mock_assign_role_to_user.call_count == 4


### PR DESCRIPTION
Convert create_external_project and create_internal_project into standalone python scripts - this will enable us to deprecate the orquesta workflows that we currently use 