### PR TITLE
ENH: Add project search by regex action

### DIFF
--- a/actions/project.search.by.regex.yaml
+++ b/actions/project.search.by.regex.yaml
@@ -29,12 +29,22 @@ parameters:
   properties_to_select:
     default:
       - "description"
+      - "domain_id"
+      - "id"
+      - "is_domain"
+      - "is_enabled"
       - "name"
+      - "parent_id"
     type: array
     description: "
-    A comma-spaced list of server properties to display for the resulting hypervisors - leave empty for all properties. One of:
+    A comma-spaced list of server properties to display for the resulting projects - leave empty for all properties. One of:
       - 'description'
+      - 'domain_id'
+      - 'id'
+      - 'is_domain'
+      - 'is_enabled'
       - 'name'
+      - 'parent_id'
     Anything else will raise an error"
     required: false
   output_type:
@@ -57,12 +67,7 @@ parameters:
     description: "choose property to search by (acts as OR for each)"
     enum:
       - "description"
-      - "domain_id"
-      - "id"
-      - "is_domain"
-      - "is_enabled"
       - "name"
-      - "parent_id"
     type: string
     required: true
   pattern:

--- a/actions/project.search.by.regex.yaml
+++ b/actions/project.search.by.regex.yaml
@@ -29,22 +29,12 @@ parameters:
   properties_to_select:
     default:
       - "description"
-      - "domain_id"
-      - "id"
-      - "is_domain"
-      - "is_enabled"
       - "name"
-      - "parent_id"
     type: array
     description: "
     A comma-spaced list of server properties to display for the resulting hypervisors - leave empty for all properties. One of:
       - 'description'
-      - 'domain_id'
-      - 'id'
-      - 'is_domain'
-      - 'is_enabled'
       - 'name'
-      - 'parent_id'
     Anything else will raise an error"
     required: false
   output_type:

--- a/actions/project.search.by.regex.yaml
+++ b/actions/project.search.by.regex.yaml
@@ -1,0 +1,111 @@
+---
+description: Search for projects using regex pattern.
+enabled: true
+entry_point: src/openstack_actions.py
+name: project.search.by.regex
+parameters:
+  timeout:
+    default: 5400
+  lib_entry_point:
+    default: workflows.search_by_regex.search_by_regex
+    immutable: true
+    type: string
+  query_type:
+    default: ProjectQuery
+    immutable: true
+    type: string
+  as_admin:
+    default: True
+    immutable: true
+    type: boolean
+  cloud_account:
+    description: The clouds.yaml account to use whilst performing this action
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  properties_to_select:
+    default:
+      - "description"
+      - "domain_id"
+      - "id"
+      - "is_domain"
+      - "is_enabled"
+      - "name"
+      - "parent_id"
+    type: array
+    description: "
+    A comma-spaced list of server properties to display for the resulting hypervisors - leave empty for all properties. One of:
+      - 'description'
+      - 'domain_id'
+      - 'id'
+      - 'is_domain'
+      - 'is_enabled'
+      - 'name'
+      - 'parent_id'
+    Anything else will raise an error"
+    required: false
+  output_type:
+    default: "to_string"
+    type: string
+    enum:
+      - "to_html"
+      - "to_objects"
+      - "to_props"
+      - "to_string"
+    description: "
+    A string representing how to return the results of the query
+      - 'to_html' - a tabulate table (in html)
+      - 'to_props' - properties dicts as a python list
+      - 'to_objects - as a list of openstack resources
+      - 'to_string' - a tabulate table"
+    required: true
+  property_to_search_by:
+    default: "id"
+    description: "choose property to search by (acts as OR for each)"
+    enum:
+      - "description"
+      - "domain_id"
+      - "id"
+      - "is_domain"
+      - "is_enabled"
+      - "name"
+      - "parent_id"
+    type: string
+    required: true
+  pattern:
+    description: "the regex pattern to use - must be compatible with python regex 're' module"
+    required: true
+    type: string
+  group_by:
+    description: "(Optional) project property to group unique results by
+    One of
+      - 'description'
+      - 'domain_id'
+      - 'id'
+      - 'is_domain'
+      - 'is_enabled'
+      - 'name'
+      - 'parent_id'
+    Anything else will raise an error"
+    type: string
+    required: false
+    default: null
+  sort_by:
+    description: "(Optional) comma-spaced list of project properties to sort by (by ascending only)
+    - multiple of the same property will be ignored.
+    Any of:
+      - 'description'
+      - 'domain_id'
+      - 'id'
+      - 'is_domain'
+      - 'is_enabled'
+      - 'name'
+      - 'parent_id'
+    Anything else will raise an error"
+    type: array
+    required: false
+    default: null
+runner_type: python-script

--- a/stackstorm_openstack.yaml.example
+++ b/stackstorm_openstack.yaml.example
@@ -13,10 +13,10 @@ jira_accounts:
 smtp_accounts:
   - name: "default"
     password:
-    port: 
-    secure: 
-    server: 
-    smtp_auth: 
-    username: 
+    port:
+    secure:
+    server:
+    smtp_auth:
+    username:
 max_attachment_size: 1024
 attachment_datastore_ttl: 1800


### PR DESCRIPTION
### Description:

- Added in `project.search.by.regex.yaml` to search projects by regex

### Notes:
- The only properties that you can search by are `name` and `description` as they are the only options in `mappings/project_mapping.py`
- I am unable to test this on dev as there is a pagination error that I have raised with Anish who suggested that it can be tested on prod. 
---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
