### PR TITLE
Fixed the migration functions to wait for status

### DIFF
--- a/lib/openstack_api/openstack_server.py
+++ b/lib/openstack_api/openstack_server.py
@@ -75,6 +75,8 @@ def wait_for_image_status(conn: Connection, image, status, interval=5, timeout=6
     :param interval:How long to wait between checks
     :param timeout: Timeout of the function
     """
+    if image.status == status:
+        return image
     start_time = time.time()
     while time.time() - start_time < timeout:
         image = conn.image.get_image(image.id)

--- a/tests/lib/openstack_api/test_openstack_server.py
+++ b/tests/lib/openstack_api/test_openstack_server.py
@@ -1,18 +1,23 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
-from openstack.exceptions import ResourceFailure
+from openstack.exceptions import ResourceTimeout, ResourceFailure
 import pytest
 from openstack_api.openstack_server import (
     build_server,
     delete_server,
     snapshot_and_migrate_server,
     snapshot_server,
+    wait_for_migration_status,
+    wait_for_image_status,
 )
 
 
 @pytest.mark.parametrize("dest_host", [None, "hv01"])
 @patch("openstack_api.openstack_server.snapshot_server")
-def test_active_migration(mock_snapshot_server, dest_host):
+@patch("openstack_api.openstack_server.wait_for_migration_status")
+def test_active_migration(
+    mock_wait_for_migration_status, mock_snapshot_server, dest_host
+):
     """
     Test migration when the status of the server is ACTIVE and the destination host is supplied
     """
@@ -34,12 +39,18 @@ def test_active_migration(mock_snapshot_server, dest_host):
     mock_connection.compute.live_migrate_server.assert_called_once_with(
         server=mock_server_id, host=dest_host, block_migration=True
     )
+    mock_wait_for_migration_status.assert_called_once_with(
+        mock_connection, mock_server_id, "completed"
+    )
     mock_connection.compute.migrate_server.assert_not_called()
 
 
 @pytest.mark.parametrize("dest_host", [None, "hv01"])
 @patch("openstack_api.openstack_server.snapshot_server")
-def test_shutoff_migration(mock_snapshot_server, dest_host):
+@patch("openstack_api.openstack_server.wait_for_migration_status")
+def test_shutoff_migration(
+    mock_wait_for_migration_status, mock_snapshot_server, dest_host
+):
     """
     Test migration when the status of the server is SHUTOFF and the destination host is supplied
     """
@@ -47,6 +58,8 @@ def test_shutoff_migration(mock_snapshot_server, dest_host):
     mock_server_id = "server1"
     mock_server_status = "SHUTOFF"
     mock_flavor_id = "mock_flavor"
+    mock_server = MagicMock()
+    mock_connection.compute.get_server.return_value = mock_server
     snapshot_and_migrate_server(
         conn=mock_connection,
         server_id=mock_server_id,
@@ -62,6 +75,47 @@ def test_shutoff_migration(mock_snapshot_server, dest_host):
     mock_connection.compute.migrate_server.assert_called_once_with(
         server=mock_server_id, host=dest_host
     )
+    mock_connection.compute.wait_for_server.assert_called_once_with(
+        mock_server, status="VERIFY_RESIZE"
+    )
+    mock_connection.compute.confirm_server_resize(mock_server_id)
+    mock_wait_for_migration_status.assert_called_once_with(
+        mock_connection, mock_server_id, "confirmed"
+    )
+
+
+@patch("openstack_api.openstack_server.snapshot_server")
+@patch("openstack_api.openstack_server.wait_for_migration_status")
+def test_active_migration_failed_wait_for_status(
+    mock_wait_for_migration_status, mock_snapshot_server
+):
+    """
+    Test migration when the the status of migration raises an error
+    """
+    mock_connection = MagicMock()
+    mock_server_id = "server1"
+    mock_server_status = "ACTIVE"
+    mock_flavor_id = "mock_flavor"
+    mock_wait_for_migration_status.side_effect = ResourceTimeout
+    with pytest.raises(ResourceTimeout):
+        snapshot_and_migrate_server(
+            conn=mock_connection,
+            server_id=mock_server_id,
+            server_status=mock_server_status,
+            flavor_id=mock_flavor_id,
+            dest_host=None,
+            snapshot=True,
+        )
+    mock_snapshot_server.assert_called_once_with(
+        conn=mock_connection, server_id=mock_server_id
+    )
+    mock_connection.compute.live_migrate_server.assert_called_once_with(
+        server=mock_server_id, host=None, block_migration=True
+    )
+    mock_wait_for_migration_status.assert_called_once_with(
+        mock_connection, mock_server_id, "completed"
+    )
+    mock_connection.compute.migrate_server.assert_not_called()
 
 
 @patch("openstack_api.openstack_server.snapshot_server")
@@ -108,7 +162,8 @@ def test_migration_fail(mock_snapshot_server):
     mock_connection.compute.migrate_server.assert_not_called()
 
 
-def test_snapshot_server():
+@patch("openstack_api.openstack_server.wait_for_image_status")
+def test_snapshot_server(mock_wait_for_image_status):
     """
     Test server snapshot
     """
@@ -132,6 +187,9 @@ def test_snapshot_server():
         wait=True,
         timeout=3600,
     )
+    mock_wait_for_image_status.assert_called_once_with(
+        mock_connection, mock_image, "active"
+    )
     mock_connection.image.update_image.assert_called_once_with(
         mock_image, owner=mock_project_id
     )
@@ -154,6 +212,106 @@ def test_block_gpu_migration():
             flavor_id=mock_flavor_id,
             dest_host=None,
             snapshot=True,
+        )
+
+
+def test_wait_for_image_status_success():
+    """
+    Test wait_for_image_status when it is a success
+    """
+    mock_conn = MagicMock()
+    image = MagicMock(id="123", name="test-image", status="queued")
+
+    mock_conn.image.get_image.side_effect = [
+        MagicMock(id="123", name="test-image", status="pending"),
+        MagicMock(id="123", name="test-image", status="pending"),
+        MagicMock(id="123", name="test-image", status="active"),
+    ]
+    result = wait_for_image_status(mock_conn, image, "active", interval=1, timeout=10)
+    assert result.status == "active"
+
+
+def test_wait_for_image_status_timeout():
+    """
+    Test wait_for_image_status when it hits the timeout
+    """
+    mock_conn = MagicMock()
+    image = MagicMock(id="123", name="test-image", status="pending")
+    mock_conn.image.get_image.side_effect = [image] * 10
+    with pytest.raises(
+        ResourceTimeout,
+        match=f"Timeout waiting for image {image.name} to become active.",
+    ):
+        wait_for_image_status(mock_conn, image, "active", interval=1, timeout=5)
+
+
+def test_wait_for_image_status_error():
+    """
+    Test wait_for_image_status when the image status becomes error
+    """
+    mock_conn = MagicMock()
+    image_pending = MagicMock(id="123", name="test-image", status="pending")
+    image_error = MagicMock(id="123", name="test-image", status="error")
+    mock_conn.image.get_image.side_effect = [
+        image_pending,
+        image_error,
+    ]
+    with pytest.raises(
+        ResourceFailure, match=f"Image {image_error.name} failed to upload."
+    ):
+        wait_for_image_status(mock_conn, image_error, "active", interval=1, timeout=5)
+
+
+def test_wait_for_migration_status_success():
+    """
+    Test wait_for_migration_status when it is a success
+    """
+    mock_conn = MagicMock()
+    migration_pending = MagicMock(status="pending")
+    migration_completed = MagicMock(status="completed")
+
+    mock_conn.compute.migrations.side_effect = [
+        iter([migration_pending]),
+        iter([migration_pending]),
+        iter([migration_completed]),
+    ]
+
+    result = wait_for_migration_status(
+        mock_conn, "server_id", "completed", interval=1, timeout=10
+    )
+    assert result.status == "completed"
+
+
+def test_wait_for_migration_status_timeout():
+    """
+    Test wait_for_migration_status when it hits the timeout
+    """
+    mock_conn = MagicMock()
+    mock_conn.compute.migrations.side_effect = iter([MagicMock(status="pending")] * 10)
+
+    with pytest.raises(
+        ResourceTimeout, match="Timeout waiting for migration to become completed."
+    ):
+        wait_for_migration_status(
+            mock_conn, "server_id", "completed", interval=1, timeout=5
+        )
+
+
+@pytest.mark.parametrize("bad_state", ["error", "failed"])
+def test_wait_for_migration_status_error(bad_state):
+    """
+    Test wait_for_migration_status when the migration status becomes error
+    """
+    mock_conn = MagicMock()
+    migration_pending = MagicMock(status="pending")
+    migration_error = MagicMock(status=bad_state)
+    mock_conn.compute.migrations.side_effect = [
+        iter([migration_pending]),
+        iter([migration_error]),
+    ]
+    with pytest.raises(ResourceFailure):
+        wait_for_migration_status(
+            mock_conn, "server_id", "completed", interval=1, timeout=5
         )
 
 


### PR DESCRIPTION
Tested in dev-deployment

### Description:

This PR adds checks in for the status of image and migration so that the actions in stackstorm will fail.

I am not sure why the code coverage is failing - I think the line is covered. 

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
