### PR TITLE
ENH: Add webhook output to search actions

### DIFF
--- a/actions/hv.search.by.expression.yaml
+++ b/actions/hv.search.by.expression.yaml
@@ -157,4 +157,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/hv.search.by.regex.yaml
+++ b/actions/hv.search.by.regex.yaml
@@ -153,4 +153,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/project.search.by.property.yaml
+++ b/actions/project.search.by.property.yaml
@@ -120,4 +120,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/project.search.by.regex.yaml
+++ b/actions/project.search.by.regex.yaml
@@ -103,4 +103,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/server.search.by.datetime.yaml
+++ b/actions/server.search.by.datetime.yaml
@@ -155,4 +155,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/server.search.by.property.yaml
+++ b/actions/server.search.by.property.yaml
@@ -143,4 +143,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/server.search.by.regex.yaml
+++ b/actions/server.search.by.regex.yaml
@@ -135,4 +135,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/user.search.by.property.yaml
+++ b/actions/user.search.by.property.yaml
@@ -110,4 +110,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/actions/user.search.by.regex.yaml
+++ b/actions/user.search.by.regex.yaml
@@ -102,4 +102,9 @@ parameters:
     type: array
     required: false
     default: null
+  webhook:
+    description: "Optional string representing a stackstorm webhook url path, can't be used alongside group_by"
+    default: null
+    type: string
+    required: false
 runner_type: python-script

--- a/lib/workflows/search_by_datetime.py
+++ b/lib/workflows/search_by_datetime.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from enums.query.query_presets import QueryPresetsDateTime
 from enums.query.sort_order import SortOrder
 import openstack_query
+from workflows.to_webhook import to_webhook
 
 # pylint:disable=too-many-arguments
 
@@ -19,6 +20,7 @@ def search_by_datetime(
     output_type: str = "to_string",
     group_by: Optional[str] = None,
     sort_by: Optional[List[str]] = None,
+    webhook: Optional[str] = None,
     **kwargs,
 ):
     """
@@ -38,6 +40,7 @@ def search_by_datetime(
     :param output_type: string representing how to output the query
     :param group_by: an optional string representing a property to group results by
     :param sort_by: an optional set of tuples representing way which properties to sort results by
+    :param webhook: an Optional string representing a stackstorm webhook url path, can't be used alongside group_by
     :param kwargs: A set of optional meta params to pass to the query
     """
     if all(x <= 0 for x in [days, minutes, seconds, hours]):
@@ -67,6 +70,10 @@ def search_by_datetime(
         query.group_by(group_by)
 
     query.run(cloud_account, **kwargs)
+
+    if webhook:
+        to_webhook(webhook=webhook, payload=query.to_props())
+
     return {
         "to_html": query.to_html(),
         "to_string": query.to_string(),

--- a/lib/workflows/search_by_expression.py
+++ b/lib/workflows/search_by_expression.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from enums.query.query_presets import QueryPresetsInteger
 from enums.query.sort_order import SortOrder
 import openstack_query
+from workflows.to_webhook import to_webhook
 
 # pylint:disable=too-many-arguments
 
@@ -16,6 +17,7 @@ def search_by_expression(
     output_type: Optional[str] = None,
     group_by: Optional[str] = None,
     sort_by: Optional[List[str]] = None,
+    webhook: Optional[str] = None,
     **kwargs
 ):
     """
@@ -35,6 +37,7 @@ def search_by_expression(
     :param output_type: string representing how to output the query
     :param group_by: an optional string representing a property to group results by
     :param sort_by: an optional set of tuples representing way which properties to sort results by
+    :param webhook: an Optional string representing a stackstorm webhook url path, can't be used alongside group_by
     :param kwargs: A set of optional meta params to pass to the query
     """
 
@@ -56,6 +59,10 @@ def search_by_expression(
         query.group_by(group_by)
 
     query.run(cloud_account, **kwargs)
+
+    if webhook:
+        to_webhook(webhook=webhook, payload=query.to_props())
+
     return {
         "to_html": query.to_html(),
         "to_string": query.to_string(),

--- a/lib/workflows/search_by_property.py
+++ b/lib/workflows/search_by_property.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from enums.query.query_presets import QueryPresetsGeneric
 from enums.query.sort_order import SortOrder
 import openstack_query
+from workflows.to_webhook import to_webhook
 
 # pylint:disable=too-many-arguments
 
@@ -16,6 +17,7 @@ def search_by_property(
     output_type: Optional[str] = None,
     group_by: Optional[str] = None,
     sort_by: Optional[List[str]] = None,
+    webhook: Optional[str] = None,
     **kwargs
 ):
     """
@@ -32,6 +34,7 @@ def search_by_property(
     :param output_type: string representing how to output the query
     :param group_by: an optional string representing a property to group results by
     :param sort_by: an optional set of tuples representing way which properties to sort results by
+    :param webhook: an Optional string representing a stackstorm webhook url path, can't be used alongside group_by
     :param kwargs: A set of optional meta params to pass to the query
     """
 
@@ -56,6 +59,10 @@ def search_by_property(
         query.group_by(group_by)
 
     query.run(cloud_account, **kwargs)
+
+    if webhook:
+        to_webhook(webhook=webhook, payload=query.to_props())
+
     return {
         "to_html": query.to_html(),
         "to_string": query.to_string(),

--- a/lib/workflows/search_by_regex.py
+++ b/lib/workflows/search_by_regex.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from enums.query.query_presets import QueryPresetsString
 from enums.query.sort_order import SortOrder
 import openstack_query
+from workflows.to_webhook import to_webhook
 
 # pylint:disable=too-many-arguments
 
@@ -15,6 +16,7 @@ def search_by_regex(
     output_type: Optional[str] = None,
     group_by: Optional[str] = None,
     sort_by: Optional[List[str]] = None,
+    webhook: Optional[str] = None,
     **kwargs,
 ):
     """
@@ -27,6 +29,7 @@ def search_by_regex(
     :param output_type: string representing how to output the query
     :param group_by: an optional string representing a property to group results by
     :param sort_by: an optional set of tuples representing way which properties to sort results by
+    :param webhook: an Optional string representing a stackstorm webhook url path, can't be used alongside group_by
     :param kwargs: A set of optional meta params to pass to the query
     """
 
@@ -48,6 +51,10 @@ def search_by_regex(
         query.group_by(group_by)
 
     query.run(cloud_account, **kwargs)
+
+    if webhook:
+        to_webhook(webhook=webhook, payload=query.to_props())
+
     return {
         "to_html": query.to_html(),
         "to_string": query.to_string(),

--- a/lib/workflows/to_webhook.py
+++ b/lib/workflows/to_webhook.py
@@ -1,0 +1,24 @@
+import json
+import os
+from typing import Dict, List
+import requests
+
+
+def to_webhook(webhook: str, payload: List[Dict]) -> None:
+    """
+    Send post request to a stackstorm webhook
+    :param webhook: Webhook url path
+    :param payload: Data to send to webhook
+    """
+    webhook_url = f'{os.environ["ST2_ACTION_API_URL"]}/webhooks/{webhook}'
+
+    for data in payload:
+        res = requests.post(
+            url=webhook_url,
+            headers={"X-Auth-Token": os.environ["ST2_ACTION_AUTH_TOKEN"]},
+            timeout=300,
+            data=json.dumps(data),
+            verify=False,
+        )
+        if not res.status_code == 202:
+            raise requests.exceptions.HTTPError(res)

--- a/tests/lib/workflows/test_search_by_datetime.py
+++ b/tests/lib/workflows/test_search_by_datetime.py
@@ -69,12 +69,15 @@ def test_search_by_datetime_errors_when_args_all_zero():
         )
 
 
+@patch("workflows.search_by_datetime.to_webhook")
 @patch("workflows.search_by_datetime.openstack_query")
 @patch("workflows.search_by_datetime.QueryPresetsDateTime")
 @pytest.mark.parametrize(
     "output_type", ["to_html", "to_string", "to_objects", "to_props"]
 )
-def test_search_by_datetime_all(mock_preset_enum, mock_openstack_query, output_type):
+def test_search_by_datetime_all(
+    mock_preset_enum, mock_openstack_query, mock_to_webhook, output_type
+):
     """
     Runs search_by_datetime providing all available params
     """
@@ -93,6 +96,7 @@ def test_search_by_datetime_all(mock_preset_enum, mock_openstack_query, output_t
         "days": 1,
         "group_by": NonCallableMock(),
         "sort_by": ["prop1", "prop2"],
+        "webhook": "test",
         "arg1": "val1",
         "arg2": "val2",
     }
@@ -115,6 +119,9 @@ def test_search_by_datetime_all(mock_preset_enum, mock_openstack_query, output_t
     mock_query.group_by.assert_called_once_with(params["group_by"])
     mock_query.run.assert_called_once_with(
         params["cloud_account"], arg1="val1", arg2="val2"
+    )
+    mock_to_webhook.assert_called_once_with(
+        webhook="test", payload=mock_query.to_props.return_value
     )
 
     assert (

--- a/tests/lib/workflows/test_search_by_expression.py
+++ b/tests/lib/workflows/test_search_by_expression.py
@@ -50,12 +50,15 @@ def test_search_by_expression_minimal(
     )
 
 
+@patch("workflows.search_by_expression.to_webhook")
 @patch("workflows.search_by_expression.openstack_query")
 @patch("workflows.search_by_expression.QueryPresetsInteger")
 @pytest.mark.parametrize(
     "output_type", ["to_html", "to_string", "to_objects", "to_props"]
 )
-def test_search_by_expression_all(mock_preset_enum, mock_openstack_query, output_type):
+def test_search_by_expression_all(
+    mock_preset_enum, mock_openstack_query, mock_to_webhook, output_type
+):
     """
     Runs search_by_expression providing all available params
     """
@@ -74,6 +77,7 @@ def test_search_by_expression_all(mock_preset_enum, mock_openstack_query, output
         "value": 1,
         "group_by": NonCallableMock(),
         "sort_by": ["prop1", "prop2"],
+        "webhook": "test",
         "arg1": "val1",
         "arg2": "val2",
     }
@@ -91,6 +95,9 @@ def test_search_by_expression_all(mock_preset_enum, mock_openstack_query, output
     mock_query.group_by.assert_called_once_with(params["group_by"])
     mock_query.run.assert_called_once_with(
         params["cloud_account"], arg1="val1", arg2="val2"
+    )
+    mock_to_webhook.assert_called_once_with(
+        webhook="test", payload=mock_query.to_props.return_value
     )
 
     assert (

--- a/tests/lib/workflows/test_search_by_property.py
+++ b/tests/lib/workflows/test_search_by_property.py
@@ -65,12 +65,15 @@ def test_search_by_property_errors_when_no_values_given():
         )
 
 
+@patch("workflows.search_by_property.to_webhook")
 @patch("workflows.search_by_property.openstack_query")
 @patch("workflows.search_by_property.QueryPresetsGeneric")
 @pytest.mark.parametrize(
     "output_type", ["to_html", "to_string", "to_objects", "to_props"]
 )
-def test_search_by_property_all(mock_preset_enum, mock_openstack_query, output_type):
+def test_search_by_property_all(
+    mock_preset_enum, mock_openstack_query, mock_to_webhook, output_type
+):
     """
     Runs search_by_property providing all values
     """
@@ -89,6 +92,7 @@ def test_search_by_property_all(mock_preset_enum, mock_openstack_query, output_t
         "values": ["val1", "val2"],
         "group_by": NonCallableMock(),
         "sort_by": ["prop1", "prop2"],
+        "webhook": "test",
         "arg1": "val1",
         "arg2": "val2",
     }
@@ -106,6 +110,9 @@ def test_search_by_property_all(mock_preset_enum, mock_openstack_query, output_t
     mock_query.group_by.assert_called_once_with(params["group_by"])
     mock_query.run.assert_called_once_with(
         params["cloud_account"], arg1="val1", arg2="val2"
+    )
+    mock_to_webhook.assert_called_once_with(
+        webhook="test", payload=mock_query.to_props.return_value
     )
 
     assert (

--- a/tests/lib/workflows/test_search_by_regex.py
+++ b/tests/lib/workflows/test_search_by_regex.py
@@ -47,11 +47,12 @@ def test_search_by_regex_minimal(mock_openstack_query, output_type):
     )
 
 
+@patch("workflows.search_by_regex.to_webhook")
 @patch("workflows.search_by_regex.openstack_query")
 @pytest.mark.parametrize(
     "output_type", ["to_html", "to_string", "to_objects", "to_props"]
 )
-def test_search_by_regex_all(mock_openstack_query, output_type):
+def test_search_by_regex_all(mock_openstack_query, mock_to_webhook, output_type):
     """
     Runs search_by_regex providing all values
     """
@@ -69,6 +70,7 @@ def test_search_by_regex_all(mock_openstack_query, output_type):
         "pattern": NonCallableMock(),
         "group_by": NonCallableMock(),
         "sort_by": ["prop1", "prop2"],
+        "webhook": "test",
         "arg1": "val1",
         "arg2": "val2",
     }
@@ -86,6 +88,9 @@ def test_search_by_regex_all(mock_openstack_query, output_type):
     mock_query.group_by.assert_called_once_with(params["group_by"])
     mock_query.run.assert_called_once_with(
         params["cloud_account"], arg1="val1", arg2="val2"
+    )
+    mock_to_webhook.assert_called_once_with(
+        webhook="test", payload=mock_query.to_props.return_value
     )
 
     assert (

--- a/tests/lib/workflows/test_to_webhook.py
+++ b/tests/lib/workflows/test_to_webhook.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch, MagicMock
+import os
+import json
+
+import pytest
+import requests
+from workflows.to_webhook import to_webhook
+
+
+@patch.dict(
+    os.environ,
+    {"ST2_ACTION_API_URL": "http://example.com", "ST2_ACTION_AUTH_TOKEN": "fake_token"},
+)
+@patch("requests.post")
+def test_to_webhook_success(mock_post):
+    """
+    Test post is called with the correct parameters
+    """
+    webhook = "test_webhook"
+    payload = [{"key1": "value1"}, {"key2": "value2"}]
+    mock_response = MagicMock()
+    mock_response.status_code = 202
+    mock_post.return_value = mock_response
+
+    to_webhook(webhook, payload)
+
+    assert mock_post.call_count == 2
+
+    mock_post.assert_any_call(
+        url="http://example.com/webhooks/test_webhook",
+        headers={"X-Auth-Token": "fake_token"},
+        timeout=300,
+        data=json.dumps({"key1": "value1"}),
+        verify=False,
+    )
+    mock_post.assert_any_call(
+        url="http://example.com/webhooks/test_webhook",
+        headers={"X-Auth-Token": "fake_token"},
+        timeout=300,
+        data=json.dumps({"key2": "value2"}),
+        verify=False,
+    )
+
+
+@patch.dict(
+    os.environ,
+    {"ST2_ACTION_API_URL": "http://example.com", "ST2_ACTION_AUTH_TOKEN": "fake_token"},
+)
+@patch("workflows.to_webhook.requests.post")
+def test_to_webhook_failure(mock_post):
+    """
+    Test exception is raised if post request doesn't succeed
+    """
+    webhook = "test_webhook"
+    payload = [{"key1": "value1"}, {"key2": "value2"}]
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_post.return_value = mock_response
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        to_webhook(webhook, payload)


### PR DESCRIPTION
### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->
Add to_webhook output which sends the results of a search action to a webhook. 
This will allow the output of a search action to send triggers for each item in the results to a webhook which will create a trigger to start other actions.

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
