### PR TITLE
ENH: Add Flavor Sensor Rule to create Jira task

### DIFF
--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -20,7 +20,7 @@ action:
       - Target Flavor ID: {{trigger.target_flavor_id}}\\
       \\
       Mismatch:\\
-      {{trigger.mismatch}}\\
+      {{trigger.flavor_mismatch}}\\
       \\
       Source Flavor Properties:\\
       {{trigger.source_flavor_properties}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -15,7 +15,7 @@ action:
     description: >
       Details:\\
       - Flavor Name: {{trigger.flavor_name}}\\
-      - Sync Direction: {{trigger.source_cloud}} >>> {{trigger.target_cloud}}\\
+      - Sync Direction: {{trigger.source_cloud}} {{ '>>>' }} {{trigger.target_cloud}}\\
       - Source Flavor ID: {{trigger.source_flavor_id}}\\
       - Target Flavor ID: {{trigger.target_flavor_id}}\\
       \\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -1,0 +1,21 @@
+---
+name: "alert.flavor.properties.mismatch"
+pack: "stackstorm_openstack"
+description: "Sends Jira Ticket when it finds a Flavor mismatch is found between the source and target clouds"
+enabled: true
+
+trigger:
+  type: "stackstorm_openstack.flavor.flavor_mismatch"
+
+action:
+  ref: "jira.create_issue"
+  parameters:
+    summary: "[Stackstorm Alert]: Flavor Mismatch Found"
+    type: Problem
+    description: >
+      Flavor Details:\\
+      - Flavor Name: {{trigger.flavor_name}}\\
+      - Source Flavor ID: {{trigger.source_flavor_id}}\\
+      - Target Flavor ID: {{trigger.target_flavor_id}}\\
+      - Mismatch: {{trigger.mismatch}}\\
+      - Triggered At: {{trigger.occurrence_time}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -22,8 +22,8 @@ action:
       Mismatch:\\
       {{trigger.flavor_mismatch}}\\
       \\
-      Source Flavor Properties:\\
-      {{trigger.source_flavor_properties}}\\
-      \\
-      Target Flavor Properties:\\
-      {{trigger.target_flavor_properties}}\\
+# Source Flavor Properties:\\
+# {{trigger.source_flavor_properties}}\\
+# \\
+# Target Flavor Properties:\\
+# {{trigger.target_flavor_properties}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -8,7 +8,7 @@ trigger:
   type: "stackstorm_openstack.flavor.flavor_mismatch"
 
 action:
-  ref: "jira.create_issue"
+  ref: "jira.create_test_issue"
   parameters:
     summary: "[Stackstorm Alert]: Flavor properties mismatch between source and target cloud"
     type: Task

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -11,7 +11,7 @@ action:
   ref: "jira.create_issue"
   parameters:
     summary: "[Stackstorm Alert]: Flavor properties mismatch between source and target cloud"
-    type: Problem
+    type: Task
     description: >
       Flavor Details:\\
       - Flavor Name: {{trigger.flavor_name}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -18,4 +18,3 @@ action:
       - Source Flavor ID: {{trigger.source_flavor_id}}\\
       - Target Flavor ID: {{trigger.target_flavor_id}}\\
       - Mismatch: {{trigger.mismatch}}\\
-      - Triggered At: {{trigger.occurrence_time}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -8,7 +8,7 @@ trigger:
   type: "stackstorm_openstack.flavor.flavor_mismatch"
 
 action:
-  ref: "jira.create_test_issue"
+  ref: "jira.create_issue"
   parameters:
     summary: "[Stackstorm Alert]: Flavor properties mismatch between source and target cloud"
     type: Task

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -11,7 +11,7 @@ action:
   ref: "jira.create_issue"
   parameters:
     summary: "[Stackstorm Alert]: Flavor mismatch detected - {{trigger.flavor_name}}"
-    type: Task
+    type: Problem
     description: >
       Details:\\
       - Flavor Name: {{trigger.flavor_name}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -22,8 +22,8 @@ action:
       Mismatch:\\
       {{trigger.flavor_mismatch}}\\
       \\
-# Source Flavor Properties:\\
-# {{trigger.source_flavor_properties}}\\
-# \\
-# Target Flavor Properties:\\
-# {{trigger.target_flavor_properties}}\\
+      Source Flavor Properties:\\
+      {{trigger.source_flavor_properties}}\\
+      \\
+      Target Flavor Properties:\\
+      {{trigger.target_flavor_properties}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -10,11 +10,20 @@ trigger:
 action:
   ref: "jira.create_issue"
   parameters:
-    summary: "[Stackstorm Alert]: Flavor properties mismatch detected - {{trigger.flavor_name}}"
+    summary: "[Stackstorm Alert]: Flavor mismatch detected - {{trigger.flavor_name}}"
     type: Task
     description: >
-      Flavor Details:\\
+      Details:\\
       - Flavor Name: {{trigger.flavor_name}}\\
+      - Sync Direction: {{trigger.source_cloud}} >>> {{trigger.target_cloud}}\\
       - Source Flavor ID: {{trigger.source_flavor_id}}\\
       - Target Flavor ID: {{trigger.target_flavor_id}}\\
-      - Mismatch: {{trigger.mismatch}}\\
+      \\
+      Mismatch:\\
+      {{trigger.mismatch}}\\
+      \\
+      Source Flavor Properties:\\
+      {{trigger.source_flavor_properties}}\\
+      \\
+      Target Flavor Properties:\\
+      {{trigger.target_flavor_properties}}\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -10,7 +10,7 @@ trigger:
 action:
   ref: "jira.create_issue"
   parameters:
-    summary: "[Stackstorm Alert]: Flavor properties mismatch between source and target cloud"
+    summary: "[Stackstorm Alert]: Flavor properties mismatch detected - {{trigger.flavor_name}}"
     type: Task
     description: >
       Flavor Details:\\

--- a/rules/alert.flavor.properties.mismatch.yaml
+++ b/rules/alert.flavor.properties.mismatch.yaml
@@ -10,7 +10,7 @@ trigger:
 action:
   ref: "jira.create_issue"
   parameters:
-    summary: "[Stackstorm Alert]: Flavor Mismatch Found"
+    summary: "[Stackstorm Alert]: Flavor properties mismatch between source and target cloud"
     type: Problem
     description: >
       Flavor Details:\\

--- a/rules/alert.image.metadata.mismatch.yaml
+++ b/rules/alert.image.metadata.mismatch.yaml
@@ -1,0 +1,19 @@
+---
+name: "alert.image.metadata.mismatch"
+pack: "stackstorm_openstack"
+description: "Sends Jira Ticket for Image metadata mismatch between source and target cloud"
+enabled: true
+
+trigger:
+  type: "stackstorm_openstack.image.metadata_mismatch"
+
+action:
+  ref: "jira.create_issue"
+  parameters:
+    summary: "[Stackstorm Alert]: Image metadata mismatch between source and target cloud"
+    type: Problem
+    description: >
+      Image metadata mismatch Details:\\
+      - Name: {{trigger.image_name}}\\
+      - Source Metadata: {{trigger.source_metadata}}\\
+      - Target Cloud: {{trigger.target_cloud}}\\

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,10 +4,10 @@ set -e
 # set repo directory as st2-cloud-pack location
 REPO_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-export ST2_REPO_PATH="/home/pam62425/repositories/st2"
+export ST2_REPO_PATH="/tmp/st2"
 if [ ! -d "$ST2_REPO_PATH" ]; then
     git clone --depth=1 https://github.com/stackstorm/st2.git "$ST2_REPO_PATH"
 fi
 
 export PYTHONPATH="$PYTHONPATH:$REPO_DIR/lib"
-"$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c -x -v
+"$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,10 +4,10 @@ set -e
 # set repo directory as st2-cloud-pack location
 REPO_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-export ST2_REPO_PATH="/tmp/st2"
+export ST2_REPO_PATH="/home/pam62425/repositories/st2"
 if [ ! -d "$ST2_REPO_PATH" ]; then
     git clone --depth=1 https://github.com/stackstorm/st2.git "$ST2_REPO_PATH"
 fi
 
 export PYTHONPATH="$PYTHONPATH:$REPO_DIR/lib"
-"$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c
+"$ST2_REPO_PATH/st2common/bin/st2-run-pack-tests" -p "$REPO_DIR" -c -x -v

--- a/sensors/flavor.flavor_mismatch.yaml
+++ b/sensors/flavor.flavor_mismatch.yaml
@@ -24,12 +24,12 @@ trigger_types:
         target_flavor_id:
           type: "string"
           description: "ID of the flavor in the target cloud"
+        mismatch:
+          type: "string"
+          descripion: "The difference between the source and target flavors"
         source_flavor_properties:
           type: "object"
           description: "The properties of the source flavor"
         target_flavor_properties:
           type: "object"
           description: "The properties of the target flavor"
-        mismatch:
-          type: "string"
-          descripion: "The difference between the source and target flavors"

--- a/sensors/flavor.flavor_mismatch.yaml
+++ b/sensors/flavor.flavor_mismatch.yaml
@@ -24,9 +24,9 @@ trigger_types:
         target_flavor_id:
           type: "string"
           description: "ID of the flavor in the target cloud"
-        mismatch:
+        flavor_mismatch:
           type: "string"
-          descripion: "The difference between the source and target flavors"
+          description: "The difference between the source and target flavors"
         source_flavor_properties:
           type: "object"
           description: "The properties of the source flavor"

--- a/sensors/flavor.flavor_mismatch.yaml
+++ b/sensors/flavor.flavor_mismatch.yaml
@@ -12,12 +12,24 @@ trigger_types:
         flavor_name:
           type: "string"
           description: "The name of the flavor"
+        source_cloud:
+          type: "string"
+          description: "Name of the source cloud"
+        target_cloud:
+          type: "string"
+          description: "Name of the target cloud"
         source_flavor_id:
           type: "string"
           description: "ID of the flavor in the source cloud"
         target_flavor_id:
           type: "string"
           description: "ID of the flavor in the target cloud"
+        source_flavor_properties:
+          type: "object"
+          description: "The properties of the source flavor"
+        target_flavor_properties:
+          type: "object"
+          description: "The properties of the target flavor"
         mismatch:
           type: "string"
           descripion: "The difference between the source and target flavors"

--- a/sensors/flavor.flavor_mismatch.yaml
+++ b/sensors/flavor.flavor_mismatch.yaml
@@ -27,9 +27,9 @@ trigger_types:
         flavor_mismatch:
           type: "string"
           description: "The difference between the source and target flavors"
-        source_flavor_properties:
-          type: "object"
-          description: "The properties of the source flavor"
-        target_flavor_properties:
-          type: "object"
-          description: "The properties of the target flavor"
+        # source_flavor_properties:
+        #   type: "object"
+        #   description: "The properties of the source flavor"
+        # target_flavor_properties:
+        #   type: "object"
+        #   description: "The properties of the target flavor"

--- a/sensors/flavor.flavor_mismatch.yaml
+++ b/sensors/flavor.flavor_mismatch.yaml
@@ -28,8 +28,8 @@ trigger_types:
           type: "string"
           description: "The difference between the source and target flavors"
         source_flavor_properties:
-          type: "array"
+          type: "string"
           description: "The properties of the source flavor"
         target_flavor_properties:
-          type: "array"
+          type: "string"
           description: "The properties of the target flavor"

--- a/sensors/flavor.flavor_mismatch.yaml
+++ b/sensors/flavor.flavor_mismatch.yaml
@@ -27,9 +27,9 @@ trigger_types:
         flavor_mismatch:
           type: "string"
           description: "The difference between the source and target flavors"
-        # source_flavor_properties:
-        #   type: "object"
-        #   description: "The properties of the source flavor"
-        # target_flavor_properties:
-        #   type: "object"
-        #   description: "The properties of the target flavor"
+        source_flavor_properties:
+          type: "array"
+          description: "The properties of the source flavor"
+        target_flavor_properties:
+          type: "array"
+          description: "The properties of the target flavor"

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -75,7 +75,7 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=None,
                         flavor_mismatch=mismatch,
-                        source_flavor_properties=[source_flavor.to_dict()],
+                        source_flavor_properties=str(source_flavor.to_dict()),
                         target_flavor_properties=None,
                     )
                     continue
@@ -109,8 +109,8 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=target_flavor.id,
                         flavor_mismatch=mismatch,
-                        source_flavor_properties=[source_flavor_properties],
-                        target_flavor_properties=[target_flavor_properties],
+                        source_flavor_properties=str(source_flavor_properties),
+                        target_flavor_properties=str(target_flavor_properties),
                     )
 
                 else:

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -70,8 +70,12 @@ class FlavorPropertiesSensor(PollingSensor):
 
                     dispatch_trigger(
                         flavor_name=source_flavor.name,
+                        source_cloud=self.source_cloud,
+                        target_cloud=self.target_cloud,
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=None,
+                        source_flavor_properties=source_flavor.to_dict(),
+                        target_flavor_properties=None,
                         mismatch=mismatch,
                     )
                     continue
@@ -79,9 +83,13 @@ class FlavorPropertiesSensor(PollingSensor):
                 self.log.info(
                     f"Checking for mismatch between source and target: {flavor_name}"
                 )
+
+                source_flavor_properties = source_flavor.to_dict()
+                target_flavor_properties = target_flavor.to_dict()
+
                 diff = DeepDiff(
-                    source_flavor.to_dict(),
-                    target_flavor.to_dict(),
+                    source_flavor_properties,
+                    target_flavor_properties,
                     ignore_order=True,
                     threshold_to_diff_deeper=0,
                     exclude_paths={
@@ -96,8 +104,12 @@ class FlavorPropertiesSensor(PollingSensor):
 
                     dispatch_trigger(
                         flavor_name=source_flavor.name,
+                        source_cloud=self.source_cloud,
+                        target_cloud=self.target_cloud,
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=target_flavor.id,
+                        source_flavor_properties=source_flavor_properties,
+                        target_flavor_properties=target_flavor_properties,
                         mismatch=mismatch,
                     )
 

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -75,8 +75,8 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=None,
                         flavor_mismatch=mismatch,
-                        source_flavor_properties=source_flavor.to_dict(),
-                        target_flavor_properties=None,
+                        # source_flavor_properties=source_flavor.to_dict(),
+                        # target_flavor_properties=None,
                     )
                     continue
 
@@ -109,8 +109,8 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=target_flavor.id,
                         flavor_mismatch=mismatch,
-                        source_flavor_properties=source_flavor_properties,
-                        target_flavor_properties=target_flavor_properties,
+                        # source_flavor_properties=source_flavor_properties,
+                        # target_flavor_properties=target_flavor_properties,
                     )
 
                 else:

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -59,8 +59,6 @@ class FlavorPropertiesSensor(PollingSensor):
                 flavor.name: flavor for flavor in target_conn.list_flavors()
             }
 
-            self.log.info(f"source_flavors: {source_flavors}")
-
             for flavor_name, source_flavor in source_flavors.items():
                 target_flavor = target_flavors.get(flavor_name)
 

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -68,6 +68,8 @@ class FlavorPropertiesSensor(PollingSensor):
                     )
                     self.log.info(mismatch)
 
+                    source_flavor_properties = source_flavor.to_dict()
+
                     dispatch_trigger(
                         flavor_name=source_flavor.name,
                         source_cloud=self.source_cloud,
@@ -75,7 +77,7 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=None,
                         flavor_mismatch=mismatch,
-                        source_flavor_properties=str(source_flavor.to_dict()),
+                        source_flavor_properties=str(source_flavor_properties),
                         target_flavor_properties=None,
                     )
                     continue

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -75,8 +75,8 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=None,
                         flavor_mismatch=mismatch,
-                        # source_flavor_properties=source_flavor.to_dict(),
-                        # target_flavor_properties=None,
+                        source_flavor_properties=[source_flavor.to_dict()],
+                        target_flavor_properties=None,
                     )
                     continue
 
@@ -109,8 +109,8 @@ class FlavorPropertiesSensor(PollingSensor):
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=target_flavor.id,
                         flavor_mismatch=mismatch,
-                        # source_flavor_properties=source_flavor_properties,
-                        # target_flavor_properties=target_flavor_properties,
+                        source_flavor_properties=[source_flavor_properties],
+                        target_flavor_properties=[target_flavor_properties],
                     )
 
                 else:

--- a/sensors/src/flavor_properties_sensor.py
+++ b/sensors/src/flavor_properties_sensor.py
@@ -74,9 +74,9 @@ class FlavorPropertiesSensor(PollingSensor):
                         target_cloud=self.target_cloud,
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=None,
+                        flavor_mismatch=mismatch,
                         source_flavor_properties=source_flavor.to_dict(),
                         target_flavor_properties=None,
-                        mismatch=mismatch,
                     )
                     continue
 
@@ -108,9 +108,9 @@ class FlavorPropertiesSensor(PollingSensor):
                         target_cloud=self.target_cloud,
                         source_flavor_id=source_flavor.id,
                         target_flavor_id=target_flavor.id,
+                        flavor_mismatch=mismatch,
                         source_flavor_properties=source_flavor_properties,
                         target_flavor_properties=target_flavor_properties,
-                        mismatch=mismatch,
                     )
 
                 else:

--- a/tests/actions/test_openstack_actions.py
+++ b/tests/actions/test_openstack_actions.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch, NonCallableMock, MagicMock
 from importlib import import_module
-import pytest
+from unittest.mock import MagicMock, NonCallableMock, patch
 
+import pytest
 from src.openstack_actions import OpenstackActions
+
 from tests.actions.openstack_action_test_base import OpenstackActionTestBase
 
 
@@ -11,9 +12,10 @@ def test_module_exists(action_name):
     """
     Test that each action's entry-point module exists
     """
-    workflow_module = import_module("workflows")
-
-    assert hasattr(workflow_module, action_name)
+    try:
+        import_module(f"workflows.{action_name}")
+    except ModuleNotFoundError:
+        pytest.fail(f"Module workflows.{action_name} not found")
 
 
 class TestOpenstackActions(OpenstackActionTestBase):

--- a/tests/actions/test_openstack_actions.py
+++ b/tests/actions/test_openstack_actions.py
@@ -12,10 +12,9 @@ def test_module_exists(action_name):
     """
     Test that each action's entry-point module exists
     """
-    try:
-        import_module(f"workflows.{action_name}")
-    except ModuleNotFoundError:
-        pytest.fail(f"Module workflows.{action_name} not found")
+    workflow_module = import_module(f"workflows.{action_name}")
+
+    assert hasattr(workflow_module, action_name)
 
 
 class TestOpenstackActions(OpenstackActionTestBase):

--- a/tests/sensors/test_flavor_properties_sensor.py
+++ b/tests/sensors/test_flavor_properties_sensor.py
@@ -100,9 +100,9 @@ def test_poll_flavor_mismatch(mock_openstack_connection, sensor):
         "target_cloud": sensor.target_cloud,
         "source_flavor_id": mock_source_flavor.id,
         "target_flavor_id": mock_target_flavor.id,
+        "flavor_mismatch": expected_mismatch,
         "source_flavor_properties": mock_source_flavor_dict,
         "target_flavor_properties": mock_target_flavor_dict,
-        "mismatch": expected_mismatch,
     }
 
     sensor.sensor_service.dispatch.assert_called_once_with(
@@ -165,9 +165,9 @@ def test_poll_flavor_not_in_target(mock_openstack_connection, sensor):
         "target_cloud": sensor.target_cloud,
         "source_flavor_id": mock_source_flavor.id,
         "target_flavor_id": None,
+        "flavor_mismatch": expected_mismatch,
         "source_flavor_properties": mock_source_flavor_dict,
         "target_flavor_properties": None,
-        "mismatch": expected_mismatch,
     }
 
     sensor.sensor_service.dispatch.assert_called_once_with(

--- a/tests/sensors/test_flavor_properties_sensor.py
+++ b/tests/sensors/test_flavor_properties_sensor.py
@@ -80,7 +80,6 @@ def test_poll_flavor_mismatch(mock_openstack_connection, sensor):
     mock_target_flavor.name = "test_flavor"
     mock_target_flavor.id = "9999-9999-9999-9999"
     mock_target_conn.list_flavors.return_value = [mock_target_flavor]
-    mock_target_flavor.items.return_value = mock_target_flavor_dict.items
     mock_target_flavor.to_dict.return_value = mock_target_flavor_dict
 
     sensor.poll()
@@ -96,9 +95,13 @@ def test_poll_flavor_mismatch(mock_openstack_connection, sensor):
         + "Value of root['vcpus'] changed from 12 to 14."
     )
     expected_payload = {
-        "flavor_name": "test_flavor",
-        "source_flavor_id": "0000-0000-0000-0000",
-        "target_flavor_id": "9999-9999-9999-9999",
+        "flavor_name": mock_source_flavor.name,
+        "source_cloud": sensor.source_cloud,
+        "target_cloud": sensor.target_cloud,
+        "source_flavor_id": mock_source_flavor.id,
+        "target_flavor_id": mock_target_flavor.id,
+        "source_flavor_properties": mock_source_flavor_dict,
+        "target_flavor_properties": mock_target_flavor_dict,
         "mismatch": expected_mismatch,
     }
 
@@ -144,24 +147,26 @@ def test_poll_flavor_not_in_target(mock_openstack_connection, sensor):
     mock_source_flavor.items.return_value = mock_source_flavor_dict.items()
     mock_source_flavor.to_dict.return_value = mock_source_flavor_dict
 
-    mock_target_flavor_dict = {}
     mock_target_flavor = MagicMock()
     mock_target_flavor.name = None
-    mock_target_flavor.id = None
     mock_target_conn.list_flavors.return_value = [mock_target_flavor]
-    mock_target_flavor.items.return_value = mock_target_flavor_dict.items
-    mock_target_flavor.to_dict.return_value = mock_target_flavor_dict
 
     sensor.poll()
 
     mock_source_conn.list_flavors.assert_called_once_with()
     mock_target_conn.list_flavors.assert_called_once_with()
 
-    expected_mismatch = "Flavor does not exist in target cloud: test_flavor"
+    expected_mismatch = (
+        f"Flavor does not exist in target cloud: {mock_source_flavor.name}"
+    )
     expected_payload = {
-        "flavor_name": "test_flavor",
-        "source_flavor_id": "0000-0000-0000-0000",
+        "flavor_name": mock_source_flavor.name,
+        "source_cloud": sensor.source_cloud,
+        "target_cloud": sensor.target_cloud,
+        "source_flavor_id": mock_source_flavor.id,
         "target_flavor_id": None,
+        "source_flavor_properties": mock_source_flavor_dict,
+        "target_flavor_properties": None,
         "mismatch": expected_mismatch,
     }
 
@@ -227,7 +232,6 @@ def test_poll_flavor_match(mock_openstack_connection, sensor):
     mock_target_flavor.name = "test_flavor"
     mock_target_flavor.id = "9999-9999-9999-9999"
     mock_target_conn.list_flavors.return_value = [mock_target_flavor]
-    mock_target_flavor.items.return_value = mock_target_flavor_dict.items
     mock_target_flavor.to_dict.return_value = mock_target_flavor_dict
 
     sensor.poll()

--- a/tests/sensors/test_flavor_properties_sensor.py
+++ b/tests/sensors/test_flavor_properties_sensor.py
@@ -101,8 +101,8 @@ def test_poll_flavor_mismatch(mock_openstack_connection, sensor):
         "source_flavor_id": mock_source_flavor.id,
         "target_flavor_id": mock_target_flavor.id,
         "flavor_mismatch": expected_mismatch,
-        "source_flavor_properties": mock_source_flavor_dict,
-        "target_flavor_properties": mock_target_flavor_dict,
+        "source_flavor_properties": str(mock_source_flavor_dict),
+        "target_flavor_properties": str(mock_target_flavor_dict),
     }
 
     sensor.sensor_service.dispatch.assert_called_once_with(
@@ -166,7 +166,7 @@ def test_poll_flavor_not_in_target(mock_openstack_connection, sensor):
         "source_flavor_id": mock_source_flavor.id,
         "target_flavor_id": None,
         "flavor_mismatch": expected_mismatch,
-        "source_flavor_properties": mock_source_flavor_dict,
+        "source_flavor_properties": str(mock_source_flavor_dict),
         "target_flavor_properties": None,
     }
 


### PR DESCRIPTION
### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

Adds a Rule that creates a Jira task whenever the FlavorPropertiesSensor is triggered. 

Tested on Jira Project DevOps_Cloud_Test_Env queue.

The sync direction is dev >>> prod, in line with the image metadata sensor that's been merged into main - this can be changed in the flavor sensor config, within `config.schema.yaml`.

Much of this PR is dependent on #371, recommend reviewing and merging that PR before merging this one. 

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
