### PR TITLE
BUG: Fix actions when group_by is null

### DIFF
--- a/actions/server.search.by.datetime.yaml
+++ b/actions/server.search.by.datetime.yaml
@@ -124,6 +124,7 @@ parameters:
     required: false
     default: null
     enum:
+      - null
       - 'flavor_id'
       - 'hypervisor_id'
       - 'image_id'

--- a/actions/server.search.by.property.yaml
+++ b/actions/server.search.by.property.yaml
@@ -112,6 +112,7 @@ parameters:
     required: false
     default: null
     enum:
+      - null
       - 'flavor_id'
       - 'hypervisor_id'
       - 'image_id'

--- a/actions/server.search.by.regex.yaml
+++ b/actions/server.search.by.regex.yaml
@@ -104,6 +104,7 @@ parameters:
     required: false
     default: null
     enum:
+      - null
       - 'flavor_id'
       - 'hypervisor_id'
       - 'image_id'

--- a/actions/user.search.by.property.yaml
+++ b/actions/user.search.by.property.yaml
@@ -93,6 +93,7 @@ parameters:
     required: false
     default: null
     enum:
+      - null
       - "user_domain_id"
       - "user_description"
       - "user_name"

--- a/actions/user.search.by.regex.yaml
+++ b/actions/user.search.by.regex.yaml
@@ -85,6 +85,7 @@ parameters:
     required: false
     default: null
     enum:
+      - null
       - "user_domain_id"
       - "user_description"
       - "user_name"


### PR DESCRIPTION
Add null as an option for group_by, fixes error that null is not an option when no group_by is selected

### Description:
Add null as an option for group_by, fixes error that null is not an option when no group_by is selected

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
