### PR TITLE
BUG: Correct hypervisor query string alias

### DIFF
--- a/lib/workflows/find_empty_hypervisors.py
+++ b/lib/workflows/find_empty_hypervisors.py
@@ -14,7 +14,7 @@ def find_empty_hypervisors(cloud_account: str, include_offline: bool) -> List[st
     hv_query = HypervisorQuery()
     hv_query.where(
         "equal_to",
-        "hypervisor_vcpus_used",
+        "vcpus_used",
         value=0,
     )
     if not include_offline:

--- a/tests/lib/workflows/test_find_empty_hypervisors.py
+++ b/tests/lib/workflows/test_find_empty_hypervisors.py
@@ -21,7 +21,7 @@ def test_with_empty_hvs(mocked_query_factory):
     query_obj.select.assert_called_once_with("hypervisor_name")
     query_obj.where.assert_called_once_with(
         "equal_to",
-        "hypervisor_vcpus_used",
+        "vcpus_used",
         value=0,
     )
     query_obj.run.assert_called_once_with(cloud_account="test")
@@ -46,7 +46,7 @@ def test_with_empty_hvs_excluding_offline(mocked_query_factory):
     query_obj.select.assert_called_once_with("hypervisor_name")
     query_obj.where.assert_any_call(
         "equal_to",
-        "hypervisor_vcpus_used",
+        "vcpus_used",
         value=0,
     )
     query_obj.where.assert_any_call(


### PR DESCRIPTION
### Description:

`hypervisor_vcpus_used` has been renamed to `vcpus_used`

Closes #377

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
