### PR TITLE
Fix HV state bug

### DIFF
--- a/actions/hv.search.by.property.yaml
+++ b/actions/hv.search.by.property.yaml
@@ -42,6 +42,7 @@ parameters:
       - "vcpus"
       - "vcpus_used"
       - "disabled_reason"
+      - "uptime"
     type: array
     description: "
     A comma-spaced list of server properties to display for the resulting hypervisors - leave empty for all properties. One of:
@@ -59,6 +60,7 @@ parameters:
       - 'vcpus'
       - 'vcpus_used'
       - 'disabled_reason'
+      - 'uptime'
     Anything else will raise an error"
     required: false
   output_type:
@@ -94,6 +96,7 @@ parameters:
       - "vcpus"
       - "vcpus_used"
       - "disabled_reason"
+      - "uptime"
     type: string
     required: true
   search_mode:
@@ -125,6 +128,7 @@ parameters:
       - 'vcpus'
       - 'vcpus_used'
       - 'disabled_reason'
+      - 'uptime'
     Anything else will raise an error"
     type: string
     required: false
@@ -147,6 +151,7 @@ parameters:
       - 'vcpus'
       - 'vcpus_used'
       - 'disabled_reason'
+      - 'uptime'
     Anything else will raise an error"
     type: array
     required: false

--- a/lib/enums/hypervisor_states.py
+++ b/lib/enums/hypervisor_states.py
@@ -12,12 +12,6 @@ class HypervisorState(Enum):
         "state": True,
         "servers": True,
     }
-    PENDING_MAINTENANCE = {
-        "uptime": False,
-        "enabled": True,
-        "state": True,
-        "servers": True,
-    }
     DRAINING = {
         "uptime": False,
         "enabled": False,
@@ -42,6 +36,7 @@ class HypervisorState(Enum):
         "state": True,
         "servers": False,
     }
+    PENDING_MAINTENANCE = auto()
     DOWN = auto()
     UNKNOWN = auto()
 

--- a/lib/openstack_api/openstack_hypervisor.py
+++ b/lib/openstack_api/openstack_hypervisor.py
@@ -13,6 +13,8 @@ def get_hypervisor_state(hypervisor: Dict, uptime_limit: int) -> HypervisorState
         return HypervisorState.DOWN
     if not valid_state(hypervisor):
         return HypervisorState.UNKNOWN
+    if hypervisor["hypervisor_uptime_days"] > uptime_limit:
+        return HypervisorState.PENDING_MAINTENANCE
     hv_state = {
         "uptime": hypervisor["hypervisor_uptime_days"] < uptime_limit,
         "enabled": hypervisor["hypervisor_status"] == "enabled",

--- a/lib/openstack_api/openstack_hypervisor.py
+++ b/lib/openstack_api/openstack_hypervisor.py
@@ -13,7 +13,10 @@ def get_hypervisor_state(hypervisor: Dict, uptime_limit: int) -> HypervisorState
         return HypervisorState.DOWN
     if not valid_state(hypervisor):
         return HypervisorState.UNKNOWN
-    if hypervisor["hypervisor_uptime_days"] > uptime_limit:
+    if (
+        hypervisor["hypervisor_uptime_days"] > uptime_limit
+        and hypervisor["hypervisor_status"] == "enabled"
+    ):
         return HypervisorState.PENDING_MAINTENANCE
     hv_state = {
         "uptime": hypervisor["hypervisor_uptime_days"] < uptime_limit,

--- a/tests/lib/openstack_api/test_openstack_hypervisor.py
+++ b/tests/lib/openstack_api/test_openstack_hypervisor.py
@@ -17,16 +17,27 @@ def test_get_state_running():
     assert state == HypervisorState.RUNNING
 
 
-def test_get_state_pending_maintenance():
+@pytest.mark.parametrize(
+    "hypervisor",
+    [
+        {
+            "hypervisor_uptime_days": 70,
+            "hypervisor_status": "enabled",
+            "hypervisor_state": "up",
+            "hypervisor_server_count": 0,
+        },
+        {
+            "hypervisor_uptime_days": 100,
+            "hypervisor_status": "enabled",
+            "hypervisor_state": "up",
+            "hypervisor_server_count": 12,
+        },
+    ],
+)
+def test_get_state_pending_maintenance(hypervisor):
     """
-    Test hypervisor state is pending maintenace for given variables
+    Test hypervisor state is pending maintenace for given variables, even if the hv is empty
     """
-    hypervisor = {
-        "hypervisor_uptime_days": 100,
-        "hypervisor_status": "enabled",
-        "hypervisor_state": "up",
-        "hypervisor_server_count": 5,
-    }
     state = get_hypervisor_state(hypervisor, 60)
     assert state == HypervisorState.PENDING_MAINTENANCE
 


### PR DESCRIPTION
### Description:
- Added in the PENDING_MAINTENANCE enum to be determined before EMPTY. 
- Added the uptime option to the `hv.search.by.property` action
 
---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
