### PR TITLE
Add disabled state for hypervisors

### DIFF
--- a/lib/enums/hypervisor_states.py
+++ b/lib/enums/hypervisor_states.py
@@ -38,6 +38,7 @@ class HypervisorState(Enum):
     }
     PENDING_MAINTENANCE = auto()
     DOWN = auto()
+    DISABLED = auto()
     UNKNOWN = auto()
 
     @classmethod

--- a/lib/openstack_api/openstack_hypervisor.py
+++ b/lib/openstack_api/openstack_hypervisor.py
@@ -13,6 +13,10 @@ def get_hypervisor_state(hypervisor: Dict, uptime_limit: int) -> HypervisorState
     """
     if hypervisor["hypervisor_state"] == "down":
         return HypervisorState.DOWN
+    if hypervisor["hypervisor_disabled_reason"] and not hypervisor[
+        "hypervisor_disabled_reason"
+    ].startswith("Stackstorm:"):
+        return HypervisorState.DISABLED
     if not valid_state(hypervisor):
         return HypervisorState.UNKNOWN
     if (

--- a/lib/openstack_query_api/hypervisor_queries.py
+++ b/lib/openstack_query_api/hypervisor_queries.py
@@ -17,6 +17,7 @@ def query_hypervisor_state(cloud_account: str):
         "hypervisor_state",
         "hypervisor_status",
         "hypervisor_uptime_days",
+        "disabled_reason",
     )
 
     state_query.run(cloud_account=cloud_account, all_projects=True, as_admin=True)

--- a/lib/workflows/hv_patch_and_reboot.py
+++ b/lib/workflows/hv_patch_and_reboot.py
@@ -52,7 +52,7 @@ def patch_and_reboot(
     silence_details_instance = SilenceDetails(
         matchers=[matcher_instance],
         author="stackstorm",
-        comment="Stackstorm HV maintenance",
+        comment="Stackstorm: HV Patching",
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
     )
@@ -63,7 +63,7 @@ def patch_and_reboot(
     silence_details_hostname = SilenceDetails(
         matchers=[matcher_hostname],
         author="stackstorm",
-        comment="Stackstorm HV maintenance",
+        comment="Stackstorm: HV Patching",
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
     )

--- a/rules/hv.compute.service.disable.yaml
+++ b/rules/hv.compute.service.disable.yaml
@@ -19,4 +19,4 @@ action:
   parameters:
     cloud_account: "dev"
     hypervisor_name: "{{ trigger.hypervisor_name }}"
-    disabled_reason: "Stackstorm Patch Reboot Maintenance"
+    disabled_reason: "Stackstorm: Disabled for Maintenance"

--- a/tests/lib/openstack_api/test_openstack_hypervisor.py
+++ b/tests/lib/openstack_api/test_openstack_hypervisor.py
@@ -17,6 +17,7 @@ def test_get_state_running():
         "hypervisor_status": "enabled",
         "hypervisor_state": "up",
         "hypervisor_server_count": 5,
+        "hypervisor_disabled_reason": None,
     }
     state = get_hypervisor_state(hypervisor, 60)
     assert state == HypervisorState.RUNNING
@@ -30,12 +31,14 @@ def test_get_state_running():
             "hypervisor_status": "enabled",
             "hypervisor_state": "up",
             "hypervisor_server_count": 0,
+            "hypervisor_disabled_reason": None,
         },
         {
             "hypervisor_uptime_days": 100.0,
             "hypervisor_status": "enabled",
             "hypervisor_state": "up",
             "hypervisor_server_count": 12,
+            "hypervisor_disabled_reason": None,
         },
     ],
 )
@@ -47,6 +50,21 @@ def test_get_state_pending_maintenance(hypervisor):
     assert state == HypervisorState.PENDING_MAINTENANCE
 
 
+def test_get_state_disabled():
+    """
+    Test hypervisor state is draining for given variables
+    """
+    hypervisor = {
+        "hypervisor_uptime_days": 100.3,
+        "hypervisor_status": "disabled",
+        "hypervisor_state": "up",
+        "hypervisor_server_count": 5,
+        "hypervisor_disabled_reason": "HV Broken - AB",
+    }
+    state = get_hypervisor_state(hypervisor, 60)
+    assert state == HypervisorState.DISABLED
+
+
 def test_get_state_draining():
     """
     Test hypervisor state is draining for given variables
@@ -56,6 +74,7 @@ def test_get_state_draining():
         "hypervisor_status": "disabled",
         "hypervisor_state": "up",
         "hypervisor_server_count": 5,
+        "hypervisor_disabled_reason": "Stackstorm: Disabled for Maintenance",
     }
     state = get_hypervisor_state(hypervisor, 60)
     assert state == HypervisorState.DRAINING
@@ -70,6 +89,7 @@ def test_get_state_drained():
         "hypervisor_status": "disabled",
         "hypervisor_state": "up",
         "hypervisor_server_count": 0,
+        "hypervisor_disabled_reason": "Stackstorm: Disabled for Maintenance",
     }
     state = get_hypervisor_state(hypervisor, 60)
     assert state == HypervisorState.DRAINED
@@ -84,6 +104,7 @@ def test_get_state_rebooted():
         "hypervisor_status": "disabled",
         "hypervisor_state": "up",
         "hypervisor_server_count": 0,
+        "hypervisor_disabled_reason": "Stackstorm: Disabled for Maintenance",
     }
     state = get_hypervisor_state(hypervisor, 60)
     assert state == HypervisorState.REBOOTED
@@ -98,6 +119,7 @@ def test_get_state_empty():
         "hypervisor_status": "enabled",
         "hypervisor_state": "up",
         "hypervisor_server_count": 0,
+        "hypervisor_disabled_reason": None,
     }
     state = get_hypervisor_state(hypervisor, 60)
     assert state == HypervisorState.EMPTY
@@ -142,30 +164,35 @@ def test_get_state_down(hypervisor):
             "hypervisor_status": "enabled",
             "hypervisor_state": "up",
             "hypervisor_server_count": 0,
+            "hypervisor_disabled_reason": None,
         },
         {
             "hypervisor_uptime_days": 100,
             "hypervisor_status": None,
             "hypervisor_state": "up",
             "hypervisor_server_count": 0,
+            "hypervisor_disabled_reason": None,
         },
         {
             "hypervisor_uptime_days": 40,
             "hypervisor_status": "enabled",
             "hypervisor_state": None,
             "hypervisor_server_count": 2,
+            "hypervisor_disabled_reason": None,
         },
         {
             "hypervisor_uptime_days": 40,
             "hypervisor_status": "enabled",
             "hypervisor_state": "up",
             "hypervisor_server_count": None,
+            "hypervisor_disabled_reason": None,
         },
         {
             "hypervisor_uptime_days": 5,
             "hypervisor_status": "enabled",
             "hypervisor_state": "up",
             "hypervisor_server_count": -2,
+            "hypervisor_disabled_reason": None,
         },
     ],
 )

--- a/tests/lib/workflows/test_hv_patch_and_reboot.py
+++ b/tests/lib/workflows/test_hv_patch_and_reboot.py
@@ -58,14 +58,14 @@ def test_successful_patch_and_reboot(
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
         author="stackstorm",
-        comment="Stackstorm HV maintenance",
+        comment="Stackstorm: HV Patching",
     )
     mock_silence_details_hostname = SilenceDetails(
         matchers=[AlertMatcherDetails(name="hostname", value="test_host")],
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
         author="stackstorm",
-        comment="Stackstorm HV maintenance",
+        comment="Stackstorm: HV Patching",
     )
     mock_schedule_silence.assert_has_calls(
         [
@@ -187,14 +187,14 @@ def test_failed_ssh(
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
         author="stackstorm",
-        comment="Stackstorm HV maintenance",
+        comment="Stackstorm: HV Patching",
     )
     mock_silence_details_hostname = SilenceDetails(
         matchers=[AlertMatcherDetails(name="hostname", value="test_host")],
         start_time_dt=datetime.datetime.utcnow(),
         duration_hours=6,
         author="stackstorm",
-        comment="Stackstorm HV maintenance",
+        comment="Stackstorm: HV Patching",
     )
     mock_schedule_silence.assert_has_calls(
         [


### PR DESCRIPTION
### Description:
Add disabled state for any hypervisors disabled not disabled by stackstorm, this will prevent stackstorm automatically running action unintentionally
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
