### PR TITLE
Post reboot action

### DIFF
--- a/actions/hv.patch.reboot.yaml
+++ b/actions/hv.patch.reboot.yaml
@@ -21,4 +21,9 @@ parameters:
     description: Private key to authenticate with
     required: true
     type: string
+  alertmanager_account_name:
+    type: string
+    description: Name of Alertmanager Account to use. Must be configured in the pack settings.
+    required: true
+    default: "default"
 runner_type: python-script

--- a/actions/hv.post.reboot.yaml
+++ b/actions/hv.post.reboot.yaml
@@ -4,7 +4,7 @@ enabled: true
 entry_point: src/openstack_actions.py
 name: hv.post.reboot
 parameters:
-  name:
+  hypervisor_hostname:
     type: string
     description: Name of host in Icinga
     required: true

--- a/actions/hv.post.reboot.yaml
+++ b/actions/hv.post.reboot.yaml
@@ -1,0 +1,37 @@
+---
+description: Post reboot action
+enabled: true
+entry_point: src/openstack_actions.py
+name: hv.post.reboot
+parameters:
+  name:
+    type: string
+    description: Name of host in Icinga
+    required: true
+  lib_entry_point:
+    type: string
+    default: workflows.hv_post_reboot.post_reboot
+    immutable: true
+  icinga_account_name:
+    type: string
+    description: "Name of Icinga Account to use. Must be configured in in the pack settings."
+    required: true
+    default: "default"
+  alertmanager_account_name:
+    type: string
+    description: Name of Alertmanager Account to use. Must be configured in the pack settings.
+    required: true
+    default: "default"
+  cloud_account:
+    description: "The clouds.yaml account to use whilst performing this action"
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  requires_openstack:
+    default: true
+    immutable: true
+    type: boolean
+runner_type: python-script

--- a/actions/hv.post.reboot.yaml
+++ b/actions/hv.post.reboot.yaml
@@ -6,7 +6,7 @@ name: hv.post.reboot
 parameters:
   hypervisor_hostname:
     type: string
-    description: Name of host in Icinga
+    description: Hostname of hypervisor to run action against 
     required: true
   lib_entry_point:
     type: string

--- a/lib/workflows/hv_patch_and_reboot.py
+++ b/lib/workflows/hv_patch_and_reboot.py
@@ -24,8 +24,10 @@ def patch_and_reboot(
     """
     Takes the selected hypervisor, schedules a downtime on it starting immediately then runs
     the patch and reboot scripts on the machine, before ending the downtime.
-    icinga_account: IcingaAccount: The icinga account object to use to schedule and remove the downtimes
-    hypervisor_name: the name of the hypervisor - should also be the host name on icinga
+    :param alertmanager_account: Alertmanager Account to use
+    :param icinga_account: IcingaAccount: The icinga account object to use to schedule and remove the downtimes
+    :param hypervisor_name: the name of the hypervisor - should also be the host name on icinga
+    :param private_key_path: Path to the stackstorm key
     return: Dict[str] a dictionary containing the remote commands output
     """
     connection_details = SSHDetails(

--- a/lib/workflows/hv_patch_and_reboot.py
+++ b/lib/workflows/hv_patch_and_reboot.py
@@ -1,15 +1,21 @@
 import datetime
 
+from alertmanager_api.silence import AlertManagerAPI
+from alertmanager_api.silence_details import SilenceDetails
+
 from paramiko import SSHException
 from enums.icinga.icinga_objects import IcingaObject
 from icinga_api.downtime import schedule_downtime, remove_downtime
+from structs.alertmanager.alertmanager_account import AlertManagerAccount
 from structs.icinga.downtime_details import DowntimeDetails
 from structs.icinga.icinga_account import IcingaAccount
 from structs.ssh.ssh_connection_details import SSHDetails
 from ssh_api.exec_command import SSHConnection
 
 
+# pylint:disable=too-many-locals
 def patch_and_reboot(
+    alertmanager_account: AlertManagerAccount,
     icinga_account: IcingaAccount,
     hypervisor_name: str,
     private_key_path: str,
@@ -39,6 +45,16 @@ def patch_and_reboot(
         duration=end_timestamp - start_timestamp,
     )
     schedule_downtime(icinga_account=icinga_account, details=downtime_details)
+    alertmanager = AlertManagerAPI(alertmanager_account)
+    silence_details = SilenceDetails(
+        instance_name=hypervisor_name,
+        start_time_dt=start_time,
+        end_time_dt=end_time,
+        author="stackstorm",
+        comment="Stackstorm HV maintenance",
+    )
+    scheduled_silence = alertmanager.schedule_silence(silence_details)
+
     try:
         patch_out = ssh_client.run_command_on_host("patch")
         reboot_out = ssh_client.run_command_on_host("reboot")
@@ -52,4 +68,5 @@ def patch_and_reboot(
             object_type=IcingaObject.HOST,
             object_name=hypervisor_name,
         )
+        alertmanager.remove_silence(scheduled_silence)
         raise exc

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -1,0 +1,38 @@
+from openstack.connection import Connection
+
+from alertmanager_api.silence import AlertManagerAPI
+
+from enums.icinga.icinga_objects import IcingaObject
+
+from structs.alertmanager.alertmanager_account import AlertManagerAccount
+from structs.icinga.icinga_account import IcingaAccount
+from workflows.hv_service_actions import hv_service_enable
+from workflows.hv_create_test_server import create_test_server
+from icinga_api import downtime
+
+
+def post_reboot(
+    alertmanager_account: AlertManagerAccount,
+    icinga_account: IcingaAccount,
+    name: str,
+    conn=Connection,
+):
+    """
+    Action to run after a successful reboot
+    :param icinga_account: Icinga account to use
+    :param name: Name of host in icinga
+    """
+    # Remove downtime
+    downtime.remove_downtime(
+        icinga_account=icinga_account,
+        object_type=IcingaObject.HOST,
+        object_name=name,
+    )
+    # get silence to be removed and remove all the alertmanager silences on that host.
+    alertmanager = AlertManagerAPI(alertmanager_account)
+    silences = alertmanager.get_silences().get_by_name(name)
+    alertmanager.remove_silences(silences)
+    # test vm creation
+    create_test_server(conn=conn, hypervisor_name=name, test_all_flavors=False)
+    # enable in openstack
+    hv_service_enable(conn=conn, hypervisor_name=name, service_binary="nova-compute")

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -1,6 +1,6 @@
 from openstack.connection import Connection
 
-from alertmanager_api.silence import AlertManagerAPI
+from alertmanager_api.silence import get_hv_silences, remove_silence
 
 from enums.icinga.icinga_objects import IcingaObject
 
@@ -29,9 +29,9 @@ def post_reboot(
         object_name=name,
     )
     # get silence to be removed and remove all the alertmanager silences on that host.
-    alertmanager = AlertManagerAPI(alertmanager_account)
-    silences = alertmanager.get_silences().get_by_name(name)
-    alertmanager.remove_silences(silences)
+    silences = get_hv_silences(alertmanager_account, name)
+    for silence_id in silences:
+        remove_silence(alertmanager_account, silence_id)
     # test vm creation
     create_test_server(conn=conn, hypervisor_name=name, test_all_flavors=False)
     # enable in openstack

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -21,6 +21,8 @@ def post_reboot(
     Action to run after a successful reboot
     :param icinga_account: Icinga account to use
     :param hypervisor_hostname: Hostname of hypervisor to run action against
+    :param alertmanager_account: Alertmanager Account to use
+    :param conn: Openstack Connection
     """
     downtime.remove_downtime(
         icinga_account=icinga_account,

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -28,15 +28,12 @@ def post_reboot(
         object_type=IcingaObject.HOST,
         object_name=hypervisor_hostname,
     )
-    # get silence to be removed and remove all the alertmanager silences on that host.
-    silences = get_hv_silences(alertmanager_account, hypervisor_hostname)
-    for silence_id in silences:
-        remove_silence(alertmanager_account, silence_id)
-    # test vm creation
     create_test_server(
         conn=conn, hypervisor_name=hypervisor_hostname, test_all_flavors=False
     )
-    # enable in openstack
     hv_service_enable(
         conn=conn, hypervisor_name=hypervisor_hostname, service_binary="nova-compute"
     )
+    silences = get_hv_silences(alertmanager_account, hypervisor_hostname)
+    for silence_id in silences:
+        remove_silence(alertmanager_account, silence_id)

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -22,7 +22,6 @@ def post_reboot(
     :param icinga_account: Icinga account to use
     :param hypervisor_hostname: Hostname of hypervisor to run action against
     """
-    # Remove downtime
     downtime.remove_downtime(
         icinga_account=icinga_account,
         object_type=IcingaObject.HOST,

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -14,7 +14,7 @@ from icinga_api import downtime
 def post_reboot(
     alertmanager_account: AlertManagerAccount,
     icinga_account: IcingaAccount,
-    name: str,
+    hypervisor_hostname: str,
     conn=Connection,
 ):
     """
@@ -26,13 +26,17 @@ def post_reboot(
     downtime.remove_downtime(
         icinga_account=icinga_account,
         object_type=IcingaObject.HOST,
-        object_name=name,
+        object_name=hypervisor_hostname,
     )
     # get silence to be removed and remove all the alertmanager silences on that host.
-    silences = get_hv_silences(alertmanager_account, name)
+    silences = get_hv_silences(alertmanager_account, hypervisor_hostname)
     for silence_id in silences:
         remove_silence(alertmanager_account, silence_id)
     # test vm creation
-    create_test_server(conn=conn, hypervisor_name=name, test_all_flavors=False)
+    create_test_server(
+        conn=conn, hypervisor_name=hypervisor_hostname, test_all_flavors=False
+    )
     # enable in openstack
-    hv_service_enable(conn=conn, hypervisor_name=name, service_binary="nova-compute")
+    hv_service_enable(
+        conn=conn, hypervisor_name=hypervisor_hostname, service_binary="nova-compute"
+    )

--- a/lib/workflows/hv_post_reboot.py
+++ b/lib/workflows/hv_post_reboot.py
@@ -20,7 +20,7 @@ def post_reboot(
     """
     Action to run after a successful reboot
     :param icinga_account: Icinga account to use
-    :param name: Name of host in icinga
+    :param hypervisor_hostname: Hostname of hypervisor to run action against
     """
     # Remove downtime
     downtime.remove_downtime(

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ nose
 parameterized
 pytest
 pytest-cov
+pytest-freezegun

--- a/rules/hv.compute.service.disable.yaml
+++ b/rules/hv.compute.service.disable.yaml
@@ -3,14 +3,13 @@ name: "hv.compute.service.disable"
 pack: "stackstorm_openstack"
 description: "Triggers the disable action when the hypervisor state changes from 'RUNNING' to 'PENDING MAINTENANCE'"
 enabled: false # Disable
-
 criteria:
   trigger.previous_state:
     type: equals
     pattern: RUNNING
   trigger.current_state:
     type: equals
-    pattern: PENDING MAINTENANCE
+    pattern: PENDING_MAINTENANCE
 
 trigger:
   type: "stackstorm_openstack.hypervisor.state_change"

--- a/rules/hv.patch.reboot.yaml
+++ b/rules/hv.patch.reboot.yaml
@@ -3,7 +3,6 @@ name: "hv.patch.reboot"
 pack: "stackstorm_openstack"
 description: "Starts the patch reboot action when the hypervisor is drained"
 enabled: true
-
 criteria:
   trigger.previous_state:
     type: equals
@@ -11,13 +10,12 @@ criteria:
   trigger.current_state:
     type: equals
     pattern: DRAINED
-
 trigger:
   type: "stackstorm_openstack.hypervisor.state_change"
-
 action:
   ref: "stackstorm_openstack.hv.patch.reboot"
   parameters:
+    alertmanager_account_name: "default"
     icinga_account_name: "default"
     hypervisor_name: "{{ trigger.hypervisor_name }}"
     private_key_path: "/home/stanley/.ssh/id_rsa"

--- a/rules/hv.post.reboot.yaml
+++ b/rules/hv.post.reboot.yaml
@@ -1,7 +1,7 @@
 ---
-name: "hv.remove.downtime"
+name: "hv.post.reboot"
 pack: "stackstorm_openstack"
-description: "Removes the downtime on a HV once it has successfullly rebooted"
+description: "Removes the scheduled downtime, removes the alertmanager silence and enables the hv in openstack when the hv is back up."
 enabled: true
 
 criteria:
@@ -11,13 +11,13 @@ criteria:
   trigger.current_state:
     type: equals
     pattern: REBOOTED
-
 trigger:
   type: "stackstorm_openstack.hypervisor.state_change"
 
 action:
-  ref: "stackstorm_openstack.icinga.remove.downtime"
+  ref: "stackstorm_openstack.hv.post.reboot"
   parameters:
+    alertmanager_account_name: "default"
     icinga_account_name: "default"
     name: "{{ trigger.hypervisor_name }}"
-    object_type: "Host"
+    cloud_account: "dev"

--- a/stackstorm_openstack.yaml.example
+++ b/stackstorm_openstack.yaml.example
@@ -16,6 +16,12 @@ icinga_accounts:
     password:
     icinga_endpoint:
 
+alertmanager_accounts:
+  - name: "default"
+    username:
+    password:
+    alertmanager_endpoint:
+
 smtp_accounts:
   - name: "default"
     password:

--- a/tests/actions/test_openstack_actions.py
+++ b/tests/actions/test_openstack_actions.py
@@ -113,6 +113,22 @@ class TestOpenstackActions(OpenstackActionTestBase):
         )
         assert res == {"jira_account": mock_jira_account.from_pack_config.return_value}
 
+    @patch("src.openstack_actions.AlertManagerAccount")
+    def test_parse_configs_with_alertmanager_account(self, mock_alertmanager_account):
+        """
+        tests that parse_configs parses alertmanager_account_name properly if provided
+        """
+        mock_alertmanager_account_name = NonCallableMock()
+        res = self.action.parse_configs(
+            {"alertmanager_account_name": mock_alertmanager_account_name}
+        )
+        mock_alertmanager_account.from_pack_config.assert_called_once_with(
+            self.config, mock_alertmanager_account_name
+        )
+        assert res == {
+            "alertmanager_account": mock_alertmanager_account.from_pack_config.return_value
+        }
+
     def test_parse_configs_with_no_accounts(self):
         """
         tests that parse_configs doesn't do anything if no stackstorm config names given

--- a/tests/actions/test_openstack_actions.py
+++ b/tests/actions/test_openstack_actions.py
@@ -120,7 +120,7 @@ class TestOpenstackActions(OpenstackActionTestBase):
         """
         mock_alertmanager_account_name = NonCallableMock()
         res = self.action.parse_configs(
-            {"alertmanager_account_name": mock_alertmanager_account_name}
+            **{"alertmanager_account_name": mock_alertmanager_account_name}
         )
         mock_alertmanager_account.from_pack_config.assert_called_once_with(
             self.config, mock_alertmanager_account_name

--- a/tests/lib/workflows/test_hv_patch_and_reboot.py
+++ b/tests/lib/workflows/test_hv_patch_and_reboot.py
@@ -1,9 +1,10 @@
 import datetime
 from unittest.mock import MagicMock, patch
-
 from paramiko import SSHException
 
 from enums.icinga.icinga_objects import IcingaObject
+from structs.alertmanager.alert_matcher_details import AlertMatcherDetails
+from structs.alertmanager.silence_details import SilenceDetails
 from structs.icinga.downtime_details import DowntimeDetails
 from structs.ssh.ssh_connection_details import SSHDetails
 from workflows.hv_patch_and_reboot import patch_and_reboot
@@ -11,13 +12,14 @@ import pytest
 
 
 # pylint:disable=too-many-locals
-@patch("workflows.hv_patch_and_reboot.AlertManagerAPI")
+@pytest.mark.freeze_time
+@patch("workflows.hv_patch_and_reboot.schedule_silence")
 @patch("workflows.hv_patch_and_reboot.schedule_downtime")
 @patch("workflows.hv_patch_and_reboot.SSHConnection")
 def test_successful_patch_and_reboot(
     mock_ssh_conn,
     mock_schedule_downtime,
-    mock_alertmanager_api,
+    mock_schedule_silence,
 ):
     """
     Test successful running of patch and reboot workflow
@@ -34,20 +36,15 @@ def test_successful_patch_and_reboot(
     mock_end_time = mock_start_time + datetime.timedelta(hours=6)
     mock_start_timestamp = int(mock_start_time.timestamp())
     mock_end_timestamp = int(mock_end_time.timestamp())
-
-    mock_alertmanager = MagicMock()
-    mock_alertmanager_api.return_value = mock_alertmanager
-    mock_scheduled_silence = MagicMock()
-    mock_alertmanager.schedule_silence.return_value = mock_scheduled_silence
+    mock_silence_id = "mock ID"
+    mock_schedule_silence.return_value = mock_silence_id
     alertmanager_account = MagicMock()
-
     result = patch_and_reboot(
         alertmanager_account,
         icinga_account,
         hypervisor_name=mock_hypervisor_name,
         private_key_path=mock_private_key_path,
     )
-
     mock_schedule_downtime.assert_called_once_with(
         icinga_account=icinga_account,
         details=DowntimeDetails(
@@ -60,14 +57,19 @@ def test_successful_patch_and_reboot(
             duration=mock_end_timestamp - mock_start_timestamp,
         ),
     )
-
-    mock_alertmanager_api.assert_called_once_with(alertmanager_account)
-    mock_alertmanager.schedule_silence.assert_called_once()
-    called_args = mock_alertmanager.schedule_silence.call_args[0][0]
-    assert called_args.instance_name == mock_hypervisor_name
-    assert called_args.comment == "Stackstorm HV maintenance"
-    assert called_args.author == "stackstorm"
-
+    mock_silence_details = SilenceDetails(
+        matchers=(
+            AlertMatcherDetails(name="instance", value="test_host"),
+            AlertMatcherDetails(name="hostname", value="test_host"),
+        ),
+        start_time_dt=datetime.datetime.utcnow(),
+        duration_hours=6,
+        author="stackstorm",
+        comment="Stackstorm HV maintenance",
+    )
+    mock_schedule_silence.assert_called_once_with(
+        alertmanager_account, mock_silence_details
+    )
     mock_ssh_conn.assert_called_once_with(
         SSHDetails(
             host=mock_hypervisor_name,
@@ -81,7 +83,7 @@ def test_successful_patch_and_reboot(
     assert result["reboot_output"] == "Reboot command output"
 
 
-@patch("workflows.hv_patch_and_reboot.AlertManagerAPI")
+@patch("workflows.hv_patch_and_reboot.schedule_silence")
 @patch("workflows.hv_patch_and_reboot.schedule_downtime")
 @patch("workflows.hv_patch_and_reboot.SSHConnection")
 @patch("workflows.hv_patch_and_reboot.remove_downtime")
@@ -89,7 +91,7 @@ def test_failed_schedule_downtime(
     mock_remove_downtime,
     mock_ssh_conn,
     mock_schedule_downtime,
-    mock_alertmanager_api,
+    mock_schedule_silence,
 ):
     """
     Test unsuccessful running of patch and reboot workflow - where the schedule
@@ -99,11 +101,6 @@ def test_failed_schedule_downtime(
     mock_private_key_path = "/home/stackstorm/.ssh/id_rsa"
     mock_hypervisor_name = "test_host"
     mock_schedule_downtime.side_effect = Exception
-
-    mock_alertmanager = MagicMock()
-    mock_alertmanager_api.return_value = mock_alertmanager
-    mock_scheduled_silence = MagicMock()
-    mock_alertmanager.schedule_silence.return_value = mock_scheduled_silence
     alertmanager_account = MagicMock()
 
     with pytest.raises(Exception):
@@ -122,15 +119,15 @@ def test_failed_schedule_downtime(
             private_key_path=mock_private_key_path,
         )
     )
-
-    mock_alertmanager_api.assert_not_called()
-    mock_alertmanager.schedule_silence.assert_not_called()
+    mock_schedule_silence.assert_not_called()
 
     mock_ssh_conn.return_value.run_command_on_host.assert_not_called()
     mock_remove_downtime.assert_not_called()
 
 
-@patch("workflows.hv_patch_and_reboot.AlertManagerAPI")
+@pytest.mark.freeze_time
+@patch("workflows.hv_patch_and_reboot.schedule_silence")
+@patch("workflows.hv_patch_and_reboot.remove_silence")
 @patch("workflows.hv_patch_and_reboot.remove_downtime")
 @patch("workflows.hv_patch_and_reboot.schedule_downtime")
 @patch("workflows.hv_patch_and_reboot.SSHConnection")
@@ -138,7 +135,8 @@ def test_failed_ssh(
     mock_ssh_conn,
     mock_schedule_downtime,
     mock_remove_downtime,
-    mock_alertmanager_api,
+    mock_remove_silence,
+    mock_schedule_silence,
 ):
     """
     Test unsuccessful running of patch and reboot workflow - where either ssh command
@@ -148,11 +146,8 @@ def test_failed_ssh(
     mock_hypervisor_name = "test_host"
     mock_private_key_path = "/home/stackstorm/.ssh/id_rsa"
     mock_ssh_conn.return_value.run_command_on_host.side_effect = SSHException
-
-    mock_alertmanager = MagicMock()
-    mock_alertmanager_api.return_value = mock_alertmanager
-    mock_scheduled_silence = MagicMock()
-    mock_alertmanager.schedule_silence.return_value = mock_scheduled_silence
+    mock_silence_id = "mock_silence_id"
+    mock_schedule_silence.return_value = mock_silence_id
     alertmanager_account = MagicMock()
 
     with pytest.raises(Exception):
@@ -186,18 +181,24 @@ def test_failed_ssh(
             duration=mock_end_timestamp - mock_start_timestamp,
         ),
     )
+    mock_silence_details = SilenceDetails(
+        matchers=(
+            AlertMatcherDetails(name="instance", value="test_host"),
+            AlertMatcherDetails(name="hostname", value="test_host"),
+        ),
+        start_time_dt=datetime.datetime.utcnow(),
+        duration_hours=6,
+        author="stackstorm",
+        comment="Stackstorm HV maintenance",
+    )
 
-    mock_alertmanager_api.assert_called_once_with(alertmanager_account)
-    mock_alertmanager.schedule_silence.assert_called_once()
-    called_args = mock_alertmanager.schedule_silence.call_args[0][0]
-    assert called_args.instance_name == mock_hypervisor_name
-    assert called_args.comment == "Stackstorm HV maintenance"
-    assert called_args.author == "stackstorm"
+    mock_schedule_silence.assert_called_once_with(
+        alertmanager_account, mock_silence_details
+    )
 
     mock_remove_downtime.assert_called_once_with(
         icinga_account=icinga_account,
         object_type=IcingaObject.HOST,
         object_name=mock_hypervisor_name,
     )
-
-    mock_alertmanager.remove_silence.assert_called_once_with(mock_scheduled_silence)
+    mock_remove_silence.assert_called_once_with(alertmanager_account, mock_silence_id)

--- a/tests/lib/workflows/test_hv_patch_and_reboot.py
+++ b/tests/lib/workflows/test_hv_patch_and_reboot.py
@@ -188,19 +188,25 @@ def test_failed_ssh(
             duration=mock_end_timestamp - mock_start_timestamp,
         ),
     )
-    mock_silence_details = SilenceDetails(
-        matchers=(
-            AlertMatcherDetails(name="instance", value="test_host"),
-            AlertMatcherDetails(name="hostname", value="test_host"),
-        ),
+    mock_silence_details_instance = SilenceDetails(
+        matchers=AlertMatcherDetails(name="instance", value="test_host"),
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
         author="stackstorm",
         comment="Stackstorm HV maintenance",
     )
-
-    mock_schedule_silence.assert_called_once_with(
-        alertmanager_account, mock_silence_details
+    mock_silence_details_hostname = SilenceDetails(
+        matchers=AlertMatcherDetails(name="hostname", value="test_host"),
+        start_time_dt=datetime.datetime.utcnow(),
+        duration_hours=6,
+        author="stackstorm",
+        comment="Stackstorm HV maintenance",
+    )
+    mock_schedule_silence.assert_has_calls(
+        [
+            call(alertmanager_account, mock_silence_details_instance),
+            call(alertmanager_account, mock_silence_details_hostname),
+        ]
     )
 
     mock_remove_downtime.assert_called_once_with(
@@ -208,4 +214,9 @@ def test_failed_ssh(
         object_type=IcingaObject.HOST,
         object_name=mock_hypervisor_name,
     )
-    mock_remove_silence.assert_called_once_with(alertmanager_account, mock_silence_id)
+    mock_remove_silence.assert_has_calls(
+        [
+            call(alertmanager_account, mock_silence_id),
+            call(alertmanager_account, mock_silence_id),
+        ]
+    )

--- a/tests/lib/workflows/test_hv_patch_and_reboot.py
+++ b/tests/lib/workflows/test_hv_patch_and_reboot.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import MagicMock, patch
 
 from paramiko import SSHException
+
 from enums.icinga.icinga_objects import IcingaObject
 from structs.icinga.downtime_details import DowntimeDetails
 from structs.ssh.ssh_connection_details import SSHDetails
@@ -9,11 +10,14 @@ from workflows.hv_patch_and_reboot import patch_and_reboot
 import pytest
 
 
+# pylint:disable=too-many-locals
+@patch("workflows.hv_patch_and_reboot.AlertManagerAPI")
 @patch("workflows.hv_patch_and_reboot.schedule_downtime")
 @patch("workflows.hv_patch_and_reboot.SSHConnection")
 def test_successful_patch_and_reboot(
     mock_ssh_conn,
     mock_schedule_downtime,
+    mock_alertmanager_api,
 ):
     """
     Test successful running of patch and reboot workflow
@@ -30,11 +34,20 @@ def test_successful_patch_and_reboot(
     mock_end_time = mock_start_time + datetime.timedelta(hours=6)
     mock_start_timestamp = int(mock_start_time.timestamp())
     mock_end_timestamp = int(mock_end_time.timestamp())
+
+    mock_alertmanager = MagicMock()
+    mock_alertmanager_api.return_value = mock_alertmanager
+    mock_scheduled_silence = MagicMock()
+    mock_alertmanager.schedule_silence.return_value = mock_scheduled_silence
+    alertmanager_account = MagicMock()
+
     result = patch_and_reboot(
+        alertmanager_account,
         icinga_account,
         hypervisor_name=mock_hypervisor_name,
         private_key_path=mock_private_key_path,
     )
+
     mock_schedule_downtime.assert_called_once_with(
         icinga_account=icinga_account,
         details=DowntimeDetails(
@@ -47,6 +60,14 @@ def test_successful_patch_and_reboot(
             duration=mock_end_timestamp - mock_start_timestamp,
         ),
     )
+
+    mock_alertmanager_api.assert_called_once_with(alertmanager_account)
+    mock_alertmanager.schedule_silence.assert_called_once()
+    called_args = mock_alertmanager.schedule_silence.call_args[0][0]
+    assert called_args.instance_name == mock_hypervisor_name
+    assert called_args.comment == "Stackstorm HV maintenance"
+    assert called_args.author == "stackstorm"
+
     mock_ssh_conn.assert_called_once_with(
         SSHDetails(
             host=mock_hypervisor_name,
@@ -60,11 +81,15 @@ def test_successful_patch_and_reboot(
     assert result["reboot_output"] == "Reboot command output"
 
 
+@patch("workflows.hv_patch_and_reboot.AlertManagerAPI")
 @patch("workflows.hv_patch_and_reboot.schedule_downtime")
 @patch("workflows.hv_patch_and_reboot.SSHConnection")
 @patch("workflows.hv_patch_and_reboot.remove_downtime")
 def test_failed_schedule_downtime(
-    mock_remove_downtime, mock_ssh_conn, mock_schedule_downtime
+    mock_remove_downtime,
+    mock_ssh_conn,
+    mock_schedule_downtime,
+    mock_alertmanager_api,
 ):
     """
     Test unsuccessful running of patch and reboot workflow - where the schedule
@@ -75,8 +100,15 @@ def test_failed_schedule_downtime(
     mock_hypervisor_name = "test_host"
     mock_schedule_downtime.side_effect = Exception
 
+    mock_alertmanager = MagicMock()
+    mock_alertmanager_api.return_value = mock_alertmanager
+    mock_scheduled_silence = MagicMock()
+    mock_alertmanager.schedule_silence.return_value = mock_scheduled_silence
+    alertmanager_account = MagicMock()
+
     with pytest.raises(Exception):
         patch_and_reboot(
+            alertmanager_account,
             icinga_account,
             hypervisor_name=mock_hypervisor_name,
             private_key_path=mock_private_key_path,
@@ -91,14 +123,23 @@ def test_failed_schedule_downtime(
         )
     )
 
+    mock_alertmanager_api.assert_not_called()
+    mock_alertmanager.schedule_silence.assert_not_called()
+
     mock_ssh_conn.return_value.run_command_on_host.assert_not_called()
     mock_remove_downtime.assert_not_called()
 
 
+@patch("workflows.hv_patch_and_reboot.AlertManagerAPI")
 @patch("workflows.hv_patch_and_reboot.remove_downtime")
 @patch("workflows.hv_patch_and_reboot.schedule_downtime")
 @patch("workflows.hv_patch_and_reboot.SSHConnection")
-def test_failed_ssh(mock_ssh_conn, mock_schedule_downtime, mock_remove_downtime):
+def test_failed_ssh(
+    mock_ssh_conn,
+    mock_schedule_downtime,
+    mock_remove_downtime,
+    mock_alertmanager_api,
+):
     """
     Test unsuccessful running of patch and reboot workflow - where either ssh command
     fails
@@ -108,8 +149,15 @@ def test_failed_ssh(mock_ssh_conn, mock_schedule_downtime, mock_remove_downtime)
     mock_private_key_path = "/home/stackstorm/.ssh/id_rsa"
     mock_ssh_conn.return_value.run_command_on_host.side_effect = SSHException
 
+    mock_alertmanager = MagicMock()
+    mock_alertmanager_api.return_value = mock_alertmanager
+    mock_scheduled_silence = MagicMock()
+    mock_alertmanager.schedule_silence.return_value = mock_scheduled_silence
+    alertmanager_account = MagicMock()
+
     with pytest.raises(Exception):
         patch_and_reboot(
+            alertmanager_account,
             icinga_account,
             hypervisor_name=mock_hypervisor_name,
             private_key_path=mock_private_key_path,
@@ -138,8 +186,18 @@ def test_failed_ssh(mock_ssh_conn, mock_schedule_downtime, mock_remove_downtime)
             duration=mock_end_timestamp - mock_start_timestamp,
         ),
     )
+
+    mock_alertmanager_api.assert_called_once_with(alertmanager_account)
+    mock_alertmanager.schedule_silence.assert_called_once()
+    called_args = mock_alertmanager.schedule_silence.call_args[0][0]
+    assert called_args.instance_name == mock_hypervisor_name
+    assert called_args.comment == "Stackstorm HV maintenance"
+    assert called_args.author == "stackstorm"
+
     mock_remove_downtime.assert_called_once_with(
         icinga_account=icinga_account,
         object_type=IcingaObject.HOST,
         object_name=mock_hypervisor_name,
     )
+
+    mock_alertmanager.remove_silence.assert_called_once_with(mock_scheduled_silence)

--- a/tests/lib/workflows/test_hv_patch_and_reboot.py
+++ b/tests/lib/workflows/test_hv_patch_and_reboot.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 from paramiko import SSHException
 
 from enums.icinga.icinga_objects import IcingaObject
@@ -57,18 +57,25 @@ def test_successful_patch_and_reboot(
             duration=mock_end_timestamp - mock_start_timestamp,
         ),
     )
-    mock_silence_details = SilenceDetails(
-        matchers=(
-            AlertMatcherDetails(name="instance", value="test_host"),
-            AlertMatcherDetails(name="hostname", value="test_host"),
-        ),
+    mock_silence_details_instance = SilenceDetails(
+        matchers=AlertMatcherDetails(name="instance", value="test_host"),
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
         author="stackstorm",
         comment="Stackstorm HV maintenance",
     )
-    mock_schedule_silence.assert_called_once_with(
-        alertmanager_account, mock_silence_details
+    mock_silence_details_hostname = SilenceDetails(
+        matchers=AlertMatcherDetails(name="hostname", value="test_host"),
+        start_time_dt=datetime.datetime.utcnow(),
+        duration_hours=6,
+        author="stackstorm",
+        comment="Stackstorm HV maintenance",
+    )
+    mock_schedule_silence.assert_has_calls(
+        [
+            call(alertmanager_account, mock_silence_details_instance),
+            call(alertmanager_account, mock_silence_details_hostname),
+        ]
     )
     mock_ssh_conn.assert_called_once_with(
         SSHDetails(

--- a/tests/lib/workflows/test_hv_post_reboot.py
+++ b/tests/lib/workflows/test_hv_post_reboot.py
@@ -33,7 +33,7 @@ def test_successful_post_reboot(
     post_reboot(
         alertmanager_account,
         icinga_account=mock_icinga_account,
-        name=mock_hv_name,
+        hypervisor_hostname=mock_hv_name,
         conn=mock_conn,
     )
     mock_remove_downtime.assert_called_once_with(

--- a/tests/lib/workflows/test_hv_post_reboot.py
+++ b/tests/lib/workflows/test_hv_post_reboot.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch, call
+import pytest
 
 from enums.icinga.icinga_objects import IcingaObject
 
@@ -52,3 +53,49 @@ def test_successful_post_reboot(
         [call(alertmanager_account, "id1"), call(alertmanager_account, "id2")],
         any_order=True,
     )
+
+
+@patch("workflows.hv_post_reboot.remove_silence")
+@patch("workflows.hv_post_reboot.get_hv_silences")
+@patch("workflows.hv_post_reboot.hv_service_enable")
+@patch("workflows.hv_post_reboot.create_test_server")
+@patch("workflows.hv_post_reboot.downtime.remove_downtime")
+def test_failed_post_reboot(
+    mock_remove_downtime,
+    mock_create_test_server,
+    mock_hv_service_enable,
+    mock_get_hv_silences,
+    mock_remove_silence,
+):
+    """
+    Test unsuccessful running of the post reboot workflow, where create_test_server fails
+    """
+    mock_icinga_account = MagicMock()
+    mock_hv_name = "hvxyz"
+    mock_conn = MagicMock()
+    alertmanager_account = MagicMock()
+    mock_silences = {
+        "id1": {"state": "active", "details": "details"},
+        "id2": {"state": "active", "details": "details"},
+    }
+    mock_get_hv_silences.return_value = mock_silences
+    mock_create_test_server.side_effect = Exception
+
+    with pytest.raises(Exception):
+        post_reboot(
+            alertmanager_account,
+            icinga_account=mock_icinga_account,
+            hypervisor_hostname=mock_hv_name,
+            conn=mock_conn,
+        )
+    mock_remove_downtime.assert_called_once_with(
+        icinga_account=mock_icinga_account,
+        object_type=IcingaObject.HOST,
+        object_name=mock_hv_name,
+    )
+    mock_create_test_server.assert_called_once_with(
+        conn=mock_conn, hypervisor_name=mock_hv_name, test_all_flavors=False
+    )
+    mock_hv_service_enable.assert_not_called()
+    mock_get_hv_silences.assert_not_called()
+    mock_remove_silence.assert_not_called()

--- a/tests/lib/workflows/test_hv_post_reboot.py
+++ b/tests/lib/workflows/test_hv_post_reboot.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock, patch
+
+from enums.icinga.icinga_objects import IcingaObject
+
+from workflows.hv_post_reboot import post_reboot
+
+
+@patch("workflows.hv_post_reboot.AlertManagerAPI")
+@patch("workflows.hv_post_reboot.hv_service_enable")
+@patch("workflows.hv_post_reboot.create_test_server")
+@patch("workflows.hv_post_reboot.downtime.remove_downtime")
+def test_successful_post_reboot(
+    mock_remove_downtime,
+    mock_create_test_server,
+    mock_hv_service_enable,
+    mock_alertmanager_api,
+):
+    """
+    Test successfull running of the post reboot workflow.
+    """
+    mock_icinga_account = MagicMock()
+    mock_hv_name = "hvxyz"
+    mock_conn = MagicMock()
+
+    mock_alertmanager = MagicMock()
+    mock_alertmanager_api.return_value = mock_alertmanager
+    alertmanager_account = MagicMock()
+    mock_silences = MagicMock()
+    mock_alertmanager.get_silences.return_value.get_by_name.return_value = mock_silences
+
+    post_reboot(
+        alertmanager_account,
+        icinga_account=mock_icinga_account,
+        name=mock_hv_name,
+        conn=mock_conn,
+    )
+
+    mock_remove_downtime.assert_called_once_with(
+        icinga_account=mock_icinga_account,
+        object_type=IcingaObject.HOST,
+        object_name=mock_hv_name,
+    )
+
+    mock_alertmanager_api.assert_called_once_with(alertmanager_account)
+    mock_alertmanager.get_silences.return_value.get_by_name.assert_called_once_with(
+        mock_hv_name
+    )
+    mock_alertmanager.remove_silences.assert_called_once_with(mock_silences)
+    mock_create_test_server.assert_called_once_with(
+        conn=mock_conn, hypervisor_name=mock_hv_name, test_all_flavors=False
+    )
+    mock_hv_service_enable.assert_called_once_with(
+        conn=mock_conn, hypervisor_name=mock_hv_name, service_binary="nova-compute"
+    )

--- a/tests/lib/workflows/test_hv_post_reboot.py
+++ b/tests/lib/workflows/test_hv_post_reboot.py
@@ -41,15 +41,14 @@ def test_successful_post_reboot(
         object_type=IcingaObject.HOST,
         object_name=mock_hv_name,
     )
-
-    mock_get_hv_silences.assert_called_once_with(alertmanager_account, mock_hv_name)
-    mock_remove_silence.assert_has_calls(
-        [call(alertmanager_account, "id1"), call(alertmanager_account, "id2")],
-        any_order=True,
-    )
     mock_create_test_server.assert_called_once_with(
         conn=mock_conn, hypervisor_name=mock_hv_name, test_all_flavors=False
     )
     mock_hv_service_enable.assert_called_once_with(
         conn=mock_conn, hypervisor_name=mock_hv_name, service_binary="nova-compute"
+    )
+    mock_get_hv_silences.assert_called_once_with(alertmanager_account, mock_hv_name)
+    mock_remove_silence.assert_has_calls(
+        [call(alertmanager_account, "id1"), call(alertmanager_account, "id2")],
+        any_order=True,
     )


### PR DESCRIPTION
### Description:
This PR:

- Adds the `post_reboot` action to remove the scheduled downtime, removes the `alertmanager` silence and enables the hv in openstack when the hv is back up after a reboot
- Bug fix to add the `alertManager` to openstack_actions.py.
- Fix a typo in the migrate rule.
---
Note: There is another branch called `fix_tests` which fixes the failing coverage. 

---
### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
