### PR TITLE
Deal with empty fields in the form

### DIFF
--- a/lib/jira_api/issue_types/new_project_request.py
+++ b/lib/jira_api/issue_types/new_project_request.py
@@ -15,14 +15,24 @@ class NewProjectRequestIssue(IssueBase):  # pylint: disable=too-few-public-metho
         answers = proforma_form.value.state.answers
 
         properties["project_name"] = getattr(answers, "3").text
-        properties["users"] = getattr(answers, "29").adf.content[0].content[0].text
+        potential_users_info = getattr(answers, "29").adf.content
+        if potential_users_info:
+            # the value is not an empty string
+            properties["users"] = potential_users_info[0].content[0].text
+        else:
+            properties["users"] = ""
         properties["cpus"] = int(getattr(answers, "32").text)
         properties["vms"] = int(getattr(answers, "45").text)
         properties["memory"] = int(getattr(answers, "33").text)
         properties["shared_storage"] = int(getattr(answers, "34").text)
         properties["object_storage"] = int(getattr(answers, "35").text)
         properties["block_storage"] = int(getattr(answers, "44").text)
-        properties["gpus"] = getattr(answers, "17").adf.content[0].content[0].text
+        potential_gpus_info = getattr(answers, "17").adf.content
+        if potential_gpus_info:
+            # the value is not an empty string
+            properties["gpus"] = potential_gpus_info[0].content[0].text
+        else:
+            properties["gpus"] = ""
         properties["contact_email"] = getattr(answers, "25").text
         properties["reporting_fed_id"] = getattr(answers, "42").text
 

--- a/tests/lib/jira_api/test_new_project_request.py
+++ b/tests/lib/jira_api/test_new_project_request.py
@@ -216,3 +216,67 @@ def test_create_properties_false():
     # Assert specifically for "True" here as
     assert res["externally_accessible"] is False
     assert res["tos_agreement"] is True
+
+
+MOCK_ISSUE_DATA_EMPTY_VALUES = [
+    DefaultMunch.fromDict(
+        {
+            "key": "proforma.forms.i1",
+            "value": {
+                "state": {
+                    "visibility": "e",
+                    "status": "o",
+                    "answers": {
+                        "3": {"text": "test-project-empty-values"},
+                        "29": {  # Empty list for users
+                            "adf": {
+                                "version": 1,
+                                "type": "doc",
+                                "content": [],
+                            }
+                        },
+                        "17": {  # Empty list for gpus
+                            "adf": {
+                                "version": 1,
+                                "type": "doc",
+                                "content": [],
+                            }
+                        },
+                        "32": {"text": "4"},
+                        "45": {"text": "2"},
+                        "33": {"text": "16"},
+                        "34": {"text": "5"},
+                        "35": {"text": "10"},
+                        "44": {"text": "8"},
+                        "42": {"text": "empty_fedid"},
+                        "25": {"text": "empty_user@mock_email"},
+                        "31": {"choices": ["2"]},
+                    },
+                },
+            },
+        }
+    )
+]
+
+
+def test_create_properties_empty_values():
+    """Test case where 'users' and 'gpus' fields should be empty."""
+    mock_conn = MagicMock()
+    mock_conn.issue_properties.return_value = MOCK_ISSUE_DATA_EMPTY_VALUES
+    issue = NewProjectRequestIssue(mock_conn, "EMPTY123")
+    res = issue.properties
+    mock_conn.issue_properties.assert_called_once_with("EMPTY123")
+
+    assert res["project_name"] == "test-project-empty-values"
+    assert res["users"] == ""  # Should be an empty string
+    assert res["gpus"] == ""  # Should be an empty string
+    assert res["cpus"] == 4
+    assert res["vms"] == 2
+    assert res["memory"] == 16
+    assert res["shared_storage"] == 5
+    assert res["object_storage"] == 10
+    assert res["block_storage"] == 8
+    assert res["contact_email"] == "empty_user@mock_email"
+    assert res["reporting_fed_id"] == "empty_fedid"
+    assert res["externally_accessible"] is False
+    assert res["tos_agreement"] is True


### PR DESCRIPTION
When the user does not fill the boxes with some data, the attribute
    getattr(answers, "<field number>").adf.content
is just an empty list. Therefore, we cannot just try to get the value of the first index
    getattr(answers, "<field number>").adf.content[0]
as it does not exist.

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
