### PR TITLE
Write code to query Wazuh

### DIFF
--- a/actions/src/openstack_actions.py
+++ b/actions/src/openstack_actions.py
@@ -6,14 +6,22 @@ from apis.alertmanager_api.structs.alertmanager_account import AlertManagerAccou
 from apis.email_api.structs.smtp_account import SMTPAccount
 from apis.icinga_api.structs.icinga_account import IcingaAccount
 from apis.jira_api.structs.jira_account import JiraAccount
+from apis.wazuh_api.wazuh import WazuhClient
 
 
 class OpenstackActions(Action):
-    def run(self, lib_entry_point: str, requires_openstack: bool = False, **kwargs):
+    def run(
+        self,
+        lib_entry_point: str,
+        requires_openstack: bool = False,
+        requires_wazuh: bool = False,
+        **kwargs,
+    ):
         """
         Dynamically dispatches to the function wanted
         :param lib_entry_point: path to function that handles action in lib layer
         :param requires_openstack: if action requires connection to openstack
+        :param requires_wazuh: if action requires querying the Wazuh server
         :param kwargs: all user-defined kwargs to pass to the function
         """
         module, fn_name = lib_entry_point.rsplit(".", 1)
@@ -25,6 +33,19 @@ class OpenstackActions(Action):
             "\n".join([f"{key}: {val}" for key, val in kwargs.items()]),
         )
         kwargs = self.parse_configs(**kwargs)
+
+        # in some automations we may need to query the Wazuh server
+        # however, we may not need any field in the web form related to Wazuh
+        # therefore, it will not be possible to handle the creation of
+        # the wazuh client object inside function parse_config()
+        # as there is no configuration parameter related to it that can
+        # be parsed
+        # we trigger the creation of the wazuh client object with an immutable
+        # parameter, the same way we do for OpenStack
+        if requires_wazuh:
+            wazuh = WazuhClient(self.config)
+            kwargs["wazuh"] = wazuh
+
         if not requires_openstack:
             return action_func(**kwargs)
         # setup openstack connection

--- a/lib/apis/wazuh_api/__init__.py
+++ b/lib/apis/wazuh_api/__init__.py
@@ -1,0 +1,9 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)

--- a/lib/apis/wazuh_api/wazuh.py
+++ b/lib/apis/wazuh_api/wazuh.py
@@ -1,0 +1,145 @@
+import logging
+import re
+import urllib3
+import requests
+
+# Suppress insecure request warnings if using self-signed certificates
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+logger = logging.getLogger("WazuhClient")
+
+
+# pylint: disable=too-few-public-methods
+class WazuhClient:
+    def __init__(self, pack_config):
+        """
+        gets the requires values to contact a Wazuh Server
+        from the StackStorm configuration Dictionary pack_config
+
+        :param pack_config: StackStorm configuration
+        :type pack_config: dict
+        """
+        logger.info("Creating instance of WazuhClient")
+        self.username = pack_config.get("wazuh_username")
+        self.password = pack_config.get("wazuh_password")
+        self.url = pack_config.get("wazuh_url")
+        logger.info("Instance of WazuhClient created correctly")
+
+    def _get_wazuh_token(self):
+        """
+        Authenticates with the Wazuh API and returns a JWT token.
+        """
+        logger.info("Getting a token")
+        url = f"{self.url}/security/user/authenticate"
+        try:
+            # Wazuh uses Basic Auth to fetch the initial token
+            response = requests.get(
+                url, auth=(self.username, self.password), verify=False, timeout=60
+            )
+            response.raise_for_status()
+            token = response.json().get("data", {}).get("token")
+            logger.info("Token adquired correclty, returning it")
+            return token
+        except requests.exceptions.RequestException as e:
+            logger.critical("Unable to retrieve a valid token: %s", e)
+            raise e
+
+    def _query_agents(self, values=None, query=None):
+        """
+        Queries all agents in Wazuh to get a certain list of parameters
+        for a specific query or filter
+
+        :param values: the list of variables to retrieve
+        :type values: list
+        :param query: the specific query against the Wazuh server
+        :type query: str
+        :return: the information in Wazuh for all agents
+        :rtype: list
+        """
+        logger.info("Querying all agents for values %s and query %s", values, query)
+        url = f"{self.url}/agents"
+        token = self._get_wazuh_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            # we query Wazuh using pagination
+            # we do not know how many agents there are
+            out = []
+            batch_size = 500
+            offset = 0
+            while True:
+                params = {
+                    "limit": batch_size,
+                    "offset": offset,
+                    "select": values,
+                    "q": query,
+                }
+                response = requests.get(
+                    url, headers=headers, params=params, verify=False, timeout=60
+                )
+                response.raise_for_status()
+                data = response.json()
+                items = data.get("data", {}).get("affected_items", [])
+                if not items:
+                    break
+                out.extend(items)
+                offset += batch_size
+            logger.info("Data for all agents fetched correctly")
+            return out
+        except requests.exceptions.RequestException as e:
+            logger.critical("Failed to fetch data for all agents: %s", e)
+            raise e
+
+    def get_all(self):
+        return self._query_agents()
+
+    def get_servers_for_os(self, os_name, os_version):
+        """
+        query the Wazuh server to get data only for
+        VMs running a specific version of the OS
+
+        :param os_name: the OS name
+        :type os_name: str
+        :param os_version: the OS version
+        :type os_version: str
+        :return: the list of VM IDs
+        :rtype: list
+        """
+        logger.info(
+            "query Wazuh for Servers running OS name %s and %s version",
+            os_name,
+            os_version,
+        )
+        query = f"os.platform={os_name};os.major={os_version};status=active;group!=kolla;group!=quattor"
+        # we ensure we only get information about Servers and not Hypervisors
+        # by adding conditions
+        #   group!=kolla
+        #   group!=quattor
+        # to the query string
+        data = self._query_agents(values=["name"], query=query)
+
+        # extract the Server ID from the fetched data
+        # the variable "name" for OpenStack Servers looks like this:
+        #   host-192-168-231-139.openstacklocal-001682d2-79a2-41b9-af7f-c553f7d67b0d
+        # we need to extract the ID from there
+        uuid_re = re.compile(
+            r"([0-9a-fA-F]{8}-"
+            r"[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{12})$"
+        )
+        server_id_l = []
+        for server in data:
+            name = server["name"]
+            match = uuid_re.search(name)
+            if match:
+                server_id = match.group(1)
+                server_id_l.append(server_id)
+            else:
+                logger.error("failed to extract Server ID from %s", server)
+
+        logger.info("returning a list of %s Server IDs", len(server_id_l))
+        return server_id_l

--- a/tests/lib/apis/wazuh_api/test_wazuh.py
+++ b/tests/lib/apis/wazuh_api/test_wazuh.py
@@ -1,0 +1,192 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from apis.wazuh_api.wazuh import WazuhClient
+
+
+# pylint: disable=protected-access
+class TestWazuhClient(unittest.TestCase):
+    """
+    Unit test suite for WazuhClient.
+
+    Tests client authentication, internal query pagination, and public-facing wrapper methods.
+    Network calls are mocked using `unittest.mock.patch` to isolate local logic execution.
+    """
+
+    def setUp(self):
+        """Set up dummy configuration and initialize a clean WazuhClient instance prior to each test."""
+        self.config = {
+            "wazuh_username": "user",
+            "wazuh_password": "pass",
+            "wazuh_url": "https://wazuh.example.com",
+        }
+        self.client = WazuhClient(self.config)
+
+    @patch("apis.wazuh_api.wazuh.requests.get")
+    def test_get_wazuh_token(self, mock_get):
+        """
+        WHAT IT TESTS:
+            Verifies that `_get_wazuh_token` successfully fetches and extracts the JWT token string.
+
+        HOW IT WORKS:
+            Mocks `requests.get` to return a 200 OK JSON payload containing a fake token.
+
+        WHY IT PREVENTS BUGS:
+            Ensures that changes to the token authentication URL, Basic Auth credentials, timeout,
+            or JSON parsing logic do not break authentication.
+        """
+        response = Mock()
+        response.json.return_value = {"data": {"token": "jwt-token"}}
+        response.raise_for_status.return_value = None
+        mock_get.return_value = response
+
+        token = self.client._get_wazuh_token()
+
+        # Check token extraction
+        self.assertEqual(token, "jwt-token")
+
+        # Check HTTP request parameters
+        mock_get.assert_called_once_with(
+            "https://wazuh.example.com/security/user/authenticate",
+            auth=("user", "pass"),
+            verify=False,
+            timeout=60,
+        )
+
+    @patch("apis.wazuh_api.wazuh.requests.get")
+    @patch.object(WazuhClient, "_get_wazuh_token", return_value="jwt-token")
+    def test_query_agents_pagination(self, mock_token, mock_get):
+        """
+        WHAT IT TESTS:
+            Verifies `_query_agents` loops through paginated API results until an empty page is returned.
+
+        HOW IT WORKS:
+            1. Mocks `_get_wazuh_token` to return "jwt-token" without calling the real auth method.
+            2. Mocks `requests.get` using `side_effect` with 2 responses: Page 1 with items, Page 2 empty.
+
+        WHY IT PREVENTS BUGS:
+            Guarantees offset increments (0 -> 500), pagination headers/tokens are attached,
+            and the loop terminates correctly on empty responses without causing infinite loops.
+        """
+        # First API call returns 2 agents
+        first_response = Mock()
+        first_response.raise_for_status.return_value = None
+        first_response.json.return_value = {
+            "data": {
+                "affected_items": [
+                    {"id": "001"},
+                    {"id": "002"},
+                ]
+            }
+        }
+
+        # Second API call returns empty list to stop loop
+        second_response = Mock()
+        second_response.raise_for_status.return_value = None
+        second_response.json.return_value = {"data": {"affected_items": []}}
+
+        mock_get.side_effect = [first_response, second_response]
+
+        agents = self.client._query_agents(values=["name"], query="status=active")
+
+        # Verify aggregated data
+        self.assertEqual(agents, [{"id": "001"}, {"id": "002"}])
+
+        # Verify authentication occurred once
+        mock_token.assert_called_once()
+
+        # Verify exactly 2 HTTP requests were sent (Page 1 and Page 2)
+        self.assertEqual(mock_get.call_count, 2)
+
+        # Verify request headers & query params for offset=0
+        mock_get.assert_any_call(
+            "https://wazuh.example.com/agents",
+            headers={
+                "Authorization": "Bearer jwt-token",
+                "Content-Type": "application/json",
+            },
+            params={
+                "limit": 500,
+                "offset": 0,
+                "select": ["name"],
+                "q": "status=active",
+            },
+            verify=False,
+            timeout=60,
+        )
+
+        # Verify offset updated to 500 on second request
+        mock_get.assert_any_call(
+            "https://wazuh.example.com/agents",
+            headers={
+                "Authorization": "Bearer jwt-token",
+                "Content-Type": "application/json",
+            },
+            params={
+                "limit": 500,
+                "offset": 500,
+                "select": ["name"],
+                "q": "status=active",
+            },
+            verify=False,
+            timeout=60,
+        )
+
+    @patch.object(WazuhClient, "_query_agents")
+    def test_get_all(self, mock_query):
+        """
+        WHAT IT TESTS:
+            Verifies `get_all()` acts as a direct pass-through wrapper around `_query_agents()`.
+
+        HOW IT WORKS:
+            Mocks `_query_agents` and asserts it is called without arguments.
+
+        WHY IT PREVENTS BUGS:
+            Ensures public interface contracts remain stable when calling unconstrained agent queries.
+        """
+        mock_query.return_value = [{"id": "001"}]
+
+        result = self.client.get_all()
+
+        self.assertEqual(result, [{"id": "001"}])
+        mock_query.assert_called_once_with()
+
+    @patch.object(WazuhClient, "_query_agents")
+    def test_get_servers_for_os(self, mock_query):
+        """
+        WHAT IT TESTS:
+            Verifies `get_servers_for_os()` formats the Wazuh query string correctly AND parses/extracts
+            UUIDs from OpenStack server names using regular expressions.
+
+        HOW IT WORKS:
+            Mocks `_query_agents` to return sample server names (some valid OpenStack names, some malformed).
+
+        WHY IT PREVENTS BUGS:
+            1. Verifies exact query parameters (`group!=kolla;group!=quattor`) are preserved to exclude hypervisors.
+            2. Ensures regex correctly extracts UUID suffixes and silently filters out non-matching names.
+        """
+        # Mock raw Wazuh API return data with valid and invalid OpenStack server names
+        mock_query.return_value = [
+            {
+                "name": "host-192-168-231-139.openstacklocal-001682d2-79a2-41b9-af7f-c553f7d67b0d"
+            },
+            {
+                "name": "host-192-168-231-140.openstacklocal-aabbccdd-1234-5678-90ab-cdef12345678"
+            },
+            {"name": "malformed-server-name-without-uuid"},
+        ]
+
+        server_ids = self.client.get_servers_for_os(
+            os_name="ubuntu", os_version="22.04"
+        )
+
+        # Verify extracted UUIDs match
+        expected_ids = [
+            "001682d2-79a2-41b9-af7f-c553f7d67b0d",
+            "aabbccdd-1234-5678-90ab-cdef12345678",
+        ]
+        self.assertEqual(server_ids, expected_ids)
+
+        # Verify underlying _query_agents was called with the exact required query string
+        expected_query = "os.platform=ubuntu;os.major=22.04;status=active;group!=kolla;group!=quattor"
+        mock_query.assert_called_once_with(values=["name"], query=expected_query)


### PR DESCRIPTION
In order to be able to query Wazuh we need 2 things:

* some code to perform the query and fetch the results. We implement that code as a class
  * the init method reads the all needed credentials and related parameters from stackstorm configuration
  * we get a token always right before querying the server

* the entry point for all ACTIONS in stackstorm needs to create an instance of the new class and pass it as argument to the workflows

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- Changes any parameter names, or allowed values
- Renames any actions, workflows or sensors
- Requires any additional config files placed onto the server

Or anything else you may want to note:

-->

---

### Submitter:

Have you (where applicable):

* [ ] Added unit tests?
* [ ] Checked the latest commit runs on Dev?
* [ ] Updated the example config file(s) and README?

---

### Reviewer

Does this PR:

* [ ] Place non-StackStorm code into the `lib` directory?
* [ ] Have unit tests for the action/sensor and `lib` layers?
* [ ] Have clear and obvious action parameter names and descriptions?
