### PR TITLE
PROTO: moving useful actions into workflow folder

### DIFF
--- a/lib/openstack_api/openstack_project.py
+++ b/lib/openstack_api/openstack_project.py
@@ -58,11 +58,28 @@ def delete_project(conn: Connection, project_identifier: str) -> bool:
         project_identifier=project_identifier, ignore_missing=False
     )
 
+    if not _is_project_safe_to_delete(project):
+        raise ValueError("Project is a protected project and cannot be deleted!")
+
     if _is_project_immutable(project):
         raise ValueError("Project is immutable and so can't be deleted")
 
     result = conn.identity.delete_project(project=project, ignore_missing=False)
     return result is None  # Where None == success
+
+
+def _is_project_safe_to_delete(project: Project) -> bool:
+    """
+    Returns true if the project is safe to delete - avoid deleting admin project for instance
+    :param project: project to check against
+    :return: True if safe to delete else False
+    """
+    # these are core project uuids that we shouldn't delete
+    return project["id"] not in [
+        "0e60669c49d4497aad91d8f729cfdd77",
+        "4de86830e89b4a46b590536571b6ccd4",
+        "c9aee696c4b54f12a645af2c951327dc",
+    ]
 
 
 def _find_project_tag(

--- a/lib/workflows/project_actions.py
+++ b/lib/workflows/project_actions.py
@@ -1,0 +1,36 @@
+from typing import Tuple
+
+from openstack.connection import Connection
+from openstack_api import openstack_project
+
+
+def delete_project(
+    conn: Connection, project_identifier: str, delete: bool
+) -> Tuple[bool, str]:
+    """
+    Deletes a project
+    :param conn: Openstack connection object
+    :param project_identifier: (Either) The project name to delete
+    :param delete: When true will delete the project, when false will only return it to reduce
+                   chances of accidental deletion
+    :return: The result of the operation
+    """
+    project = conn.identity.find_project(
+        project_identifier=project_identifier, ignore_missing=False
+    )
+    project_string = "\n".join(
+        f"{k}: {project.get(k, 'Not Found')}"
+        for k in ["id", "name", "description", "email"]
+    )
+
+    if delete:
+        delete_ok = openstack_project.delete_project(
+            conn, project_identifier=project_identifier
+        )
+        # Currently, we only handle one error, other throws will propagate upwards
+        message = f"The following project has been deleted:\n\n{project_string}"
+        return delete_ok, message
+    return (
+        False,
+        f"Tick the delete checkbox to delete the project:\n\n{project_string}",
+    )

--- a/lib/workflows/quota_actions.py
+++ b/lib/workflows/quota_actions.py
@@ -1,0 +1,24 @@
+from openstack.connection import Connection
+from openstack_api import openstack_quota
+from structs.quota_details import QuotaDetails
+
+
+def quota_set(
+    conn: Connection,
+    project_identifier: str,
+    num_floating_ips: int,
+    num_security_group_rules: int,
+) -> bool:
+    """
+    Set a project's quota
+    :param conn: Openstack connection object
+    :param project_identifier: Name or ID of the Openstack Project
+    :param num_floating_ips: The max number of floating IPs (or 0 to skip)
+    :param num_security_group_rules: The max number of rules (or 0 to skip)
+    :return: status
+    """
+    openstack_quota.set_quota(
+        conn,
+        QuotaDetails(project_identifier, num_floating_ips, num_security_group_rules),
+    )
+    return True

--- a/lib/workflows/role_actions.py
+++ b/lib/workflows/role_actions.py
@@ -1,0 +1,57 @@
+from openstack.connection import Connection
+
+from enums.user_domains import UserDomains
+from structs.role_details import RoleDetails
+from openstack_api import openstack_roles
+
+
+def role_add(
+    conn: Connection,
+    user_identifier: str,
+    project_identifier: str,
+    role: str,
+    user_domain: str,
+) -> bool:
+    """
+    Add a given user a project role
+    :param conn: Openstack connection object
+    :param user_identifier: Name or ID of the user to assign a role to
+    :param project_identifier: Name or ID of the project this applies to
+    :param role: Name or ID of the role to assign
+    :param user_domain: The domain the user is associated with
+    :return: status
+    """
+    details = RoleDetails(
+        user_identifier=user_identifier,
+        project_identifier=project_identifier,
+        role_identifier=role,
+        user_domain=UserDomains.from_string(user_domain),
+    )
+    openstack_roles.assign_role_to_user(conn, details=details)
+    return True  # the above method always returns None
+
+
+def role_remove(
+    conn: Connection,
+    user_identifier: str,
+    project_identifier: str,
+    role: str,
+    user_domain: str,
+) -> bool:
+    """
+    Removes a project role from a given user
+    :param conn: Openstack connection object
+    :param user_identifier: Name or ID of the user to remove a role from
+    :param project_identifier: Name or ID of the project this applies to
+    :param role: Name or ID of the role to remove
+    :param user_domain: The domain the user is associated with
+    :return: status
+    """
+    details = RoleDetails(
+        user_identifier=user_identifier,
+        project_identifier=project_identifier,
+        role_identifier=role,
+        user_domain=UserDomains.from_string(user_domain),
+    )
+    openstack_roles.remove_role_from_user(conn, details=details)
+    return True

--- a/tests/lib/openstack_api/test_openstack_project.py
+++ b/tests/lib/openstack_api/test_openstack_project.py
@@ -152,3 +152,25 @@ def test_delete_project_successful_with_name_or_id():
         project=mock_conn.identity.find_project.return_value, ignore_missing=False
     )
     assert res
+
+
+@pytest.mark.parametrize(
+    "protected_project_id",
+    [
+        "0e60669c49d4497aad91d8f729cfdd77",
+        "4de86830e89b4a46b590536571b6ccd4",
+        "c9aee696c4b54f12a645af2c951327dc",
+    ],
+)
+def test_delete_protected_project_fails(protected_project_id):
+    """tests that delete_project fails if project has uuid which is unsafe to delete"""
+    mock_conn = MagicMock()
+    mock_project_identifier = NonCallableMock()
+    mock_conn.identity.find_project.return_value = {"id": protected_project_id}
+
+    with pytest.raises(ValueError):
+        delete_project(mock_conn, mock_project_identifier)
+    mock_conn.identity.find_project.assert_called_once_with(
+        project_identifier=mock_project_identifier, ignore_missing=False
+    )
+    mock_conn.identity.delete_project.assert_not_called()

--- a/tests/lib/workflows/test_project_actions.py
+++ b/tests/lib/workflows/test_project_actions.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch, MagicMock
+from workflows.project_actions import delete_project
+
+
+@patch("workflows.project_actions.delete_project")
+def test_project_delete_with_confirmation(mock_api_delete_project):
+    """
+    Tests that project_delete function forwards on request to openstack API project_delete function
+    and returns the correct status and string
+    """
+
+    mock_api_delete_project.return_value = True
+    # setup input values
+    mock_conn = MagicMock()
+    mock_project_identifier = "project-id"
+
+    mock_conn.identity.find_project.return_value = {
+        "id": "project-id",
+        "name": "project-name",
+        "description": "project-description",
+        "email": "example@example.com",
+    }
+
+    status, _ = delete_project(mock_conn, mock_project_identifier, delete=True)
+
+    mock_conn.identity.find_project.assert_called_once_with(
+        project_identifier="project-id", ignore_missing=False
+    )
+    mock_api_delete_project.assert_called_once_with(
+        mock_conn, project_identifier=mock_project_identifier
+    )
+    assert status
+
+
+@patch("workflows.project_actions.delete_project")
+def test_project_delete_without_confirmation(mock_api_delete_project):
+    """
+    Tests that project_delete function forwards on request to openstack API project_delete function
+    and returns the correct status and string
+    """
+
+    mock_api_delete_project.return_value = True
+    # setup input values
+    mock_conn = MagicMock()
+    mock_project_identifier = "project-id"
+
+    mock_conn.identity.find_project.return_value = {
+        "id": "project-id",
+        "name": "project-name",
+        "description": "project-description",
+        "email": "example@example.com",
+    }
+
+    status, _ = delete_project(mock_conn, mock_project_identifier, delete=False)
+
+    mock_conn.identity.find_project.assert_called_once_with(
+        project_identifier="project-id", ignore_missing=False
+    )
+    mock_api_delete_project.assert_not_called()
+    assert not status

--- a/tests/lib/workflows/test_quota_actions.py
+++ b/tests/lib/workflows/test_quota_actions.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch, MagicMock
+from structs.quota_details import QuotaDetails
+from workflows.quota_actions import quota_set
+
+
+@patch("workflows.quota_actions.openstack_quota.set_quota")
+def test_quota_set(mock_api_set_quota):
+    """
+    Tests that quota_set function forwards on request to openstack API set_quota function
+    and returns the correct status (True)
+    """
+
+    # setup input values
+    mock_conn = MagicMock()
+    mock_project_identifier = "project-id"
+    mock_num_floating_ips = 1
+    mock_num_security_group_rules = 1
+
+    status = quota_set(
+        mock_conn,
+        mock_project_identifier,
+        mock_num_floating_ips,
+        mock_num_security_group_rules,
+    )
+
+    mock_api_set_quota.assert_called_once_with(
+        mock_conn,
+        QuotaDetails(
+            mock_project_identifier,
+            mock_num_floating_ips,
+            mock_num_security_group_rules,
+        ),
+    )
+
+    assert status

--- a/tests/lib/workflows/test_role_actions.py
+++ b/tests/lib/workflows/test_role_actions.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch, MagicMock
+
+from enums.user_domains import UserDomains
+from structs.role_details import RoleDetails
+from workflows.role_actions import role_add, role_remove
+
+
+@patch("workflows.role_actions.openstack_roles.assign_role_to_user")
+def test_role_add(mock_api_assign_role_to_user):
+    """
+    Tests that role_add function forwards on request to openstack API role_add function
+    and returns the correct status (True)
+    """
+
+    # setup input values
+    mock_conn = MagicMock()
+    mock_user_identifier = "user-id"
+    mock_project_identifier = "project-id"
+    mock_role = "user"
+    mock_user_domain = "stfc"
+
+    status = role_add(
+        mock_conn,
+        mock_user_identifier,
+        mock_project_identifier,
+        mock_role,
+        mock_user_domain,
+    )
+
+    mock_api_assign_role_to_user.assert_called_once_with(
+        mock_conn,
+        details=RoleDetails(
+            user_identifier=mock_user_identifier,
+            project_identifier=mock_project_identifier,
+            role_identifier=mock_role,
+            user_domain=UserDomains.STFC,
+        ),
+    )
+
+    assert status
+
+
+@patch("workflows.role_actions.openstack_roles.remove_role_from_user")
+def test_role_remove(mock_api_remove_role_from_user):
+    """
+    Tests that role_add function forwards on request to openstack API role_add function
+    and returns the correct status (True)
+    """
+
+    # setup input values
+    mock_conn = MagicMock()
+    mock_user_identifier = "user-id"
+    mock_project_identifier = "project-id"
+    mock_role = "user"
+    mock_user_domain = "stfc"
+
+    status = role_remove(
+        mock_conn,
+        mock_user_identifier,
+        mock_project_identifier,
+        mock_role,
+        mock_user_domain,
+    )
+
+    mock_api_remove_role_from_user.assert_called_once_with(
+        mock_conn,
+        details=RoleDetails(
+            user_identifier=mock_user_identifier,
+            project_identifier=mock_project_identifier,
+            role_identifier=mock_role,
+            user_domain=UserDomains.STFC,
+        ),
+    )
+
+    assert status


### PR DESCRIPTION
This is so we can remove all the unnecessary code under actions.src.*. We're only keeping useful actions here - other ones can be easily done using openstack cli so we shouldn't re-invent the wheel
