### PR TITLE
Disable hv state sensor

### DIFF
--- a/sensors/hypervisor.state_change.yaml
+++ b/sensors/hypervisor.state_change.yaml
@@ -3,6 +3,7 @@ class_name: HypervisorStateSensor
 entry_point: src/hypervisor_state_sensor.py
 description: Monitor state of Hypervisors
 poll_interval: 600
+enabled: false
 trigger_types:
   - name: "hypervisor.state_change"
     description: "Triggers when the state of the hypervisor changes"


### PR DESCRIPTION
### Description:
Disable hv state sensor there should only be one instance running at a time to avoid stackstorm instances conflicting with each other

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
