### PR TITLE
Add function to reply to JIRA Issues

### DIFF
--- a/lib/jira_api/jira_issue.py
+++ b/lib/jira_api/jira_issue.py
@@ -1,4 +1,6 @@
+from typing import Optional
 from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
+from structs.jira.jira_account import JiraAccount
 from structs.jira.jira_issue_details import IssueDetails
 from jira_api.connection import JiraConnection
 
@@ -36,3 +38,24 @@ def create_jira_task(account, issue_details: IssueDetails) -> str:
 
         conn.add_issues_to_epic(epic_id=issue_details.epic_id, issue_keys=task.key)
         return task.id
+
+
+def add_comment(
+    account: JiraAccount, issue_key: str, text: str, internal: Optional[bool] = True
+):
+    """
+    Add a comment to an existing JIRA Issue.
+
+    :param account: credentials to create a connection with the JIRA server
+    :type account: JiraAccount
+    :param issue_key: the unique key to identify the Issue to update
+    :type issue_key: str
+    :param text: the content of the comment being added to the JIRA issue
+    :type text: str
+    :param internal: boolean to decide if the comment is internal or a reply to the user
+    :type internal: bool
+    """
+    if not text:
+        raise ValueError("Comment text cannot be empty")
+    with JiraConnection(account) as conn:
+        conn.add_comment(issue_key, text, internal)

--- a/tests/lib/jira_api/test_jira_issue.py
+++ b/tests/lib/jira_api/test_jira_issue.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from exceptions.missing_mandatory_param_error import MissingMandatoryParamError
-from jira_api.jira_issue import create_jira_task
+from jira_api.jira_issue import create_jira_task, add_comment
 
 
 def test_create_jira_task_project_id_throws():
@@ -89,3 +89,49 @@ def test_create_jira_task_with_epic_success():
         assert task_id == "123"
         mock_conn.create_issue.assert_called_once()
         mock_conn.add_issues_to_epic.assert_called_once()
+
+
+def test_add_comment_calls_jira():
+    """
+    Tests that add_comment correctly calls the JIRA API
+    """
+    with patch("jira.client.JIRA") as mock_conn:
+        mock_account = MagicMock()
+
+        mock_conn = mock_conn.return_value
+
+        # Call the function
+        add_comment(mock_account, "ISSUE-123", "This is a test comment", internal=True)
+
+        # Assertions
+        mock_conn.add_comment.assert_called_once_with(
+            "ISSUE-123", "This is a test comment", True
+        )
+
+
+def test_add_comment_with_internal_false():
+    """
+    Tests that add_comment correctly calls the JIRA API with internal=False
+    """
+    with patch("jira.client.JIRA") as mock_conn:
+        mock_account = MagicMock()
+
+        mock_conn = mock_conn.return_value
+
+        # Call the function
+        add_comment(mock_account, "ISSUE-123", "Public comment", internal=False)
+
+        # Assertions
+        mock_conn.add_comment.assert_called_once_with(
+            "ISSUE-123", "Public comment", False
+        )
+
+
+def test_add_comment_empty_text():
+    """
+    Tests that add_comment raises an error when text is empty
+    """
+    mock_account = MagicMock()
+
+    with pytest.raises(ValueError):  # Assuming an empty comment should raise an error
+        add_comment(mock_account, "ISSUE-123", "")


### PR DESCRIPTION
As it is going to be needed by future automations, we need to enhance the API to interact with JIRA.
Let's start by adding a function that allows us to reply to an existing JIRA Issue. The reply can be either an internal comment or a reply to the customer.

