### PR TITLE
Jira automations skeleton

### DIFF
--- a/actions/jira.request_new_project.yaml
+++ b/actions/jira.request_new_project.yaml
@@ -1,0 +1,32 @@
+---
+description: Creates a new Project in OpenStack. This requires an associated JIRA ticket, for manual Project creation see project.create
+enabled: true
+entry_point: src/openstack_actions.py
+name: jira.request_new_project
+parameters:
+  lib_entry_point:
+    type: string
+    default: workflows.jira_openstack_request_new_project.request_new_project
+    immutable: true
+  requires_openstack:
+    default: true
+    immutable: true
+    type: boolean
+  cloud_account:
+    description: The clouds.yaml account to use whilst performing this action
+    required: true
+    type: string
+    default: "dev"
+    enum:
+      - "dev"
+      - "prod"
+  jira_account_name:
+    type: string
+    description: Name of JIRA Account to use. Must be configured in the pack settings.
+    required: true
+    default: "default"
+  issue_key:
+    type: string
+    description: The unique ID to identify each JIRA Issue
+    required: true
+runner_type: python-script

--- a/lib/workflows/jira_openstack_request_new_project.py
+++ b/lib/workflows/jira_openstack_request_new_project.py
@@ -1,9 +1,11 @@
 from structs.jira.jira_account import JiraAccount
 
+# pylint: disable=unused-argument
+
 
 def request_new_project(
-    jira_account: JiraAccount,  # pylint: disable=unused-argument
-    issue_key,  # pylint: disable=unused-argument
+    jira_account: JiraAccount,
+    issue_key,
 ):
     """
     to be implemented

--- a/lib/workflows/jira_openstack_request_new_project.py
+++ b/lib/workflows/jira_openstack_request_new_project.py
@@ -1,0 +1,11 @@
+from structs.jira.jira_account import JiraAccount
+
+
+def request_new_project(
+    jira_account: JiraAccount,  # pylint: disable=unused-argument
+    issue_key,  # pylint: disable=unused-argument
+):
+    """
+    to be implemented
+    """
+    raise NotImplementedError

--- a/rules/jira.request_new_project.yaml
+++ b/rules/jira.request_new_project.yaml
@@ -1,0 +1,13 @@
+---
+name: "JIRA Create Project to OpenStack"
+pack: "stackstorm_openstack"
+description: "Handles JIRA issues requesting OpenStack project creation."
+enabled: true
+
+trigger:
+  type: "jira.request_new_project"
+
+action:
+  ref: "stackstorm_openstack.jira.request_new_project"
+  parameters:
+    issue_key : "{{ trigger.issue_key }}"

--- a/sensors/jira.request_new_project.yaml
+++ b/sensors/jira.request_new_project.yaml
@@ -1,0 +1,15 @@
+---
+class_name: JiraIssueSensor
+entry_point: src/jira_issue_sensor.py
+description: Search for new JIRA issues
+poll_interval: 300
+enabled: true
+trigger_types:
+  - name: "jira.request_new_project"
+    description: "Triggers when there is a new JIRA issue requesting the creation of a new OpenStack project"
+    payload_schema:
+      type: "object"
+      properties:
+        issue_key:
+          type: "string"
+          description: "unique ID to identify the JIRA Issue with the needed data for the creation of a new OpenStack project"

--- a/sensors/src/jira_issue_sensor.py
+++ b/sensors/src/jira_issue_sensor.py
@@ -1,0 +1,86 @@
+from st2reactor.sensor.base import PollingSensor
+from jira_api.jira_issue import search_issues
+from structs.jira.jira_account import JiraAccount
+import jira
+
+# pylint: disable=attribute-defined-outside-init
+
+
+class JiraIssueSensor(PollingSensor):
+    """
+    class to implement an active Sensor to query a JIRA project
+    for specific types of JIRA tickets (issues) and perform
+    the corresponding actions via a StackStorm Trigger.
+
+    Active sensors poll a remote service periodically
+    (like a cron) instead of waiting for an event input.
+    """
+
+    def setup(self):
+        """
+        set the connection object for our JIRA instance
+        """
+
+        # At sensor startup, self.config holds the pack’s config
+        if not self.config:
+            raise ValueError("No config found for sensor")
+        jira_account_name = self.config["jira_account_name"]
+        self.jira_account = JiraAccount.from_pack_config(self.config, jira_account_name)
+        endpoint = self.jira_account.atlassian_endpoint
+        token = self.jira_account.api_token
+        username = self.jira_account.username
+        self.jira_client = jira.client.JIRA(
+            server=endpoint,
+            basic_auth=(
+                username,
+                token,
+            ),
+        )
+
+    def poll(self):
+        """
+        check JIRA for new tickets to process
+
+        We only search for JIRA tickets in the "Ready For Automation" state.
+        This way, once this automation starts working on them and set them
+        as "Automation In Progress", they won't be picked up again.
+        """
+        # different types of JIRA issues:
+        request_type_dict = {
+            "Request New Project": "jira.request_new_project",
+            "Add User": "jira.add_user",
+        }
+        for request_type, trigger_name in request_type_dict.items():
+            requirements_list = [
+                'statusCategory in ("Ready For Automation")',
+                f'"Request Type" = "{request_type}"',
+            ]
+            issues_list = search_issues(
+                self.jira_account,
+                "STFCCLOUD",
+                requirements_list,
+            )
+            for issue in issues_list:
+                self.sensor_service.dispatch(
+                    trigger=trigger_name, payload={"issue_key": issue.key}
+                )
+
+    def cleanup(self):
+        """
+        clean up
+        """
+        if self.jira_client:
+            self.jira_client.close()
+        # Unconditionally drop the resource in-case
+        # self.jira_client was not properly instantiated but something
+        # tries to use it between now and __exit__
+        self.jira_client = None
+
+    def add_trigger(self, trigger):
+        """This method is called when trigger is created"""
+
+    def update_trigger(self, trigger):
+        """This method is called when trigger is updated"""
+
+    def remove_trigger(self, trigger):
+        """This method is called when trigger is deleted"""

--- a/tests/lib/workflows/test_jira_openstack_request_new_project.py
+++ b/tests/lib/workflows/test_jira_openstack_request_new_project.py
@@ -1,0 +1,11 @@
+from structs.jira.jira_account import JiraAccount
+import pytest
+from workflows.jira_openstack_request_new_project import request_new_project
+
+
+def test_request_new_project_placeholder():
+    """Test that request_new_project raises NotImplementedError."""
+    issue_key = "TEST-123"
+
+    with pytest.raises(NotImplementedError):
+        request_new_project(JiraAccount, issue_key)

--- a/tests/sensors/test_jira_issue_sensor.py
+++ b/tests/sensors/test_jira_issue_sensor.py
@@ -1,0 +1,223 @@
+from unittest.mock import MagicMock, patch
+import pytest
+from sensors.src.jira_issue_sensor import JiraIssueSensor
+
+
+@pytest.fixture(name="sensor")
+def jira_sensor_fixture():
+    """
+    Pytest fixture that initializes an instance of JiraIssueSensor.
+
+    What is a fixture?
+    -------------------
+    - A fixture is a reusable setup function that pytest runs before executing a test function.
+    - It provides a fresh instance of an object for each test to prevent test interference.
+    - This fixture returns a fully initialized JiraIssueSensor instance.
+
+    What does this fixture do?
+    --------------------------
+    - Creates a `sensor_service` mock (simulates StackStorm's event handling system).
+    - Sets up a fake configuration dictionary (`config`) to simulate actual configuration values.
+    - Returns a `JiraIssueSensor` instance with the mock `sensor_service` and sample configuration.
+    """
+
+    # Create a mock object for `sensor_service` (simulates event dispatching)
+    mock_sensor_service = MagicMock()
+
+    # Define a mock configuration dictionary
+    config = {
+        "jira_accounts": [
+            {
+                "name": "default",
+                "username": "test_user",
+                "api_token": "test_token",
+                "atlassian_endpoint": "https://example-jira",
+            }
+        ],
+        "jira_account_name": "default",  # Specifies which Jira account to use
+        "jira_sensor": {},  # Placeholder (for any additional settings)
+    }
+
+    # Return a JiraIssueSensor instance with the mock sensor service and config
+    return JiraIssueSensor(
+        sensor_service=mock_sensor_service,
+        config=config,
+        poll_interval=10,
+    )
+
+
+@patch("jira.client.JIRA")  # Prevents real network requests to Jira
+@patch("structs.jira.jira_account.JiraAccount.from_pack_config")
+def test_setup(mock_from_pack_config, mock_jira_client, sensor):
+    """
+    Test the `setup()` method of JiraIssueSensor.
+
+    What does this test verify?
+    ---------------------------
+    - Ensures `JiraAccount.from_pack_config()` is called with the correct parameters.
+    - Ensures the JIRA client is initialized correctly with proper credentials.
+
+    Why is `patch("jira.client.JIRA")` needed?
+    -------------------------------------------
+    - The `setup()` method creates a Jira client (`jira.client.JIRA(...)`).
+    - If not patched, it would try to connect to a real Jira server, causing test failures.
+    """
+
+    # Mock JiraAccount instance
+    mock_jira_account = MagicMock()
+    mock_from_pack_config.return_value = mock_jira_account
+
+    # Assign fake Jira credentials to the mock JiraAccount
+    mock_jira_account.atlassian_endpoint = "https://jira.example.com"
+    mock_jira_account.api_token = "mocked_token"
+    mock_jira_account.username = "mocked_user"
+
+    # Mock JIRA client instance
+    mock_jira_instance = MagicMock()
+    mock_jira_client.return_value = mock_jira_instance
+
+    # Call setup() to initialize Jira credentials and JIRA client
+    sensor.setup()
+
+    # Ensure `from_pack_config()` is called with the correct arguments
+    mock_from_pack_config.assert_called_once_with(
+        sensor.config, sensor.config["jira_account_name"]
+    )
+
+    # Ensure JIRA client is initialized with correct parameters
+    mock_jira_client.assert_called_once_with(
+        server="https://jira.example.com",
+        basic_auth=("mocked_user", "mocked_token"),
+    )
+
+
+@patch("jira.client.JIRA")  # Prevents real network requests to Jira
+@patch(
+    "sensors.src.jira_issue_sensor.search_issues"
+)  # Mocks the Jira issue search function
+@patch(
+    "structs.jira.jira_account.JiraAccount.from_pack_config"
+)  # Mocks Jira account retrieval
+def test_poll_with_no_issues(
+    mock_from_pack_config, mock_search_issues, mock_jira_client, sensor
+):
+    """
+    Test `poll()` when `search_issues()` returns an empty list (no issues found).
+
+    Expected behavior:
+    ------------------
+    - `search_issues()` should still be called with the correct parameters.
+    - No triggers should be dispatched since there are no issues.
+
+    Why do we call `sensor.setup()` in this test?
+    ---------------------------------------------
+    - `poll()` depends on `self.jira_account`, which is initialized in `setup()`.
+    - If `setup()` is not called, `self.jira_account` does not exist, causing `AttributeError`.
+    """
+
+    # Mock JiraAccount instance
+    mock_jira_account = MagicMock()
+    mock_from_pack_config.return_value = mock_jira_account
+
+    # Assign fake Jira credentials
+    mock_jira_account.atlassian_endpoint = "https://jira.example.com"
+    mock_jira_account.api_token = "mocked_token"
+    mock_jira_account.username = "mocked_user"
+
+    mock_jira_instance = MagicMock()
+    mock_jira_client.return_value = mock_jira_instance
+
+    # Ensure `search_issues()` returns an empty list (no issues)
+    mock_search_issues.return_value = []
+
+    # Call setup() to initialize JiraAccount and JIRA client
+    sensor.setup()
+
+    # Call poll()
+    sensor.poll()
+
+    # Ensure `search_issues()` is called correctly for each request type
+    mock_search_issues.assert_any_call(
+        sensor.jira_account,
+        "STFCCLOUD",
+        [
+            'statusCategory in ("Ready For Automation")',
+            '"Request Type" = "Request New Project"',
+        ],
+    )
+    mock_search_issues.assert_any_call(
+        sensor.jira_account,
+        "STFCCLOUD",
+        [
+            'statusCategory in ("Ready For Automation")',
+            '"Request Type" = "Add User"',
+        ],
+    )
+
+    # Ensure no triggers were dispatched since no issues were found
+    sensor.sensor_service.dispatch.assert_not_called()
+
+
+@patch("jira.client.JIRA")  # Prevents real network requests to Jira
+@patch(
+    "sensors.src.jira_issue_sensor.search_issues"
+)  # Mocks the Jira issue search function
+@patch(
+    "structs.jira.jira_account.JiraAccount.from_pack_config"
+)  # Mocks Jira account retrieval
+def test_poll_with_issues(
+    mock_from_pack_config, mock_search_issues, mock_jira_client, sensor
+):
+    """
+    Test `poll()` when `search_issues()` returns a list of Jira issues.
+
+    Expected behavior:
+    ------------------
+    - `search_issues()` should be called with the correct parameters.
+    - The correct triggers should be dispatched for each issue.
+
+    Why do we call `sensor.setup()` in this test?
+    ---------------------------------------------
+    - `poll()` depends on `self.jira_account`, which is initialized in `setup()`.
+    - If `setup()` is not called, `self.jira_account` does not exist, causing `AttributeError`.
+    """
+
+    # Mock JiraAccount instance
+    mock_jira_account = MagicMock()
+    mock_from_pack_config.return_value = mock_jira_account
+
+    # Assign fake Jira credentials
+    mock_jira_account.atlassian_endpoint = "https://jira.example.com"
+    mock_jira_account.api_token = "mocked_token"
+    mock_jira_account.username = "mocked_user"
+
+    mock_jira_instance = MagicMock()
+    mock_jira_client.return_value = mock_jira_instance
+
+    # Mock Jira issues
+    mock_issue_1 = MagicMock(key="ISSUE-101")
+    mock_issue_2 = MagicMock(key="ISSUE-202")
+    mock_search_issues.return_value = [mock_issue_1, mock_issue_2]
+
+    # Call setup() to initialize JiraAccount and JIRA client
+    sensor.setup()
+
+    # Call poll()
+    sensor.poll()
+
+    # Ensure correct triggers are dispatched
+    sensor.sensor_service.dispatch.assert_any_call(
+        trigger="jira.request_new_project", payload={"issue_key": "ISSUE-101"}
+    )
+    sensor.sensor_service.dispatch.assert_any_call(
+        trigger="jira.request_new_project", payload={"issue_key": "ISSUE-202"}
+    )
+    sensor.sensor_service.dispatch.assert_any_call(
+        trigger="jira.add_user", payload={"issue_key": "ISSUE-101"}
+    )
+    sensor.sensor_service.dispatch.assert_any_call(
+        trigger="jira.add_user", payload={"issue_key": "ISSUE-202"}
+    )
+
+    # Ensure exactly 4 dispatch calls were made (2 issues x 2 request types)
+    assert sensor.sensor_service.dispatch.call_count == 4


### PR DESCRIPTION
Create an skeleton for the new set of Automations to perform changes in OpenStack triggered by JIRA Issues.

In this PR, we are only adding the skeleton, but with no actual implementation for real Actions. Not yet. This is some for of placeholder for it. From now on, the implementation of the actual Automations, including the first one, can be done in incremental steps instead of all of it in a single big bang.


