### PR TITLE
ENH: Add restrictions to automatic migrations

### DIFF
--- a/actions/server.migrate.yaml
+++ b/actions/server.migrate.yaml
@@ -30,6 +30,10 @@ parameters:
     type: string
     required: true
     description: Status of the server to migrate
+  flavor_id:
+    type: string
+    required: true
+    description: Flavor of the server to migrate
   dest_host:
     type: string
     required: false

--- a/lib/openstack_api/openstack_server.py
+++ b/lib/openstack_api/openstack_server.py
@@ -8,6 +8,7 @@ def snapshot_and_migrate_server(
     conn: Connection,
     server_id: str,
     server_status: str,
+    flavor_id: str,
     snapshot: bool,
     dest_host: Optional[str] = None,
 ) -> None:
@@ -16,8 +17,15 @@ def snapshot_and_migrate_server(
     :param conn: Openstack Connection
     :param server_id: Server ID to migrate
     :param server_status: Status of machine to migrate - must be ACTIVE or SHUTOFF
+    :param flavor_name: Server flavor name
     :param dest_host: Optional host to migrate to, otherwise chosen by scheduler
     """
+
+    if flavor_id.startswith("g-"):
+        raise ValueError(
+            f"Attempted to move GPU flavor, {flavor_id}, which is not allowed!"
+        )
+
     if server_status not in ["ACTIVE", "SHUTOFF"]:
         raise ValueError(
             f"Server status: {server_status}. The server must be ACTIVE or SHUTOFF to be migrated"

--- a/lib/workflows/icinga_downtime.py
+++ b/lib/workflows/icinga_downtime.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytz
 
+from enums.icinga.icinga_objects import IcingaObject
 from structs.icinga.downtime_details import DowntimeDetails
 from structs.icinga.icinga_account import IcingaAccount
 
@@ -34,7 +35,7 @@ def schedule_downtime(
     end_timestamp = int(utc_end_time.timestamp())
 
     downtime_details = DowntimeDetails(
-        object_type=object_type,
+        object_type=IcingaObject[object_type.upper()],
         object_name=name,
         start_time=start_timestamp,
         end_time=end_timestamp,
@@ -50,6 +51,6 @@ def remove_downtime(icinga_account: IcingaAccount, object_type: str, name: str):
 
     downtime.remove_downtime(
         icinga_account=icinga_account,
-        object_type=object_type,
+        object_type=IcingaObject[object_type.upper()],
         object_name=name,
     )

--- a/policies/migrate_server_policy.yaml
+++ b/policies/migrate_server_policy.yaml
@@ -1,0 +1,9 @@
+name: migrate.server.concurrency
+pack: stackstorm_openstack
+description: Limits the concurrent migrate server executions
+enabled: true
+resource_ref: stackstorm_openstack.server.migrate
+policy_type: action.concurrency
+parameters:
+  action: delay
+  threshold: 1

--- a/rules/webhook.server.migrate.yaml
+++ b/rules/webhook.server.migrate.yaml
@@ -19,3 +19,4 @@ action:
   parameters:
     server_id: "{{ trigger.body.server_id }}"
     server_status: "{{ trigger.body.server_status }}"
+    flavor_id: "{{ trigger.body.flavor_id }}"

--- a/rules/webhook.server.migrate.yaml
+++ b/rules/webhook.server.migrate.yaml
@@ -10,9 +10,19 @@ trigger:
     url: "migrate-server"
 
 criteria:
-  trigger.body.flavor_id:
+  # Whitelist for groups of flavors
+  # e.g. pattern (^l3.*)|(^l2.*) allows migraion of l3 and l2 flavors
+  trigger.body.flavor_id#1:
     type: regex
     pattern: (^l3.*)|(^l2.*)
+
+  # Blacklist specific flavors from migration
+  # e.g. pattern ["l2.tiny", "l3.large"] will prevent migrations of those flavors
+  # specifically but not all l2 and l3 flavors. Flavors here can still be migrated
+  # manually using the stackstorm_openstack.server.migrate action
+  trigger.body.flavor_id#2:
+    type: ninside
+    pattern: ["l3.micro"]
 
 action:
   ref: "stackstorm_openstack.server.migrate"

--- a/rules/webhook.server.migrate.yaml
+++ b/rules/webhook.server.migrate.yaml
@@ -11,8 +11,8 @@ trigger:
 
 criteria:
   trigger.body.flavor_id:
-    type: inside
-    pattern: ["l3.nano"]
+    type: regex
+    pattern: (^l3.*)|(^l2.*)
 
 action:
   ref: "stackstorm_openstack.server.migrate"

--- a/rules/webhook.server.migrate.yaml
+++ b/rules/webhook.server.migrate.yaml
@@ -9,6 +9,11 @@ trigger:
   parameters:
     url: "migrate-server"
 
+criteria:
+  trigger.body.flavor_id:
+    type: inside
+    pattern: ["l3.nano"]
+
 action:
   ref: "stackstorm_openstack.server.migrate"
   parameters:

--- a/tests/lib/openstack_api/test_openstack_server.py
+++ b/tests/lib/openstack_api/test_openstack_server.py
@@ -13,12 +13,12 @@ def test_active_migration(mock_snapshot_server, dest_host):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "ACTIVE"
-    mock_flavor_name = "mock_flavor"
+    mock_flavor_id = "mock_flavor"
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
         server_status=mock_server_status,
-        flavor_name=mock_flavor_name,
+        flavor_id=mock_flavor_id,
         dest_host=dest_host,
         snapshot=True,
     )
@@ -40,12 +40,12 @@ def test_shutoff_migration(mock_snapshot_server, dest_host):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "SHUTOFF"
-    mock_flavor_name = "mock_flavor"
+    mock_flavor_id = "mock_flavor"
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
         server_status=mock_server_status,
-        flavor_name=mock_flavor_name,
+        flavor_id=mock_flavor_id,
         dest_host=dest_host,
         snapshot=True,
     )
@@ -66,12 +66,12 @@ def test_no_snapshot_migration(mock_snapshot_server):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "ACTIVE"
-    mock_flavor_name = "mock_flavor"
+    mock_flavor_id = "mock_flavor"
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
         server_status=mock_server_status,
-        flavor_name=mock_flavor_name,
+        flavor_id=mock_flavor_id,
         snapshot=False,
     )
     mock_snapshot_server.assert_not_called()
@@ -85,7 +85,7 @@ def test_migration_fail(mock_snapshot_server):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "TEST"
-    mock_flavor_name = "mock_flavor"
+    mock_flavor_id = "mock_flavor"
     with pytest.raises(
         ValueError,
         match="Server status: TEST. The server must be ACTIVE or SHUTOFF to be migrated",
@@ -94,7 +94,7 @@ def test_migration_fail(mock_snapshot_server):
             conn=mock_connection,
             server_id=mock_server_id,
             server_status=mock_server_status,
-            flavor_name=mock_flavor_name,
+            flavor_id=mock_flavor_id,
             snapshot=True,
         )
     mock_snapshot_server.assert_not_called()
@@ -135,14 +135,14 @@ def test_block_gpu_migration():
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "SHUTOFF"
-    mock_flavor_name = "g-a100-80gb-2022.x2"
+    mock_flavor_id = "g-a100-80gb-2022.x2"
 
     with pytest.raises(ValueError):
         snapshot_and_migrate_server(
             conn=mock_connection,
             server_id=mock_server_id,
             server_status=mock_server_status,
-            flavor_name=mock_flavor_name,
+            flavor_id=mock_flavor_id,
             dest_host=None,
             snapshot=True,
         )

--- a/tests/lib/openstack_api/test_openstack_server.py
+++ b/tests/lib/openstack_api/test_openstack_server.py
@@ -13,10 +13,12 @@ def test_active_migration(mock_snapshot_server, dest_host):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "ACTIVE"
+    mock_flavor_name = "mock_flavor"
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
         server_status=mock_server_status,
+        flavor_name=mock_flavor_name,
         dest_host=dest_host,
         snapshot=True,
     )
@@ -38,10 +40,12 @@ def test_shutoff_migration(mock_snapshot_server, dest_host):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "SHUTOFF"
+    mock_flavor_name = "mock_flavor"
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
         server_status=mock_server_status,
+        flavor_name=mock_flavor_name,
         dest_host=dest_host,
         snapshot=True,
     )
@@ -62,10 +66,12 @@ def test_no_snapshot_migration(mock_snapshot_server):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "ACTIVE"
+    mock_flavor_name = "mock_flavor"
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
         server_status=mock_server_status,
+        flavor_name=mock_flavor_name,
         snapshot=False,
     )
     mock_snapshot_server.assert_not_called()
@@ -79,6 +85,7 @@ def test_migration_fail(mock_snapshot_server):
     mock_connection = MagicMock()
     mock_server_id = "server1"
     mock_server_status = "TEST"
+    mock_flavor_name = "mock_flavor"
     with pytest.raises(
         ValueError,
         match="Server status: TEST. The server must be ACTIVE or SHUTOFF to be migrated",
@@ -87,6 +94,7 @@ def test_migration_fail(mock_snapshot_server):
             conn=mock_connection,
             server_id=mock_server_id,
             server_status=mock_server_status,
+            flavor_name=mock_flavor_name,
             snapshot=True,
         )
     mock_snapshot_server.assert_not_called()
@@ -121,3 +129,20 @@ def test_snapshot_server():
     mock_connection.image.update_image.assert_called_once_with(
         mock_image, owner=mock_project_id
     )
+
+
+def test_block_gpu_migration():
+    mock_connection = MagicMock()
+    mock_server_id = "server1"
+    mock_server_status = "SHUTOFF"
+    mock_flavor_name = "g-a100-80gb-2022.x2"
+
+    with pytest.raises(ValueError):
+        snapshot_and_migrate_server(
+            conn=mock_connection,
+            server_id=mock_server_id,
+            server_status=mock_server_status,
+            flavor_name=mock_flavor_name,
+            dest_host=None,
+            snapshot=True,
+        )

--- a/tests/lib/workflows/test_icinga_downtime.py
+++ b/tests/lib/workflows/test_icinga_downtime.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime
 import pytest
 import pytz
+from enums.icinga.icinga_objects import IcingaObject
 from workflows.icinga_downtime import schedule_downtime, remove_downtime
 from structs.icinga.downtime_details import DowntimeDetails
 
@@ -49,7 +50,7 @@ def test_schedule_fixed_downtime(
     )
 
     expected_downtime_details = DowntimeDetails(
-        object_type=object_type,
+        object_type=IcingaObject.HOST,
         object_name=name,
         start_time=expected_start_timestamp,
         end_time=expected_end_timestamp,
@@ -107,7 +108,7 @@ def test_schedule_flexible_downtime(
     )
 
     expected_downtime_details = DowntimeDetails(
-        object_type=object_type,
+        object_type=IcingaObject.HOST,
         object_name=name,
         start_time=expected_start_timestamp,
         end_time=expected_end_timestamp,
@@ -130,5 +131,7 @@ def test_remove_downtime(mock_remove_downtime):
     remove_downtime(icinga_account, object_type, name)
 
     mock_remove_downtime.assert_called_once_with(
-        icinga_account=icinga_account, object_type=object_type, object_name=name
+        icinga_account=icinga_account,
+        object_type=IcingaObject.HOST,
+        object_name=name,
     )


### PR DESCRIPTION
### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

- Prevents any migration of GPU (g-*) flavors, this applies to all migration actions
- Blacklist and Whitelist flavor able to be migrated through the migration webhook, these flavors can still be migrated by running the action manually
- Add a concurrency policy to limit the number of concurrent migrations running at a time
- Fix icinga downtime action

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
