### PR TITLE
Fix bug in JIRA query

### DIFF
--- a/sensors/src/jira_issue_sensor.py
+++ b/sensors/src/jira_issue_sensor.py
@@ -57,7 +57,7 @@ class JiraIssueSensor(PollingSensor):
         """
         for request_type, trigger_name in self.request_type_dict.items():
             requirements_list = [
-                'statusCategory in ("Ready For Automation")',
+                'status = "Ready For Automation"',
                 f'"Request Type" = "{request_type}"',
             ]
             issues_list = search_issues(

--- a/tests/sensors/test_jira_issue_sensor.py
+++ b/tests/sensors/test_jira_issue_sensor.py
@@ -183,7 +183,7 @@ def test_poll_with_no_issues(
         sensor.jira_account,
         "DCTE",
         [
-            'statusCategory in ("Ready For Automation")',
+            'status = "Ready For Automation"',
             '"Request Type" = "Request New Project"',
         ],
     )
@@ -191,7 +191,7 @@ def test_poll_with_no_issues(
         sensor.jira_account,
         "DCTE",
         [
-            'statusCategory in ("Ready For Automation")',
+            'status = "Ready For Automation"',
             '"Request Type" = "Add User"',
         ],
     )


### PR DESCRIPTION
To find JIRA Issues ready for automation, we need to check their "status" rather than their "statusCategory".
Those are 2 different things in JIRA.

For us, at least for the time being until the JIRA Workflow is finalised, the relevant one is the "status".
