### PR TITLE
BUG: fix lib_entry_point default for server datetime search action

### DIFF
--- a/actions/server.search.by.datetime.yaml
+++ b/actions/server.search.by.datetime.yaml
@@ -7,7 +7,7 @@ parameters:
   timeout:
     default: 5400
   lib_entry_point:
-    default: workflows.search_by_datetime_search_by_datetime
+    default: workflows.search_by_datetime.search_by_datetime
     immutable: true
     type: string
   query_type:


### PR DESCRIPTION
### Description:
Changed lib_entry_point default in server.search.by.datetime parameters since StackStorm earlier used to output:
```
AttributeError: module 'workflows' has no attribute 'search_by_datetime_search_by_datetime'
```  
when running the action. 

This addresses that issue. However, further issues still exist:
1. `group_by` is listed as optional but is required for the action to start running
2. Currently running anything shows `parse_meta_params() got an unexpected keyword argument 'limit_by_projects'` as an error.

So I am currently creating a draft pull request for this.
---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
