### PR TITLE
BUG: group by does not accept default of null

### DIFF
--- a/actions/project.search.by.property.yaml
+++ b/actions/project.search.by.property.yaml
@@ -105,6 +105,7 @@ parameters:
       - "is_enabled"
       - "name"
       - "parent_id"
+      - "null"
   sort_by:
     description: "(Optional) comma-spaced list of project properties to sort by (by ascending only)
     - multiple of the same property will be ignored.

--- a/actions/project.search.by.property.yaml
+++ b/actions/project.search.by.property.yaml
@@ -105,7 +105,7 @@ parameters:
       - "is_enabled"
       - "name"
       - "parent_id"
-      - "null"
+      - null
   sort_by:
     description: "(Optional) comma-spaced list of project properties to sort by (by ascending only)
     - multiple of the same property will be ignored.


### PR DESCRIPTION


### Description:

Action fails to run with default values as null is not an accepted value, adding "null" to the list of Enums fixes this.

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
