### PR TITLE
Move JiraConnection to a separate file

### DIFF
--- a/lib/jira_api/connection.py
+++ b/lib/jira_api/connection.py
@@ -1,0 +1,27 @@
+import jira
+from structs.jira.jira_account import JiraAccount
+
+
+class JiraConnection:
+    """
+    Wrapper for Jira connection
+    """
+
+    def __init__(self, account: JiraAccount):
+        self.conn = None
+        self.endpoint = account.atlassian_endpoint
+        self.token = account.api_token
+        self.username = account.username
+
+    def __enter__(self):
+        self.conn = jira.client.JIRA(
+            server=self.endpoint,
+            basic_auth=(
+                self.username,
+                self.token,
+            ),
+        )
+        return self.conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.conn.close()

--- a/lib/jira_api/jira_issue.py
+++ b/lib/jira_api/jira_issue.py
@@ -1,32 +1,6 @@
-import jira
 from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
-from structs.jira.jira_account import JiraAccount
 from structs.jira.jira_issue_details import IssueDetails
-
-
-class JiraConnection:
-    """
-    Wrapper for Jira connection
-    """
-
-    def __init__(self, account: JiraAccount):
-        self.conn = None
-        self.endpoint = account.atlassian_endpoint
-        self.token = account.api_token
-        self.username = account.username
-
-    def __enter__(self):
-        self.conn = jira.client.JIRA(
-            server=self.endpoint,
-            basic_auth=(
-                self.username,
-                self.token,
-            ),
-        )
-        return self.conn
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.conn.close()
+from jira_api.connection import JiraConnection
 
 
 def create_jira_task(account, issue_details: IssueDetails) -> str:

--- a/tests/lib/jira_api/test_connection.py
+++ b/tests/lib/jira_api/test_connection.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock, patch
+from jira_api.jira_issue import JiraConnection
+
+
+def test_jira_connection():
+    """
+    Tests a client to connect to a atlassian server is created and closed
+    """
+    with patch("jira.client.JIRA") as mock_jira:
+        mock_account = MagicMock()
+        mock_account.atlassian_endpoint = "https://example.atlassian.net/"
+        mock_account.username = "foo"
+        mock_account.api_token = "bar"
+
+        # Use the JiraConnection class in a with statement
+        with JiraConnection(mock_account) as conn:
+            # Check if the JIRA instance was created with the correct parameters
+            mock_jira.assert_called_once_with(
+                server="https://example.atlassian.net/", basic_auth=("foo", "bar")
+            )
+            # Check if the connection object is the mock JIRA instance
+            assert conn == mock_jira.return_value

--- a/tests/lib/jira_api/test_jira_issue.py
+++ b/tests/lib/jira_api/test_jira_issue.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
-from jira_api.jira_issue import create_jira_task, JiraConnection
+from jira_api.jira_issue import create_jira_task
 
 
 def test_create_jira_task_project_id_throws():
@@ -45,26 +45,6 @@ def test_create_jira_task_description_throws():
     mock_account = MagicMock()
     with pytest.raises(MissingMandatoryParamError):
         create_jira_task(mock_account, mock_issue_details)
-
-
-def test_jira_connection():
-    """
-    Tests a client to connect to a atlassian server is created and closed
-    """
-    with patch("jira.client.JIRA") as mock_jira:
-        mock_account = MagicMock()
-        mock_account.atlassian_endpoint = "https://example.atlassian.net/"
-        mock_account.username = "foo"
-        mock_account.api_token = "bar"
-
-        # Use the JiraConnection class in a with statement
-        with JiraConnection(mock_account) as conn:
-            # Check if the JIRA instance was created with the correct parameters
-            mock_jira.assert_called_once_with(
-                server="https://example.atlassian.net/", basic_auth=("foo", "bar")
-            )
-            # Check if the connection object is the mock JIRA instance
-            assert conn == mock_jira.return_value
 
 
 def test_create_jira_task_without_epic_success():

--- a/tests/lib/jira_api/test_template_handler.py
+++ b/tests/lib/jira_api/test_template_handler.py
@@ -6,8 +6,8 @@ from yaml import YAMLError
 
 from jinja2.exceptions import TemplateError, TemplateNotFound
 from exceptions.jira_template_error import JiraTemplateError
-from jira_api.template_handler import TemplateHandler
 from structs.jira.jira_template_details import JiraTemplateDetails
+from jira_api.template_handler import TemplateHandler
 
 # pylint:disable=protected-access
 


### PR DESCRIPTION
For clarity, move the class JiraConnection to its own module. This way, it is more clear the purpose of the module jira_issue.py, just to create new tickets.
