### PR TITLE
Adding Cloud ChatOps Sensor

### DIFF
--- a/actions/chatops.pr_reminder.yaml
+++ b/actions/chatops.pr_reminder.yaml
@@ -1,0 +1,29 @@
+---
+description: Send a reminder request to the ChatOps application
+enabled: true
+entry_point: src/openstack_actions.py
+name: chatops.pr_reminder
+runner_type: python-script
+parameters:
+  lib_entry_point:
+    type: string
+    default: workflows.chatops_pr_reminder.pr_reminder
+    immutable: true
+  reminder_type:
+    type: string
+    description: "The type of message to send (e.g., global, personal)"
+    required: true
+  channel:
+    type: string
+    description: "The channel to send the message to. Must be configured in the pack settings."
+    required: true
+    default: "default"
+  chatops_token:
+    type: string
+    secret: true
+    description: "The token to authenticate the request with. Must be configured in the pack settings."
+    default: "default"
+  endpoint:
+    type: string
+    description: "The endpoint URL to send the request to. Must be configured in the pack settings."
+    default: "default"

--- a/actions/chatops.pr_reminder.yaml
+++ b/actions/chatops.pr_reminder.yaml
@@ -9,7 +9,7 @@ parameters:
     type: string
     default: workflows.chatops_pr_reminder.pr_reminder
     immutable: true
-  reminder_type:
+  chatops_reminder_type:
     type: string
     description: "The type of message to send."
     required: true

--- a/actions/chatops.pr_reminder.yaml
+++ b/actions/chatops.pr_reminder.yaml
@@ -11,11 +11,11 @@ parameters:
     immutable: true
   reminder_type:
     type: string
-    description: "The type of message to send (e.g., global, personal)"
+    description: "The type of message to send."
     required: true
-  channel:
-    type: string
-    description: "The channel to send the message to. Must be configured in the pack settings."
+    enum:
+      - "global"
+      - "personal"
     required: true
     default: "default"
   chatops_token:

--- a/actions/chatops.pr_reminder.yaml
+++ b/actions/chatops.pr_reminder.yaml
@@ -16,14 +16,3 @@ parameters:
     enum:
       - "global"
       - "personal"
-    required: true
-    default: "default"
-  chatops_token:
-    type: string
-    secret: true
-    description: "The token to authenticate the request with. Must be configured in the pack settings."
-    default: "default"
-  endpoint:
-    type: string
-    description: "The endpoint URL to send the request to. Must be configured in the pack settings."
-    default: "default"

--- a/actions/src/openstack_actions.py
+++ b/actions/src/openstack_actions.py
@@ -61,4 +61,11 @@ class OpenstackActions(Action):
                 self.config, kwargs["alertmanager_account_name"]
             )
             del kwargs["alertmanager_account_name"]
+
+        if "chatops_token" in kwargs:
+            kwargs["token"] = self.config["chatops_sensor"]["token"]
+            kwargs["endpoint"] = self.config["chatops_sensor"]["endpoint"]
+            kwargs["channel"] = self.config["chatops_sensor"]["channel"]
+            del kwargs["chatops_token"]
+
         return kwargs

--- a/actions/src/openstack_actions.py
+++ b/actions/src/openstack_actions.py
@@ -62,10 +62,11 @@ class OpenstackActions(Action):
             )
             del kwargs["alertmanager_account_name"]
 
-        if "reminder_type" in kwargs:
+        if "chatops_reminder_type" in kwargs:
             kwargs["token"] = self.config["chatops_sensor"]["token"]
             kwargs["endpoint"] = self.config["chatops_sensor"]["endpoint"]
             kwargs["channel"] = self.config["chatops_sensor"]["channel"]
-            del kwargs["reminder_type"]
+            kwargs["reminder_type"] = kwargs["chatops_reminder_type"]
+            del kwargs["chatops_reminder_type"]
 
         return kwargs

--- a/actions/src/openstack_actions.py
+++ b/actions/src/openstack_actions.py
@@ -62,10 +62,10 @@ class OpenstackActions(Action):
             )
             del kwargs["alertmanager_account_name"]
 
-        if "chatops_token" in kwargs:
+        if "reminder_type" in kwargs:
             kwargs["token"] = self.config["chatops_sensor"]["token"]
             kwargs["endpoint"] = self.config["chatops_sensor"]["endpoint"]
             kwargs["channel"] = self.config["chatops_sensor"]["channel"]
-            del kwargs["chatops_token"]
+            del kwargs["reminder_type"]
 
         return kwargs

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -170,3 +170,20 @@ hypervisor_sensor:
     state_expire_after:
       type: "integer"
       description: "Number of seconds before forcefully deleting previous state to update hypervisors stuck in a state"
+
+chatops_sensor:
+  description: "ChatOps sensor specific settings."
+  type: "object"
+  required: false
+  additionalProperties: false
+  properties:
+    endpoint:
+      type: "string"
+      description: "ChatOps endpoint to use."
+    token:
+      type: "string"
+      description: "API token to authenticate requests."
+      secret: true
+    channel:
+      type: "string"
+      description: "Channel to send reminders to."

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -101,6 +101,15 @@ the following are actions related to STFC Cloud JuptyerHub Service
 | workflow.jupyter.user.prepare | Creates a list of JupyterHub users, and starts up servers for each user                         |
 
 
+## ChatOps Actions
+
+The following are actions related to STFC Cloud Slack ChatOps
+
+| Action Name         | Description                                                                                 |
+|---------------------|---------------------------------------------------------------------------------------------|
+| chatops.pr_reminder | Sends a HTTP Post request to a ChatOps endpoint to trigger reminders to the Slack workspace |
+
+
 ## Query Library (WIP)
 
 The following are actions that use the query library.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -35,3 +35,10 @@ to handle rabbitmq message commands.
 | ----------- | ----------- |
 | `openstack.deletedmachines.rule` | matches trigger `openstack.deletingmachines` when a machine is stuck in the deleting state for more than 10m. Calls the `atlassian.create.tickets` action. The sensor for this rule runs every 7 days. |
 | `openstack.loadbalancers.rule` | matches trigger `openstack.loadbalancer` when a loadbalancer or amphora is not pingable or is reporting an error. Calls the `atlassian.create.tickets` action. The sensor for this rule runs every 7 days. |
+
+## ChatOps rules
+
+| Rule                           | Description                                                                                             |
+|--------------------------------|---------------------------------------------------------------------------------------------------------|
+| `chatops.pr_reminder.global`   | Uses `core.st2.CronTimer` to trigger every Monday, Wednesday at 8AM UTC and calls `chatops.pr_reminder` |
+| `chatops.pr_reminder.personal` | Uses `core.st2.CronTimer` to trigger every Monday at 8AM UTC and calls `chatops.pr_reminder`            |

--- a/lib/workflows/chatops_pr_reminder.py
+++ b/lib/workflows/chatops_pr_reminder.py
@@ -12,6 +12,6 @@ def pr_reminder(endpoint: str, token: str, channel: str, reminder_type: str) -> 
     """
     headers = {"Content-Type": "application/json", "Authorization": f"token {token}"}
     body = {"reminder_type": reminder_type, "channel": channel}
-    response = requests.post(endpoint, json=body, headers=headers)
+    response = requests.post(endpoint, json=body, headers=headers, timeout=120)
     response.raise_for_status()
     return {"status_code": response.status_code, "response": response.text}

--- a/lib/workflows/chatops_pr_reminder.py
+++ b/lib/workflows/chatops_pr_reminder.py
@@ -1,0 +1,26 @@
+from typing import Dict
+import requests
+
+
+def pr_reminder(endpoint: str, token: str, channel: str, reminder_type: str) -> Dict:
+    """
+    Send a HTTP post request to the ChatOps app endpoint to trigger a reminder.
+    :param endpoint: URL of ChatOps application endpoint
+    :param token: Token to authenticate request with
+    :param channel: Channel to send the message to
+    :param reminder_type: Type of reminder. E.g. global or personal
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"token {token}"
+    }
+    body = {
+        "reminder_type": reminder_type,
+        "channel": channel
+    }
+    response = requests.post(endpoint, json=body, headers=headers)
+    response.raise_for_status()
+    return {
+        "status_code": response.status_code,
+        "response": response.text
+    }

--- a/lib/workflows/chatops_pr_reminder.py
+++ b/lib/workflows/chatops_pr_reminder.py
@@ -10,17 +10,8 @@ def pr_reminder(endpoint: str, token: str, channel: str, reminder_type: str) -> 
     :param channel: Channel to send the message to
     :param reminder_type: Type of reminder. E.g. global or personal
     """
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"token {token}"
-    }
-    body = {
-        "reminder_type": reminder_type,
-        "channel": channel
-    }
+    headers = {"Content-Type": "application/json", "Authorization": f"token {token}"}
+    body = {"reminder_type": reminder_type, "channel": channel}
     response = requests.post(endpoint, json=body, headers=headers)
     response.raise_for_status()
-    return {
-        "status_code": response.status_code,
-        "response": response.text
-    }
+    return {"status_code": response.status_code, "response": response.text}

--- a/rules/chatops.pr_reminder.global.yaml
+++ b/rules/chatops.pr_reminder.global.yaml
@@ -16,4 +16,4 @@ trigger:
 action:
   ref: stackstorm_openstack.chatops.pr_reminder
   parameters:
-    reminder_type: "global"
+    chatops_reminder_type: "global"

--- a/rules/chatops.pr_reminder.global.yaml
+++ b/rules/chatops.pr_reminder.global.yaml
@@ -7,9 +7,9 @@ enabled: true
 trigger:
   type: core.st2.CronTimer
   parameters:
-    timezone: "UTC"
+    timezone: "Europe/London"
     day_of_week: mon,wed
-    hour: 8
+    hour: 9
     minute: 00
 
 

--- a/rules/chatops.pr_reminder.global.yaml
+++ b/rules/chatops.pr_reminder.global.yaml
@@ -1,0 +1,19 @@
+---
+name: chatops_pr_reminder_global
+pack: stackstorm_openstack
+description: Send a global reminder request every Monday and Wednesday at 9AM to the ChatOps application
+enabled: true
+
+trigger:
+  type: core.st2.CronTimer
+  parameters:
+    timezone: "UTC"
+    day_of_week: mon,wed
+    hour: 8
+    minute: 00
+
+
+action:
+  ref: stackstorm_openstack.chatops.pr_reminder
+  parameters:
+    reminder_type: "global"

--- a/rules/chatops.pr_reminder.personal.yaml
+++ b/rules/chatops.pr_reminder.personal.yaml
@@ -7,9 +7,9 @@ enabled: true
 trigger:
   type: core.st2.CronTimer
   parameters:
-    timezone: "UTC"
+    timezone: "Europe/London"
     day_of_week: mon
-    hour: 8
+    hour: 9
     minute: 00
 
 

--- a/rules/chatops.pr_reminder.personal.yaml
+++ b/rules/chatops.pr_reminder.personal.yaml
@@ -1,0 +1,19 @@
+---
+name: chatops_pr_reminder_personal
+pack: stackstorm_openstack
+description: Send a personal reminder request every Monday at 9AM to the ChatOps application
+enabled: true
+
+trigger:
+  type: core.st2.CronTimer
+  parameters:
+    timezone: "UTC"
+    day_of_week: mon
+    hour: 8
+    minute: 00
+
+
+action:
+  ref: stackstorm_openstack.chatops.pr_reminder
+  parameters:
+    reminder_type: "personal"

--- a/rules/chatops.pr_reminder.personal.yaml
+++ b/rules/chatops.pr_reminder.personal.yaml
@@ -16,4 +16,4 @@ trigger:
 action:
   ref: stackstorm_openstack.chatops.pr_reminder
   parameters:
-    reminder_type: "personal"
+    chatops_reminder_type: "personal"

--- a/stackstorm_openstack.yaml.example
+++ b/stackstorm_openstack.yaml.example
@@ -37,3 +37,8 @@ hypervisor_sensor:
   cloud_account:
   uptime_limit:
   state_expire_after:
+
+chatops_sensor:
+  endpoint:
+  token:
+  channel:

--- a/tests/actions/test_openstack_actions.py
+++ b/tests/actions/test_openstack_actions.py
@@ -145,16 +145,17 @@ class TestOpenstackActions(OpenstackActionTestBase):
         self.action.config = {
             "chatops_sensor": {
                 "token": "mock_token",
-                "endpoint": "mock_endpoint",  # fix typo here
+                "endpoint": "mock_endpoint",
                 "channel": "mock_channel",
             }
         }
 
         # Call parse_configs with reminder_type
-        result = self.action.parse_configs(reminder_type="mock_reminder_type")
+        result = self.action.parse_configs(chatops_reminder_type="mock_reminder_type")
 
         assert result == {
             "token": "mock_token",
             "endpoint": "mock_endpoint",
             "channel": "mock_channel",
+            "reminder_type": "mock_reminder_type",
         }

--- a/tests/actions/test_openstack_actions.py
+++ b/tests/actions/test_openstack_actions.py
@@ -136,3 +136,25 @@ class TestOpenstackActions(OpenstackActionTestBase):
         mock_kwargs = {"arg1": "val1", "arg2": "val2"}
         res = self.action.parse_configs(**mock_kwargs)
         assert res == mock_kwargs
+
+    def test_parse_configs_with_chatops(self):
+        """
+        tests that parse_configs parses chatops config properly if reminder_type is provided
+        """
+        # Set the config properly
+        self.action.config = {
+            "chatops_sensor": {
+                "token": "mock_token",
+                "endpoint": "mock_endpoint",  # fix typo here
+                "channel": "mock_channel",
+            }
+        }
+
+        # Call parse_configs with reminder_type
+        result = self.action.parse_configs(reminder_type="mock_reminder_type")
+
+        assert result == {
+            "token": "mock_token",
+            "endpoint": "mock_endpoint",
+            "channel": "mock_channel",
+        }

--- a/tests/lib/workflows/test_chatops_pr_reminder.py
+++ b/tests/lib/workflows/test_chatops_pr_reminder.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+from workflows.chatops_pr_reminder import pr_reminder
+
+
+@patch("workflows.chatops_pr_reminder.requests")
+def test_pr_reminder(mock_requests) -> None:
+    """Test PR reminder runs successfully with correct arguments."""
+    mock_endpoint = "https://mock.url/endpoint"
+    mock_token = "mock_token"
+    mock_channel = "mock_channel"
+    mock_reminder_type = "mock_reminder_type"
+    res = pr_reminder(mock_endpoint, mock_token, mock_channel, mock_reminder_type)
+    mock_response = mock_requests.post.return_value
+    mock_headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"token {mock_token}",
+    }
+    mock_body = {"reminder_type": mock_reminder_type, "channel": mock_channel}
+    mock_requests.post.assert_called_once_with(
+        mock_endpoint, json=mock_body, headers=mock_headers, timeout=120
+    )
+    mock_response.raise_for_status.assert_called_once()
+    assert res == {
+        "status_code": mock_response.status_code,
+        "response": mock_response.text,
+    }


### PR DESCRIPTION
### Description:

Adds a sensor to trigger the ChatOps weekly reminders.

The sensor uses the [schedule](https://schedule.readthedocs.io/en/stable/) library to run events on specific days and times. When the schedule is triggered it makes a HTTP request to the ChatOps application with a token we provide in the pack config.

### Special Notes:

Adds extra variables to the pack config.

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [x] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
