### PR TITLE
ENH: add capi image creation notification

### DIFF
--- a/actions/email.mailing.list.with.create.capi.images.yaml
+++ b/actions/email.mailing.list.with.create.capi.images.yaml
@@ -1,0 +1,47 @@
+---
+description: Sends an email to inform users that new CAPI Images have been released
+enabled: true
+entry_point: src/openstack_actions.py
+name: email.mailing.list.with.create.capi.images
+parameters:
+  timeout:
+    default: 5400
+  lib_entry_point:
+    default: workflows.send_mailing_list_capi_image_create_email.send_mailing_list_capi_image_create_email
+    immutable: true
+    type: string
+  subject:
+    type: string
+    description: "Subject to add to each email"
+    required: true
+    default: "STFC Cloud CAPI Image Creation Notice"
+  mailing_list:
+    required: true
+    type: string
+    description: "Email address of the mailing list."
+  image_name_list:
+    type: array
+    description: "Comma-spaced list of Openstack CAPI Images Names that have been created."
+    required: True
+  send_email:
+    type: boolean
+    description: "Set this flag to actually send emails instead of printing what will be sent"
+    required: true
+    default: false
+  email_from:
+    type: string
+    description: "Email address to send email from"
+    required: true
+    default: "cloud-support@stfc.ac.uk"
+    immutable: true
+  smtp_account_name:
+    type: string
+    description: "Name of SMTP Account to use. Must be configured in the pack settings."
+    required: true
+    default: "default"
+  as_html:
+    type: boolean
+    description: "Send email body as HTML"
+    required: true
+    default: true
+runner_type: python-script

--- a/lib/apis/email_api/email_template_schemas.yaml
+++ b/lib/apis/email_api/email_template_schemas.yaml
@@ -75,3 +75,9 @@ decom_image:
     decom_table: "No VMs affected"
   html_filepath: "html/decom_image.html.j2"
   plaintext_filepath: "plaintext/decom_image.txt.j2"
+
+mailing_list_capi_create_image:
+  schema:
+    created_images_table: "No New Images"
+  html_filepath: "html/mailing_list_capi_create_image.html.j2"
+  plaintext_filepath: "plaintext/mailing_list_capi_create_image.txt.j2"

--- a/lib/apis/email_api/templates/html/mailing_list_capi_create_image.html.j2
+++ b/lib/apis/email_api/templates/html/mailing_list_capi_create_image.html.j2
@@ -1,0 +1,21 @@
+
+<meta charset="UTF-8">
+<title>STFC Cloud - CAPI Images Update</title>
+
+
+<p>Dear Cloud Users,</p>
+
+<p>The STFC Cloud maintains a set of CAPI (Cluster API) images for deployment of Kubernetes clusters. Part of this maintenance is the release of new CAPI images to allow for the usage of new Kubernetes versions, and provide an updated set of base operating system updates.</p>
+
+<p>The following new images have been released:</p>
+
+{{ new_images_table }}
+
+<p>These images can be added to existing CAPI configurations and be used immediately.</p>
+
+<p>Note that End-of-Life and outdated images are eventually rotated out, approximately bi-annually, so please be alert for future notifications when this set of new images are inevitably deprecated.</p>
+
+<p>If you have any concerns with this notice or require clarification or support, please get in touch with the Cloud Ops Team directly by raising a ticket with STFC Cloud Support at <a href="mailto:cloud-support@stfc.ac.uk">cloud-support@stfc.ac.uk</a>.</p>
+
+<p>Best Regards,<br>
+STFC Cloud Operations Group</p>

--- a/lib/apis/email_api/templates/html/mailing_list_capi_create_image.html.j2
+++ b/lib/apis/email_api/templates/html/mailing_list_capi_create_image.html.j2
@@ -9,7 +9,7 @@
 
 <p>The following new images have been released:</p>
 
-{{ new_images_table }}
+{{created_images_table}}
 
 <p>These images can be added to existing CAPI configurations and be used immediately.</p>
 

--- a/lib/apis/email_api/templates/plaintext/mailing_list_capi_create_image.txt.j2
+++ b/lib/apis/email_api/templates/plaintext/mailing_list_capi_create_image.txt.j2
@@ -3,7 +3,7 @@ Dear Cloud Users,
 The STFC Cloud maintains a set of CAPI (Cluster API) images for deployment of Kubernetes clusters. Part of this maintainence is the release of new CAPI images to allow for the usage of new Kubernetes versions, and provide an updated set of base operating system updates.
 
 The following new images have been released:
-{{ new_images_table }}
+{{created_images_table}}
 
 These images can be added to existing CAPI configurations and be used immediately.
 

--- a/lib/apis/email_api/templates/plaintext/mailing_list_capi_create_image.txt.j2
+++ b/lib/apis/email_api/templates/plaintext/mailing_list_capi_create_image.txt.j2
@@ -1,0 +1,15 @@
+Dear Cloud Users,
+
+The STFC Cloud maintains a set of CAPI (Cluster API) images for deployment of Kubernetes clusters. Part of this maintainence is the release of new CAPI images to allow for the usage of new Kubernetes versions, and provide an updated set of base operating system updates.
+
+The following new images have been released:
+{{ new_images_table }}
+
+These images can be added to existing CAPI configurations and be used immediately.
+
+Note that End-of-Life and outdated images are eventually rotated out, approximately bi-annually, so please be alert for future notifications when this set of new images are inevitably deprecated.
+
+If you have any concerns with this notice or require clarification or support, please get in touch with the Cloud Ops Team directly by raising a ticket with STFC Cloud Support at cloud-support@stfc.ac.uk.
+
+Best Regards,
+STFC Cloud Operations Group

--- a/lib/workflows/send_mailing_list_capi_image_create_email.py
+++ b/lib/workflows/send_mailing_list_capi_image_create_email.py
@@ -1,0 +1,111 @@
+from typing import Dict, List
+
+from apis.email_api.emailer import Emailer
+from apis.email_api.structs.email_params import EmailParams
+from apis.email_api.structs.email_template_details import EmailTemplateDetails
+from apis.email_api.structs.smtp_account import SMTPAccount
+from tabulate import tabulate
+
+
+def get_created_images_html(image_info_list: List[Dict]):
+    """
+    returns information on images that have been created as a html table
+    :param image_info_list: A list of dictionaries containing information on images that have been created
+    """
+
+    table_html = "<table>"
+    table_html += "<tr><th>Created Images</th></tr>"
+    for image in image_info_list:
+        table_html += f"<tr><td>{image['name']}</td></tr>"
+    table_html += "</table>"
+    return table_html
+
+
+def get_created_images_plaintext(image_info_list: List[Dict]):
+    """
+    returns information on images that have been created as a plaintext tabulate table
+    :param image_info_list: A list of dictionaries containing information on images that have been created
+    """
+    return tabulate(
+        image_info_list,
+        headers={"name": "Created Images"},
+        tablefmt="plain",
+    )
+
+
+def get_image_info(image_name_list: List[str]):
+    """
+    function validates key-word arguments related to displaying information on images that have been
+    created and parses it into a list of dictionaries
+    """
+    if len(image_name_list) == 0:
+        raise RuntimeError(
+            "please provide a list of image names that have been created"
+        )
+
+    img_list = []
+    for image_name in image_name_list:
+        img_list.append({"name": image_name})
+
+    return img_list
+
+
+def print_email_params(email_addr: str, image_table: str):
+    """
+    Print email params instead of sending the email
+    :param email_addr: email address to send to
+    :param image_table: a table representing created images
+    """
+
+    print(f"Send Email To: {email_addr}\n" f"Created image table: {image_table}\n")
+
+
+def build_email_params(image_table: str, **email_kwargs):
+    """
+    build email params dataclass which will be used to configure how to send the email
+    :param image_table: a string table representing created images
+    :param email_kwargs: a set of email kwargs to pass to EmailParams
+    """
+    body = EmailTemplateDetails(
+        template_name="mailing_list_capi_create_image",
+        template_params={"created_images_table": image_table},
+    )
+
+    footer = EmailTemplateDetails(template_name="footer", template_params={})
+
+    return EmailParams(email_templates=[body, footer], **email_kwargs)
+
+
+def send_mailing_list_capi_image_create_email(
+    smtp_account: SMTPAccount,
+    mailing_list: str,
+    image_name_list: List[str],
+    send_email: bool = False,
+    as_html: bool = True,
+    **email_params_kwargs,
+):
+    """
+    Sends an email to the mailing list with a list of created CAPI images.
+    :param mailing_list: A string representing a mailing list email
+    :param image_name_list: A list of image names that have been created
+    :param send_email: Actually send the email instead of printing what will be sent
+    :param email_params_kwargs: see EmailParams dataclass class docstring
+    """
+
+    image_data = get_image_info(image_name_list)
+
+    if as_html:
+        image_table = get_created_images_html(image_data)
+    else:
+        image_table = get_created_images_plaintext(image_data)
+
+    if not send_email:
+        print_email_params(mailing_list, image_table)
+    else:
+        email_params = build_email_params(
+            image_table,
+            email_to=[mailing_list],
+            as_html=as_html,
+            **email_params_kwargs,
+        )
+        Emailer(smtp_account).send_emails([email_params])

--- a/tests/lib/workflows/test_send_mailing_list_capi_image_create_email.py
+++ b/tests/lib/workflows/test_send_mailing_list_capi_image_create_email.py
@@ -1,0 +1,233 @@
+from unittest.mock import NonCallableMock, call, patch
+
+import pytest
+from workflows.send_mailing_list_capi_image_create_email import (
+    build_email_params,
+    get_created_images_html,
+    get_created_images_plaintext,
+    get_image_info,
+    print_email_params,
+    send_mailing_list_capi_image_create_email,
+)
+
+
+def test_get_created_images_html():
+    """
+    Tests that get_created_images_html returns a html formatted list given valid inputs
+    """
+    res = get_created_images_html(
+        [
+            {"name": "img1"},
+            {"name": "img2"},
+        ]
+    )
+    assert res == (
+        "<table>"
+        "<tr><th>Created Images</th></tr>"
+        "<tr><td>img1</td></tr>"
+        "<tr><td>img2</td></tr>"
+        "</table>"
+    )
+
+
+@patch("workflows.send_mailing_list_capi_image_create_email.tabulate")
+def test_get_created_images_plaintext(mock_tabulate):
+    """
+    Tests that get_created_plaintext calls tabulate correctly
+    """
+    mock_image_info = [
+        {"name": "img1"},
+        {"name": "img2"},
+    ]
+    res = get_created_images_plaintext(mock_image_info)
+    mock_tabulate.assert_called_once_with(
+        mock_image_info,
+        headers={"name": "Created Images"},
+        tablefmt="plain",
+    )
+    assert res == mock_tabulate.return_value
+
+
+def test_get_image_info_image_list_empty():
+    """Tests that get_image_info returns error when passed empty image name list"""
+    with pytest.raises(RuntimeError):
+        get_image_info([])
+
+
+def test_get_image_info_valid():
+    """Tests that get_image_info returns parsed list of dicts when inputs are valid"""
+    res = get_image_info(["img1", "img2"])
+    print()
+    assert res == [{"name": "img1"}, {"name": "img2"}]
+
+
+def test_print_email_params():
+    """
+    Test print_email_params() function simply prints values
+    """
+    email_addr = "test@example.com"
+    image_table = "Image Table Content"
+
+    with patch("builtins.print") as mock_print:
+        print_email_params(email_addr, image_table)
+
+    mock_print.assert_called_once_with(
+        f"Send Email To: {email_addr}\n" f"Created image table: {image_table}\n"
+    )
+
+
+@patch("workflows.send_mailing_list_capi_image_create_email.EmailTemplateDetails")
+@patch("workflows.send_mailing_list_capi_image_create_email.EmailParams")
+def test_build_params(mock_email_params, mock_email_template_details):
+    """
+    Test build_params() function creates email params appropriately and returns them
+    """
+
+    image_table = "Image Table Content"
+    email_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    res = build_email_params(image_table, **email_kwargs)
+    mock_email_template_details.assert_has_calls(
+        [
+            call(
+                template_name="mailing_list_capi_create_image",
+                template_params={
+                    "created_images_table": image_table,
+                },
+            ),
+            call(template_name="footer", template_params={}),
+        ]
+    )
+
+    mock_email_params.assert_called_once_with(
+        email_templates=[
+            mock_email_template_details.return_value,
+            mock_email_template_details.return_value,
+        ],
+        arg1="val1",
+        arg2="val2",
+    )
+
+    assert res == mock_email_params.return_value
+
+
+@patch("workflows.send_mailing_list_capi_image_create_email.get_image_info")
+@patch(
+    "workflows.send_mailing_list_capi_image_create_email.get_created_images_plaintext"
+)
+@patch("workflows.send_mailing_list_capi_image_create_email.build_email_params")
+@patch("workflows.send_mailing_list_capi_image_create_email.Emailer")
+def test_send_mailing_list_capi_image_create_email_send_plaintext(
+    mock_emailer,
+    mock_build_email_params,
+    mock_get_created_images_plaintext,
+    mock_get_image_info,
+):
+    """
+    Tests send_mailing_list_capi_image_create_email() function actually sends email - as_html False
+    """
+    image_name_list = ["img1", "img2"]
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    send_mailing_list_capi_image_create_email(
+        smtp_account=smtp_account,
+        mailing_list="mailing list email",
+        image_name_list=image_name_list,
+        as_html=False,
+        send_email=True,
+        **mock_kwargs,
+    )
+
+    mock_get_image_info.assert_called_once_with(image_name_list)
+
+    mock_build_email_params.assert_called_once_with(
+        mock_get_created_images_plaintext.return_value,
+        email_to=["mailing list email"],
+        as_html=False,
+        **mock_kwargs,
+    )
+
+    mock_emailer.assert_has_calls(
+        [
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+        ]
+    )
+
+
+@patch("workflows.send_mailing_list_capi_image_create_email.get_image_info")
+@patch("workflows.send_mailing_list_capi_image_create_email.get_created_images_html")
+@patch("workflows.send_mailing_list_capi_image_create_email.build_email_params")
+@patch("workflows.send_mailing_list_capi_image_create_email.Emailer")
+def test_send_mailing_list_capi_image_create_email_send_html(
+    mock_emailer,
+    mock_build_email_params,
+    mock_get_created_images_html,
+    mock_get_image_info,
+):
+    """
+    Tests send_mailing_list_capi_image_create_email() function actually sends email - as_html True
+    """
+    image_name_list = ["img1", "img2"]
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    send_mailing_list_capi_image_create_email(
+        smtp_account=smtp_account,
+        mailing_list="mailing list email",
+        image_name_list=image_name_list,
+        as_html=True,
+        send_email=True,
+        **mock_kwargs,
+    )
+
+    mock_get_image_info.assert_called_once_with(image_name_list)
+
+    mock_build_email_params.assert_called_once_with(
+        mock_get_created_images_html.return_value,
+        email_to=["mailing list email"],
+        as_html=True,
+        **mock_kwargs,
+    )
+
+    mock_emailer.assert_has_calls(
+        [
+            call(smtp_account),
+            call().send_emails([mock_build_email_params.return_value]),
+        ]
+    )
+
+
+@patch("workflows.send_mailing_list_capi_image_create_email.get_image_info")
+@patch(
+    "workflows.send_mailing_list_capi_image_create_email.get_created_images_plaintext"
+)
+@patch("workflows.send_mailing_list_capi_image_create_email.print_email_params")
+def test_send_mailing_list_capi_image_create_email_print_email(
+    mock_print_email_params,
+    mock_get_created_images_plaintext,
+    mock_get_image_info,
+):
+    """
+    Tests send_mailing_list_capi_image_create_email() function actually sends email - as_html false
+    """
+    image_name_list = ["img1", "img2"]
+    smtp_account = NonCallableMock()
+    mock_kwargs = {"arg1": "val1", "arg2": "val2"}
+
+    send_mailing_list_capi_image_create_email(
+        smtp_account=smtp_account,
+        mailing_list="mailing list email",
+        image_name_list=image_name_list,
+        as_html=False,
+        send_email=False,
+        **mock_kwargs,
+    )
+
+    mock_get_image_info.assert_called_once_with(image_name_list)
+
+    mock_print_email_params.assert_called_once_with(
+        "mailing list email",
+        mock_get_created_images_plaintext.return_value,
+    )


### PR DESCRIPTION
### Description:
Added an action to send created CAPI Images to the mailing list that users could use
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [x] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
