### PR TITLE
Increase default timeouts for server actions

### DIFF
--- a/lib/openstack_api/openstack_server.py
+++ b/lib/openstack_api/openstack_server.py
@@ -47,7 +47,7 @@ def snapshot_and_migrate_server(
     logger.info("Migrating server: %s", server.id)
     if server.status == "SHUTOFF":
         conn.compute.migrate_server(server=server_id, host=dest_host)
-        conn.compute.wait_for_server(server, status="VERIFY_RESIZE")
+        conn.compute.wait_for_server(server, status="VERIFY_RESIZE", wait=3600)
         conn.compute.confirm_server_resize(server_id)
         wait_for_migration_status(conn, server_id, "confirmed")
     if server.status == "ACTIVE":
@@ -82,7 +82,7 @@ def snapshot_server(conn: Connection, server_id: str) -> Image:
     return image
 
 
-def wait_for_image_status(conn: Connection, image, status, interval=5, timeout=600):
+def wait_for_image_status(conn: Connection, image, status, interval=5, timeout=3600):
     """
     Waits for the status of the image to be the selected status
     :param conn: Openstack connection
@@ -106,7 +106,7 @@ def wait_for_image_status(conn: Connection, image, status, interval=5, timeout=6
 
 
 def wait_for_migration_status(
-    conn: Connection, server_id, status, interval=5, timeout=600
+    conn: Connection, server_id, status, interval=5, timeout=3600
 ):
     """
     Waits for the status of the migration to be the selected status
@@ -172,7 +172,7 @@ def build_server(
     logger.info("Building server: %s", server.id)
     try:
         conn.compute.wait_for_server(
-            server, status="ACTIVE", failures=None, interval=5, wait=300
+            server, status="ACTIVE", failures=None, interval=5, wait=3600
         )
     except (ResourceTimeout, ResourceFailure) as e:
         if delete_on_failure:
@@ -201,5 +201,5 @@ def delete_server(
     logger.info("Deleting server: %s", server.id)
     conn.compute.delete_server(server, force)
 
-    conn.compute.wait_for_delete(server, interval=5, wait=300)
+    conn.compute.wait_for_delete(server, interval=5, wait=3600)
     logger.info("Deleted server: %s", server.id)

--- a/tests/lib/openstack_api/test_openstack_server.py
+++ b/tests/lib/openstack_api/test_openstack_server.py
@@ -78,7 +78,7 @@ def test_shutoff_migration(
         server=mock_server_id, host=dest_host
     )
     mock_connection.compute.wait_for_server.assert_called_once_with(
-        mock_server, status="VERIFY_RESIZE"
+        mock_server, status="VERIFY_RESIZE", wait=3600
     )
     mock_connection.compute.confirm_server_resize(mock_server_id)
     mock_wait_for_migration_status.assert_called_once_with(
@@ -387,7 +387,7 @@ def test_build_server():
         }
     )
     mock_conn.compute.wait_for_server.assert_called_once_with(
-        mock_server, status="ACTIVE", failures=None, interval=5, wait=300
+        mock_server, status="ACTIVE", failures=None, interval=5, wait=3600
     )
 
     assert res == mock_server
@@ -434,7 +434,7 @@ def test_build_server_delete_on_failure():
         }
     )
     mock_conn.compute.wait_for_server.assert_called_once_with(
-        mock_server, status="ACTIVE", failures=None, interval=5, wait=300
+        mock_server, status="ACTIVE", failures=None, interval=5, wait=3600
     )
     mock_conn.compute.delete_server.assert_called_once_with(mock_server, force=True)
 
@@ -480,7 +480,7 @@ def test_build_server_delete_on_failure_false():
         }
     )
     mock_conn.compute.wait_for_server.assert_called_once_with(
-        mock_server, status="ACTIVE", failures=None, interval=5, wait=300
+        mock_server, status="ACTIVE", failures=None, interval=5, wait=3600
     )
     mock_conn.compute.delete_server.assert_not_called()
 
@@ -500,7 +500,7 @@ def test_delete_server():
     mock_conn.compute.find_server.assert_called_once_with("test-server-id")
     mock_conn.compute.delete_server.assert_called_once_with(mock_server, False)
     mock_conn.compute.wait_for_delete.assert_called_once_with(
-        mock_server, interval=5, wait=300
+        mock_server, interval=5, wait=3600
     )
 
 
@@ -519,5 +519,5 @@ def test_force_delete_server():
     mock_conn.compute.find_server.assert_called_once_with("test-server-id")
     mock_conn.compute.delete_server.assert_called_once_with(mock_server, True)
     mock_conn.compute.wait_for_delete.assert_called_once_with(
-        mock_server, interval=5, wait=300
+        mock_server, interval=5, wait=3600
     )


### PR DESCRIPTION
### Description:
Increase the timeout to 1 hour for server actions, this should allow enough time to complete snapshots and migrations

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
