### PR TITLE
ENH: Added rule to start the patch reboot workflow

### DIFF
--- a/rules/hv.patch.reboot.yaml
+++ b/rules/hv.patch.reboot.yaml
@@ -1,0 +1,23 @@
+---
+name: "hv.patch.reboot"
+pack: "stackstorm_openstack"
+description: "Starts the patch reboot action when the hypervisor is drained"
+enabled: true
+
+criteria:
+  trigger.previous_state:
+    type: equals
+    pattern: DRAINING
+  trigger.current_state:
+    type: equals
+    pattern: DRAINED
+
+trigger:
+  type: "stackstorm_openstack.hypervisor.state_change"
+
+action:
+  ref: "stackstorm_openstack.hv.patch.reboot"
+  parameters:
+    icinga_account_name: "default"
+    hypervisor_name: "{{ trigger.hypervisor_name }}"
+    private_key_path: "/home/stanley/.ssh/id_rsa"


### PR DESCRIPTION
### Description:

Added a rule which starts the `hv.patch.reboot` action when the trigger `hypervisor_state_change` changes for a HV from "DRAINING" to "DRAINED"

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
