### PR TITLE
BUG: Fix handling empty migration list for VMs

### DIFF
--- a/lib/apis/openstack_api/openstack_server.py
+++ b/lib/apis/openstack_api/openstack_server.py
@@ -157,7 +157,13 @@ def wait_for_migration_status(
     """
     start_time = time.time()
     while time.time() - start_time < timeout:
-        migration = next(conn.compute.migrations(instance_uuid=server_id))
+        try:
+            migration = next(conn.compute.migrations(instance_uuid=server_id))
+        except StopIteration:
+            logger.info("No migration details available for %s yet", server_id)
+            time.sleep(interval)
+            continue
+
         logger.info("Status of migration of server %s: %s", server_id, migration.status)
         if migration.status == status:
             return migration

--- a/tests/lib/apis/openstack_api/test_openstack_server.py
+++ b/tests/lib/apis/openstack_api/test_openstack_server.py
@@ -659,3 +659,17 @@ def test_shutoff_server_propagates_resource_failure():
         shutoff_server(mock_conn, "server-123")
 
     assert exc_info.value is expected_exception
+
+
+def test_with_empty_migration_list():
+    """
+    Tests that the code can handle an empty list of migrations e.g. when we
+    ask before nova gets the message we're migrating
+    """
+    mock_conn = MagicMock()
+    mock_conn.compute.migrations.side_effect = []  # Return nothing intentionally
+
+    with pytest.raises(ResourceTimeout):
+        wait_for_migration_status(
+            mock_conn, "test-server-id", "should-timeout", interval=1, timeout=1
+        )


### PR DESCRIPTION
### Description:

If a VM had an empty migration list we would die if we asked nova faster than the migration turned up. Instead handle this case and use the existing wait for migration code to retry

### Special Notes:


### Submitter:

Have you (where applicable):

* [x] Added unit tests?
* [x] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
