### PR TITLE
Bug: Fix hv notification actions

### DIFF
--- a/actions/email.users.with.vms.on.hv.fault.notification.yaml
+++ b/actions/email.users.with.vms.on.hv.fault.notification.yaml
@@ -66,7 +66,7 @@ parameters:
     type: string
     description: "Set an email address to override where to send the emails generated"
     required: true
-    default: false
+    default: "cloud-support@stfc.ac.uk"
   cc_cloud_support:
     type: boolean
     description: "Flag if set, will cc in cloud-support@stfc.ac.uk automatically"

--- a/actions/email.users.with.vms.on.hv.maintenance.notification.yaml
+++ b/actions/email.users.with.vms.on.hv.maintenance.notification.yaml
@@ -66,7 +66,7 @@ parameters:
     type: string
     description: "Set an email address to override where to send the emails generated"
     required: true
-    default: false
+    default: "cloud-support@stfc.ac.uk"
   cc_cloud_support:
     type: boolean
     description: "Flag if set, will cc in cloud-support@stfc.ac.uk automatically"

--- a/lib/workflows/send_hv_email.py
+++ b/lib/workflows/send_hv_email.py
@@ -45,7 +45,7 @@ def find_servers_on_hv(
         )
 
     if webhook:
-        to_webhook(webhook=webhook, payload=server_query.to_props())
+        to_webhook(webhook=webhook, payload=server_query.select_all().to_props())
 
     server_query.append_from("PROJECT_QUERY", cloud_account, ["name"])
     server_query.group_by("user_id")

--- a/rules/hv.maintenance.notification.yaml
+++ b/rules/hv.maintenance.notification.yaml
@@ -20,7 +20,5 @@ action:
   parameters:
     hypervisor_name: "{{ trigger.hypervisor_name }}"
     cloud_account: "dev"
-    use_override: False
     send_email: false
-    override_email_address: None
     webhook: "migrate-server"

--- a/tests/lib/workflows/test_send_hv_email.py
+++ b/tests/lib/workflows/test_send_hv_email.py
@@ -136,9 +136,8 @@ def test_find_servers_on_hv_to_webhook(mock_server_query, mock_to_webhook):
     mock_server_query_obj.select.assert_called_once_with("id", "name", "addresses")
 
     mock_to_webhook.assert_called_once_with(
-        webhook="test", payload=mock_server_query_obj.to_props.return_value
+        webhook="test", payload=mock_server_query_obj.select_all().to_props.return_value
     )
-    assert mock_server_query_obj.to_props.call_count == 2
 
     mock_server_query_obj.append_from.assert_called_once_with(
         "PROJECT_QUERY", "test-cloud-account", ["name"]


### PR DESCRIPTION
override email should default to a string
`to_webhook` needs to send all server properties to the webhook

### Description:

- override email should default to a string
- `to_webhook` needs to send all server properties to the webhook

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
