### PR TITLE
Fix check for silence end time before start time

### DIFF
--- a/lib/structs/alertmanager/silence_details.py
+++ b/lib/structs/alertmanager/silence_details.py
@@ -72,8 +72,8 @@ class SilenceDetails:
         if self.end_time_dt is None:
             raise ValueError("Either end_time_dt or duration must be provided")
 
-        # Ensure end_time_dt is after start_time_dt
-        if self.end_time_dt <= self.start_time_dt:
+        # Ensure duration is not negative
+        if self.duration < timedelta(0):
             raise ValueError("end_time_dt must be after start_time_dt")
 
     @property


### PR DESCRIPTION
### Description:
Previous check was causing error when end time = start time which are allowed by alertmanager. Change to check for a negative duration instead
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
