### PR TITLE
Add delay to running post reboot after patching HV

### DIFF
--- a/actions/workflows/hypervisor.patch.workflow.yaml
+++ b/actions/workflows/hypervisor.patch.workflow.yaml
@@ -32,6 +32,7 @@ tasks:
 
   test_and_enable_hypervisor:
     action: stackstorm_openstack.hv.post.reboot
+    delay: 30 # Avoid race conditions when waiting for ssh
     input:
       cloud_account: <% ctx().cloud_account %>
       hypervisor_hostname: <% ctx().hypervisor_hostname %>


### PR DESCRIPTION
### Description:
This is to avoid any race conditions while the HVs restart after a reboot

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
